### PR TITLE
devcontainer: upgrade to Node 22 + fix peeler sit3.c build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,13 +1,14 @@
 # .devcontainer/Dockerfile
-# Purpose: Build a general-purpose dev image with Emscripten 4.0.10 + C/C++ + Node LTS
+# Purpose: Build a general-purpose dev image with Emscripten 4.0.10 + C/C++ + Node 22
 
 FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
 # ---- ARGs / Versions ----
 ARG DEBIAN_FRONTEND=noninteractive
 ARG EMSDK_VERSION=4.0.10
+ARG NODE_MAJOR=22
 
-# ---- Base packages (includes system Node.js LTS from Ubuntu repos) ----
+# ---- Base packages (Node.js installed separately from NodeSource below) ----
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
     build-essential \
@@ -21,12 +22,15 @@ RUN apt-get update \
     git \
     git-lfs \
     xz-utils \
-    nodejs \
-    npm \
     clang-format-18 \
     gh \
  && rm -rf /var/lib/apt/lists/* \
  && pip3 install --break-system-packages --no-cache-dir pre-commit
+
+# ---- Node.js (NodeSource; Ubuntu 24.04 only ships Node 18 in apt) ----
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && rm -rf /var/lib/apt/lists/*
 
 # Verify node/npm available
 RUN node -v && npm -v

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Granny Smith Dev",
-  "image": "ghcr.io/pappadf/granny-smith-dev:ubuntu24-emsdk4.0.10-nodeLTS",
+  "image": "ghcr.io/pappadf/granny-smith-dev:ubuntu24-emsdk4.0.10-node22",
   "remoteUser": "vscode",
 
   // Keep your port forwarding setup

--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -32,7 +32,7 @@ jobs:
         id: meta
         run: |
           IMAGE_NAME="ghcr.io/pappadf/granny-smith-dev"
-          TAG_BASE="ubuntu24-emsdk4.0.10-nodeLTS"
+          TAG_BASE="ubuntu24-emsdk4.0.10-node22"
           echo "image=${IMAGE_NAME}" >> $GITHUB_OUTPUT
           echo "tag=${TAG_BASE}" >> $GITHUB_OUTPUT
 
@@ -59,7 +59,7 @@ jobs:
           platforms: linux/amd64
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.description=Dev image with Emscripten 4.0.10, Node LTS, C/C++ toolchain
+            org.opencontainers.image.description=Dev image with Emscripten 4.0.10, Node 22, C/C++ toolchain
             org.opencontainers.image.revision=${{ github.sha }}
           tags: |
             ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Verify Node.js
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
   test:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/pappadf/granny-smith-dev:ubuntu24-emsdk4.0.10-nodeLTS
+      image: ghcr.io/pappadf/granny-smith-dev:ubuntu24-emsdk4.0.10-node22
       # Optionally, after a build you can pin by digest instead for immutability:
       # image: ghcr.io/pappadf/granny-smith-dev@sha256:<digest-here>
       credentials:

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ PEELER_SRC := $(PEELER_DIR)/lib/peeler.c \
               $(PEELER_DIR)/lib/formats/cpt.c \
               $(PEELER_DIR)/lib/formats/hqx.c \
               $(PEELER_DIR)/lib/formats/sit.c \
+              $(PEELER_DIR)/lib/formats/sit3.c \
               $(PEELER_DIR)/lib/formats/sit13.c \
               $(PEELER_DIR)/lib/formats/sit15.c
 


### PR DESCRIPTION
## Summary
- Upgrade the dev container, CI workflows, and dev image tag from Node LTS (18) to Node 22, installed via NodeSource since Ubuntu 24.04 only ships Node 18 in apt.
- Fix the WASM build that broke after the peeler library added `sit3.c` (StuffIt classic method 3 / static Huffman): both the project Makefile and peeler's own Makefile were missing `sit3.c` from their source lists, causing `undefined symbol: peel_sit3`.
- Bump the peeler submodule pointer to `855e3fa` to pick up the upstream Makefile fix.

## Test plan
- [x] `node -v` in rebuilt codespace prints `v22.x`
- [x] `make clean && make` (WASM build) succeeds end-to-end
- [x] `make test` inside `third-party/peeler` passes all 22 tests
- [ ] CI: `Copilot Setup Steps` workflow goes green on this branch
- [ ] CI: `Build & Publish Dev Image` produces the `:ubuntu24-emsdk4.0.10-node22` tag (already verified by an earlier manual run on this branch)
- [ ] CI: `tests.yml` runs against the new image tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)