### PR TITLE
Mac resource forks: parser + /rsrc/<TYPE>/<id> VFS paths + System 7 decompression

### DIFF
--- a/.agents/skills/headless-debug/SKILL.md
+++ b/.agents/skills/headless-debug/SKILL.md
@@ -523,6 +523,55 @@ mouse.click
 keyboard.press "Return"
 ```
 
+### 6.12 Reading individual resources (synthetic /rsrc tree)
+
+The image-VFS exposes each HFS file's resource fork as a directory tree
+addressable as `<file>/rsrc/<TYPE>/<id>`. The data fork stays at `<file>`,
+the Finder info stays at `<file>/finf`, and the raw fork bytes are
+still available at `<file>/rsrc/_raw` (the previous `<file>/rsrc`
+semantics, relocated under the new directory).
+
+```
+# Mount an image without auto-mounting via path-walk.
+storage.probe "tests/data/systems/System_6_0_8.dsk"
+
+# What resource types does the Finder carry?
+vfs.ls "tests/data/systems/System_6_0_8.dsk/partition1/System Folder/Finder/rsrc/"
+
+# How many CODE resources, and what are their IDs?
+vfs.ls "tests/data/systems/System_6_0_8.dsk/partition1/System Folder/Finder/rsrc/CODE/"
+# 5
+# 5.info
+# 9
+# 9.info
+# ...
+
+# Read a `vers` resource's bytes.
+vfs.cat "tests/data/systems/System_6_0_8.dsk/partition1/System Folder/Finder/rsrc/vers/1"
+
+# Read the matching .info sidecar (small JSON, safe over TCP).
+vfs.cat "tests/data/systems/System_6_0_8.dsk/partition1/System Folder/Finder/rsrc/vers/1.info"
+# {"name":"","attrs":["purgeable"],"size":50}
+
+# For binary resources (CODE, PICT, SND), use storage.cp rather than vfs.cat
+# so the bytes don't go through the TCP response stream.
+storage.cp "tests/data/.../Finder/rsrc/CODE/1" "/tmp/code1.bin"
+
+# Recursive dump of the whole fork as ordinary files.
+storage.cp -r "tests/data/.../Finder/rsrc/" "/tmp/finder-rsrc/"
+```
+
+Conventions:
+
+- `<TYPE>` is the 4-byte resource type, MacRoman-transcoded to UTF-8.
+  Quote the path when the type has a trailing space: `"…/rsrc/STR /128"`.
+- `<id>` is the signed int16 resource ID as base-10 with a leading `-`
+  for negatives: `"…/rsrc/DRVR/-16"`.
+- `<file>/rsrc/_raw` is the entire raw resource fork (use this for
+  format-level inspection or as a hand-off to an external parser).
+- Files with an empty resource fork have *no* synthetic tree —
+  `storage.path_exists "<file>/rsrc"` returns false rather than true.
+
 ## 7. Pitfalls
 
 - **Operators only work inside `${...}`.** `cpu.d0 = cpu.pc + 4` at the

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -126,3 +126,67 @@ Unit tests live in `tests/unit/suites/storage/test.c` and exercise:
 - State save/load round-trip
 - Delta persistence across close/reopen
 - Rollback (preimage journal replay)
+
+## 11. Resource forks as VFS paths
+
+The image-VFS backend (`src/core/vfs/image_vfs.c`) exposes the two-fork
+nature of classic-Mac HFS files in the path itself. For any HFS file
+`<file>` with a non-empty resource fork, the following synthetic paths
+resolve:
+
+| Path | Kind | Bytes |
+|---|---|---|
+| `<file>` | file | data fork |
+| `<file>/finf` | file (32 B) | Finder info blob (16 B FInfo + 16 B FXInfo) |
+| `<file>/rsrc` | directory | enumerates resource types and the `_raw` escape hatch |
+| `<file>/rsrc/_raw` | file | raw fork bytes (the entire resource fork) |
+| `<file>/rsrc/<TYPE>` | directory | enumerates resource IDs under a type |
+| `<file>/rsrc/<TYPE>/<id>` | file | the resource's bytes (verbatim, no length prefix) |
+| `<file>/rsrc/<TYPE>/<id>.info` | file | sidecar JSON: `{name, attrs[], size}` |
+
+`<TYPE>` is the four-byte resource type, MacRoman-transcoded to UTF-8 (so
+`CODE`, `vers`, `STR ` with trailing space, etc.). `<id>` is the signed
+int16 resource ID as base-10, including a leading `-` for negative values
+(common for system-reserved resources, e.g. `DRVR/-16` is `.Sony`).
+
+Example shell session:
+
+```
+> vfs.ls "/images/sys.img/System Folder/Finder/rsrc/"
+CODE
+MENU
+vers
+STR#
+…
+_raw
+
+> vfs.cat "/images/sys.img/System Folder/Finder/rsrc/vers/1.info"
+{"name":"","attrs":["purgeable"],"size":50}
+
+> storage.cp -r "/images/sys.img/System Folder/Finder/rsrc/" "/tmp/finder-rsrc/"
+```
+
+Eligibility rules:
+
+- **Files only.** HFS folders never gain a synthetic `/rsrc/` subtree.
+- **Non-empty fork only.** Files with `rsrc_fork.logical_size == 0`
+  resolve `<file>/rsrc` and any deeper path as ENOENT.
+- **HFS-backed only.** UFS partitions, host paths, and ISO 9660 images
+  have no resource forks; `<path>/rsrc/...` cleanly returns ENOENT on
+  those.
+- **Real HFS filenames named `rsrc` or `finf`.** Disambiguated by a
+  retry path in `image_vfs.c`: the synthetic interpretation is tried
+  first; on miss the full literal component list is retried.
+
+For binary data over the headless TCP shell or JS bridge, prefer
+`storage.cp <path> <dst>` over `vfs.cat <path>` — the latter streams
+non-printable bytes into the response stream, which is fine for small
+text resources but unsafe for arbitrary code/PICT/SND bytes.
+
+The parser lives in `src/core/storage/resource_fork.{c,h}` and exposes
+a small C API (`rfork_parse`, `rfork_num_types`, `rfork_id_at`,
+`rfork_lookup`, …) that downstream consumers (e.g. the `re`
+orchestrator under `src/core/re/`) call directly without routing
+through the VFS. Parsed maps are cached LRU-style under `image_vfs.c`
+keyed on `(mount, hfs_cnid)` with capacity 8; the cache is invalidated
+when the parent mount is destroyed.

--- a/src/core/shell/cmd_complete.c
+++ b/src/core/shell/cmd_complete.c
@@ -13,13 +13,13 @@
 #include "worker_thread.h"
 
 #include <ctype.h>
-#include <dirent.h>
 #include <stdbool.h>
 #include <string.h>
 #include <strings.h>
 
 #include "../object/object.h"
 #include "../object/value.h"
+#include "../vfs/vfs.h"
 
 // Phase 5c — legacy command registry deleted; no more `cmd_head`. The
 // completion code below skips the legacy branch entirely.
@@ -88,19 +88,27 @@ static void complete_paths(const char *prefix, struct completion *out) {
         partial = last_slash + 1;
     }
 
-    DIR *d = opendir(dir);
-    if (!d)
+    // Route through the VFS so completion works uniformly on host paths,
+    // image-vfs HFS directories, and the synthetic /rsrc/<TYPE> trees added
+    // by the resource-fork-as-VFS-tree proposal. Skip dotfiles unless the
+    // user has typed at least one '.' (same UX as the old host-only path).
+    vfs_dir_t *vd = NULL;
+    const vfs_backend_t *be = NULL;
+    if (vfs_opendir(dir, &vd, &be) < 0)
         return;
-    struct dirent *ent;
-    while ((ent = readdir(d)) != NULL && out->count < CMD_MAX_COMPLETIONS) {
-        if (ent->d_name[0] == '.' && partial[0] != '.')
+    vfs_dirent_t ent;
+    while (out->count < CMD_MAX_COMPLETIONS) {
+        int rc = be->readdir(vd, &ent);
+        if (rc <= 0)
+            break;
+        if (ent.name[0] == '.' && partial[0] != '.')
             continue;
-        const char *copy = pool_strdup(ent->d_name);
+        const char *copy = pool_strdup(ent.name);
         if (!copy)
             break;
         push_match(out, copy, partial);
     }
-    closedir(d);
+    be->closedir(vd);
 }
 
 // === Enum / bool helpers ====================================================

--- a/src/core/storage/resource_fork.c
+++ b/src/core/storage/resource_fork.c
@@ -18,6 +18,7 @@
 #include "resource_fork.h"
 
 #include "macroman.h"
+#include "rsrc_dcmp.h"
 
 #include <errno.h>
 #include <stdio.h>
@@ -42,12 +43,24 @@ typedef struct rfork_type {
     // Each resource carries: id, data slice, name slice, attrs.  Names are
     // resolved to UTF-8 once at parse time so callers don't repeat the
     // transcoding work per lookup.
+    //
+    // When the resource carries the System 7 compressed flag (attrs &
+    // RFORK_ATTR_COMPRESSED) AND its bytes start with the 0xA89F6572
+    // magic, we decompress eagerly at parse time and stash the inflated
+    // buffer in `inflated` / `inflated_size`.  rfork_lookup then returns
+    // the inflated bytes transparently so callers (CODE disassembler,
+    // per-type decoders) see real data.  `inflated` is NULL when the
+    // resource isn't compressed or when decompression failed (in which
+    // case we keep returning the raw bytes — the .info sidecar still
+    // surfaces the `compressed` flag so the caller can react).
     struct {
         int16_t id;
-        const uint8_t *bytes;
-        size_t size;
+        const uint8_t *bytes; // pointer into the fork buffer
+        size_t size; // raw (possibly compressed) size
         uint8_t attrs;
         char name_utf8[64]; // empty string when name_off == -1
+        uint8_t *inflated; // owned; NULL when not decompressed
+        size_t inflated_size;
     } *resources;
 } rfork_type_t;
 
@@ -177,6 +190,31 @@ rfork_t *rfork_parse(const uint8_t *fork_bytes, size_t fork_len, const char **er
                            sizeof(rf->types[t].resources[r].name_utf8))) {
                 FAIL("name list out of range");
             }
+
+            // System 7 compressed-resource auto-inflate.  Triggered when
+            // the attrs byte has the 0x01 (compressed) bit set AND the
+            // first 4 bytes are the dcmp magic.  Failure here is
+            // non-fatal: the .info sidecar still surfaces the
+            // compressed flag, and rfork_lookup falls through to the
+            // raw bytes — consumers that care can branch on attrs.
+            if ((attrs & RFORK_ATTR_COMPRESSED) &&
+                rsrc_dcmp_is_compressed(rf->types[t].resources[r].bytes, rf->types[t].resources[r].size)) {
+                size_t inflated_size = 0;
+                const char *derr = NULL;
+                uint8_t *inflated = rsrc_dcmp_decompress(rf->types[t].resources[r].bytes,
+                                                         rf->types[t].resources[r].size, &inflated_size, &derr);
+                if (inflated) {
+                    rf->types[t].resources[r].inflated = inflated;
+                    rf->types[t].resources[r].inflated_size = inflated_size;
+                }
+                // On decompression failure we leave inflated NULL.
+                // derr is intentionally ignored — the failure path is
+                // expected for any dcmp we don't implement yet (dcmp 2
+                // / GreggyBits, third-party compressors), and we don't
+                // want to noise up the parser caller with a per-
+                // resource warning stream.
+                (void)derr;
+            }
         }
     }
 
@@ -196,8 +234,13 @@ void rfork_free(rfork_t *rf) {
     if (!rf)
         return;
     if (rf->types) {
-        for (size_t t = 0; t < rf->num_types; t++)
-            free(rf->types[t].resources);
+        for (size_t t = 0; t < rf->num_types; t++) {
+            if (rf->types[t].resources) {
+                for (size_t r = 0; r < rf->types[t].num_resources; r++)
+                    free(rf->types[t].resources[r].inflated);
+                free(rf->types[t].resources);
+            }
+        }
         free(rf->types);
     }
     free(rf);
@@ -248,10 +291,18 @@ int rfork_lookup(const rfork_t *rf, const uint8_t type[4], int16_t id, const uin
         return -ENOENT;
     for (size_t r = 0; r < t->num_resources; r++) {
         if (t->resources[r].id == id) {
+            // Prefer the inflated bytes when present.  The .info sidecar
+            // (built by callers from `attrs`) still reports the
+            // compressed flag — that's a property of the resource record,
+            // not of the byte stream — so downstream tooling can tell
+            // "this was compressed on disk" even when we hand it the
+            // inflated form.
+            const uint8_t *bytes = t->resources[r].inflated ? t->resources[r].inflated : t->resources[r].bytes;
+            size_t size = t->resources[r].inflated ? t->resources[r].inflated_size : t->resources[r].size;
             if (bytes_out)
-                *bytes_out = t->resources[r].bytes;
+                *bytes_out = bytes;
             if (size_out)
-                *size_out = t->resources[r].size;
+                *size_out = size;
             if (name_out)
                 *name_out = t->resources[r].name_utf8;
             if (attrs_out)

--- a/src/core/storage/resource_fork.c
+++ b/src/core/storage/resource_fork.c
@@ -1,0 +1,457 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) pappadf
+
+// resource_fork.c
+// Read-only parser for the classic-Mac resource-fork on-disk format.  See
+// resource_fork.h for the format reference.  Two well-documented traps
+// the parser handles explicitly:
+//   - the on-disk num_types and count fields are stored as "minus one"
+//     (so a fork with 0 types stores 0xFFFF, and a single resource of a
+//     type stores 0 for that type's count).
+//   - the data-offset field in each ref-list entry is a packed 24-bit
+//     integer in the low three bytes of a u32; the high byte is attrs.
+//
+// All field reads are range-checked against the fork-length / map-length
+// bounds.  Malformed forks return NULL from rfork_parse with *errmsg set
+// to a static string, never abort.
+
+#include "resource_fork.h"
+
+#include "macroman.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Big-endian field readers — the fork buffer is the on-disk layout verbatim.
+static uint16_t be_u16(const uint8_t *p) {
+    return (uint16_t)((p[0] << 8) | p[1]);
+}
+static uint32_t be_u32(const uint8_t *p) {
+    return (uint32_t)((p[0] << 24) | (p[1] << 16) | (p[2] << 8) | p[3]);
+}
+static int16_t be_i16(const uint8_t *p) {
+    return (int16_t)be_u16(p);
+}
+
+// One parsed type entry: 4-CC plus a contiguous run of ref-list slots.
+typedef struct rfork_type {
+    uint8_t cc[4];
+    size_t num_resources;
+    // Each resource carries: id, data slice, name slice, attrs.  Names are
+    // resolved to UTF-8 once at parse time so callers don't repeat the
+    // transcoding work per lookup.
+    struct {
+        int16_t id;
+        const uint8_t *bytes;
+        size_t size;
+        uint8_t attrs;
+        char name_utf8[64]; // empty string when name_off == -1
+    } *resources;
+} rfork_type_t;
+
+struct rfork {
+    uint16_t fork_attrs;
+    size_t num_types;
+    rfork_type_t *types;
+};
+
+// Read a Pascal-format name out of the name list and transcode to UTF-8.
+// `name_off` is the offset relative to the name-list start; -1 means "no
+// name".  Returns true on success.
+static bool read_name(const uint8_t *map, size_t map_len, size_t name_list_off, int16_t name_off, char *out,
+                      size_t cap) {
+    out[0] = '\0';
+    if (name_off < 0)
+        return true;
+    size_t abs = name_list_off + (size_t)(uint16_t)name_off;
+    if (abs >= map_len)
+        return false;
+    uint8_t plen = map[abs];
+    if (abs + 1 + plen > map_len)
+        return false;
+    macroman_to_utf8(map + abs + 1, plen, out, cap);
+    return true;
+}
+
+rfork_t *rfork_parse(const uint8_t *fork_bytes, size_t fork_len, const char **errmsg_out) {
+    const char *err = NULL;
+#define FAIL(msg)                                                                                                      \
+    do {                                                                                                               \
+        err = (msg);                                                                                                   \
+        goto fail;                                                                                                     \
+    } while (0)
+
+    rfork_t *rf = NULL;
+
+    if (!fork_bytes || fork_len < 16)
+        FAIL("fork too small for header");
+    uint32_t data_off = be_u32(fork_bytes + 0);
+    uint32_t map_off = be_u32(fork_bytes + 4);
+    uint32_t data_len = be_u32(fork_bytes + 8);
+    uint32_t map_len = be_u32(fork_bytes + 12);
+    if ((uint64_t)data_off + data_len > fork_len)
+        FAIL("data area out of range");
+    if ((uint64_t)map_off + map_len > fork_len)
+        FAIL("map area out of range");
+    if (map_len < 30)
+        FAIL("map area too small");
+
+    const uint8_t *map = fork_bytes + map_off;
+    const uint8_t *data = fork_bytes + data_off;
+    uint16_t fork_attrs = be_u16(map + 22);
+    uint16_t type_list_off = be_u16(map + 24);
+    uint16_t name_list_off = be_u16(map + 26);
+    if ((uint32_t)type_list_off + 2 > map_len)
+        FAIL("type-list offset out of range");
+    // name_list_off may equal map_len exactly when no names are stored.
+    if ((uint32_t)name_list_off > map_len)
+        FAIL("name-list offset out of range");
+
+    rf = calloc(1, sizeof(*rf));
+    if (!rf)
+        FAIL("out of memory");
+    rf->fork_attrs = fork_attrs;
+
+    uint16_t num_types_m1 = be_u16(map + type_list_off);
+    // The off-by-one encoding means an empty fork stores 0xFFFF for the
+    // num-types word; detect that explicitly so we don't allocate 64K
+    // empty type slots.
+    if (num_types_m1 == 0xFFFF) {
+        rf->num_types = 0;
+        if (errmsg_out)
+            *errmsg_out = NULL;
+        return rf;
+    }
+    rf->num_types = (size_t)num_types_m1 + 1;
+
+    // Each type entry is 8 bytes; verify the table fits inside the map.
+    size_t type_table_end = (size_t)type_list_off + 2 + 8 * rf->num_types;
+    if (type_table_end > map_len)
+        FAIL("type table out of range");
+
+    rf->types = calloc(rf->num_types, sizeof(rfork_type_t));
+    if (!rf->types)
+        FAIL("out of memory");
+
+    for (size_t t = 0; t < rf->num_types; t++) {
+        const uint8_t *te = map + type_list_off + 2 + 8 * t;
+        memcpy(rf->types[t].cc, te + 0, 4);
+        uint16_t count_m1 = be_u16(te + 4);
+        uint16_t ref_off = be_u16(te + 6);
+        size_t num_res = (size_t)count_m1 + 1;
+        rf->types[t].num_resources = num_res;
+
+        // Each ref-list entry is 12 bytes; the offset is relative to the
+        // start of the type list (i.e., type_list_off, not the entry that
+        // owns the ref).
+        size_t ref_start = (size_t)type_list_off + ref_off;
+        size_t ref_end = ref_start + 12 * num_res;
+        if (ref_end > map_len)
+            FAIL("ref list out of range");
+
+        rf->types[t].resources = calloc(num_res, sizeof(*rf->types[t].resources));
+        if (!rf->types[t].resources)
+            FAIL("out of memory");
+
+        for (size_t r = 0; r < num_res; r++) {
+            const uint8_t *re = map + ref_start + 12 * r;
+            int16_t id = be_i16(re + 0);
+            int16_t name_off = be_i16(re + 2);
+            uint8_t attrs = re[4];
+            // 24-bit data offset in the low 3 bytes of the next u32.
+            uint32_t do24 = ((uint32_t)re[5] << 16) | ((uint32_t)re[6] << 8) | (uint32_t)re[7];
+            if ((size_t)do24 + 4 > data_len)
+                FAIL("resource data offset out of range");
+            uint32_t rlen = be_u32(data + do24);
+            if ((size_t)do24 + 4 + rlen > data_len)
+                FAIL("resource data length out of range");
+
+            rf->types[t].resources[r].id = id;
+            rf->types[t].resources[r].attrs = attrs;
+            rf->types[t].resources[r].bytes = data + do24 + 4;
+            rf->types[t].resources[r].size = rlen;
+
+            if (!read_name(map, map_len, name_list_off, name_off, rf->types[t].resources[r].name_utf8,
+                           sizeof(rf->types[t].resources[r].name_utf8))) {
+                FAIL("name list out of range");
+            }
+        }
+    }
+
+    if (errmsg_out)
+        *errmsg_out = NULL;
+    return rf;
+
+fail:
+    if (errmsg_out)
+        *errmsg_out = err ? err : "corrupt resource fork";
+    rfork_free(rf);
+    return NULL;
+#undef FAIL
+}
+
+void rfork_free(rfork_t *rf) {
+    if (!rf)
+        return;
+    if (rf->types) {
+        for (size_t t = 0; t < rf->num_types; t++)
+            free(rf->types[t].resources);
+        free(rf->types);
+    }
+    free(rf);
+}
+
+uint16_t rfork_attrs(const rfork_t *rf) {
+    return rf ? rf->fork_attrs : 0;
+}
+
+size_t rfork_num_types(const rfork_t *rf) {
+    return rf ? rf->num_types : 0;
+}
+
+const uint8_t *rfork_type_at(const rfork_t *rf, size_t idx) {
+    if (!rf || idx >= rf->num_types)
+        return NULL;
+    return rf->types[idx].cc;
+}
+
+// Linear-scan the type table for the requested 4-CC.  Type counts in
+// practice are < 200, so a linear scan is faster than building a hash.
+static const rfork_type_t *find_type(const rfork_t *rf, const uint8_t type[4]) {
+    if (!rf)
+        return NULL;
+    for (size_t t = 0; t < rf->num_types; t++) {
+        if (memcmp(rf->types[t].cc, type, 4) == 0)
+            return &rf->types[t];
+    }
+    return NULL;
+}
+
+size_t rfork_num_resources(const rfork_t *rf, const uint8_t type[4]) {
+    const rfork_type_t *t = find_type(rf, type);
+    return t ? t->num_resources : 0;
+}
+
+int16_t rfork_id_at(const rfork_t *rf, const uint8_t type[4], size_t idx) {
+    const rfork_type_t *t = find_type(rf, type);
+    if (!t || idx >= t->num_resources)
+        return 0;
+    return t->resources[idx].id;
+}
+
+int rfork_lookup(const rfork_t *rf, const uint8_t type[4], int16_t id, const uint8_t **bytes_out, size_t *size_out,
+                 const char **name_out, uint8_t *attrs_out) {
+    const rfork_type_t *t = find_type(rf, type);
+    if (!t)
+        return -ENOENT;
+    for (size_t r = 0; r < t->num_resources; r++) {
+        if (t->resources[r].id == id) {
+            if (bytes_out)
+                *bytes_out = t->resources[r].bytes;
+            if (size_out)
+                *size_out = t->resources[r].size;
+            if (name_out)
+                *name_out = t->resources[r].name_utf8;
+            if (attrs_out)
+                *attrs_out = t->resources[r].attrs;
+            return 0;
+        }
+    }
+    return -ENOENT;
+}
+
+// === Path-component helpers =================================================
+
+void rfork_type_to_path(const uint8_t type[4], char *out, size_t cap) {
+    macroman_to_utf8(type, 4, out, cap);
+}
+
+// Inverse of rfork_type_to_path: walk the UTF-8 component, decode each
+// codepoint, look it up in the MacRoman table (low byte = ASCII, high
+// byte = scan).  Reject if the decode produces != 4 MacRoman bytes.
+// Mirror of the MacRoman high-byte table from macroman.c, used by the
+// inverse transcoder below.  Duplicating the 128 entries here is cheaper
+// than exposing the internal table; both stay in sync as a single
+// source-of-truth update.
+static const uint16_t macroman_hi_lookup[128] = {
+    0x00C4, 0x00C5, 0x00C7, 0x00C9, 0x00D1, 0x00D6, 0x00DC, 0x00E1, 0x00E0, 0x00E2, 0x00E4, 0x00E3, 0x00E5,
+    0x00E7, 0x00E9, 0x00E8, 0x00EA, 0x00EB, 0x00ED, 0x00EC, 0x00EE, 0x00EF, 0x00F1, 0x00F3, 0x00F2, 0x00F4,
+    0x00F6, 0x00F5, 0x00FA, 0x00F9, 0x00FB, 0x00FC, 0x2020, 0x00B0, 0x00A2, 0x00A3, 0x00A7, 0x2022, 0x00B6,
+    0x00DF, 0x00AE, 0x00A9, 0x2122, 0x00B4, 0x00A8, 0x2260, 0x00C6, 0x00D8, 0x221E, 0x00B1, 0x2264, 0x2265,
+    0x00A5, 0x00B5, 0x2202, 0x2211, 0x220F, 0x03C0, 0x222B, 0x00AA, 0x00BA, 0x03A9, 0x00E6, 0x00F8, 0x00BF,
+    0x00A1, 0x00AC, 0x221A, 0x0192, 0x2248, 0x2206, 0x00AB, 0x00BB, 0x2026, 0x00A0, 0x00C0, 0x00C3, 0x00D5,
+    0x0152, 0x0153, 0x2013, 0x2014, 0x201C, 0x201D, 0x2018, 0x2019, 0x00F7, 0x25CA, 0x00FF, 0x0178, 0x2044,
+    0x20AC, 0x2039, 0x203A, 0xFB01, 0xFB02, 0x2021, 0x00B7, 0x201A, 0x201E, 0x2030, 0x00C2, 0x00CA, 0x00C1,
+    0x00CB, 0x00C8, 0x00CD, 0x00CE, 0x00CF, 0x00CC, 0x00D3, 0x00D4, 0xF8FF, 0x00D2, 0x00DA, 0x00DB, 0x00D9,
+    0x0131, 0x02C6, 0x02DC, 0x00AF, 0x02D8, 0x02D9, 0x02DA, 0x00B8, 0x02DD, 0x02DB, 0x02C7,
+};
+
+int rfork_type_from_path(const char *path_component, uint8_t out[4]) {
+    if (!path_component)
+        return -EINVAL;
+    const uint8_t *p = (const uint8_t *)path_component;
+    size_t out_n = 0;
+    while (*p && out_n < 4) {
+        uint32_t cp;
+        if (p[0] < 0x80) {
+            cp = p[0];
+            p++;
+        } else if ((p[0] & 0xE0) == 0xC0 && (p[1] & 0xC0) == 0x80) {
+            cp = ((uint32_t)(p[0] & 0x1F) << 6) | (p[1] & 0x3F);
+            p += 2;
+        } else if ((p[0] & 0xF0) == 0xE0 && (p[1] & 0xC0) == 0x80 && (p[2] & 0xC0) == 0x80) {
+            cp = ((uint32_t)(p[0] & 0x0F) << 12) | ((uint32_t)(p[1] & 0x3F) << 6) | (p[2] & 0x3F);
+            p += 3;
+        } else {
+            return -EINVAL;
+        }
+        if (cp < 0x80) {
+            out[out_n++] = (uint8_t)cp;
+            continue;
+        }
+        // Scan the MacRoman high-byte table for a match.  ~128 entries,
+        // amortised on 4 chars per type, is negligible.
+        bool found = false;
+        for (size_t i = 0; i < 128; i++) {
+            if (macroman_hi_lookup[i] == cp) {
+                out[out_n++] = (uint8_t)(0x80 + i);
+                found = true;
+                break;
+            }
+        }
+        if (!found)
+            return -EINVAL;
+    }
+    if (out_n != 4 || *p != '\0')
+        return -EINVAL;
+    return 0;
+}
+
+void rfork_id_to_path(int16_t id, char *out, size_t cap) {
+    if (cap == 0)
+        return;
+    snprintf(out, cap, "%d", (int)id);
+}
+
+int rfork_id_from_path(const char *path_component, int16_t *out) {
+    if (!path_component || !*path_component)
+        return -EINVAL;
+    char *end = NULL;
+    errno = 0;
+    long v = strtol(path_component, &end, 10);
+    if (errno != 0 || !end || *end != '\0')
+        return -EINVAL;
+    if (v < -32768 || v > 32767)
+        return -EINVAL;
+    if (out)
+        *out = (int16_t)v;
+    return 0;
+}
+
+// Map an attrs byte to its zero-or-more flag names.  Order matters: callers
+// inspect the JSON output by name, not bit position.
+static const char *attr_name(uint8_t bit) {
+    switch (bit) {
+    case RFORK_ATTR_SYSHEAP:
+        return "sysheap";
+    case RFORK_ATTR_PURGEABLE:
+        return "purgeable";
+    case RFORK_ATTR_LOCKED:
+        return "locked";
+    case RFORK_ATTR_PROTECTED:
+        return "protected";
+    case RFORK_ATTR_PRELOAD:
+        return "preload";
+    case RFORK_ATTR_CHANGED:
+        return "changed";
+    case RFORK_ATTR_COMPRESSED:
+        return "compressed";
+    default:
+        return NULL;
+    }
+}
+
+// JSON-escape `src` into `dst`.  Replicates the small subset required for
+// resource names: backslash, quote, control chars escaped to \uXXXX.
+static int json_escape(const char *src, char *dst, size_t cap) {
+    size_t o = 0;
+    for (size_t i = 0; src[i]; i++) {
+        unsigned char c = (unsigned char)src[i];
+        char buf[8];
+        size_t need = 0;
+        if (c == '"' || c == '\\') {
+            need = 2;
+            buf[0] = '\\';
+            buf[1] = (char)c;
+        } else if (c == '\n') {
+            need = 2;
+            buf[0] = '\\';
+            buf[1] = 'n';
+        } else if (c == '\r') {
+            need = 2;
+            buf[0] = '\\';
+            buf[1] = 'r';
+        } else if (c == '\t') {
+            need = 2;
+            buf[0] = '\\';
+            buf[1] = 't';
+        } else if (c < 0x20) {
+            need = 6;
+            snprintf(buf, sizeof(buf), "\\u%04x", c);
+        } else {
+            need = 1;
+            buf[0] = (char)c;
+        }
+        if (o + need >= cap)
+            return -EINVAL;
+        memcpy(dst + o, buf, need);
+        o += need;
+    }
+    if (o >= cap)
+        return -EINVAL;
+    dst[o] = '\0';
+    return (int)o;
+}
+
+int rfork_info_format(const char *name, uint8_t attrs, size_t size, char *out, size_t cap) {
+    char esc[256];
+    if (json_escape(name ? name : "", esc, sizeof(esc)) < 0)
+        return -EINVAL;
+
+    int n = snprintf(out, cap, "{\"name\":\"%s\",\"attrs\":[", esc);
+    if (n < 0 || (size_t)n >= cap)
+        return -EINVAL;
+    size_t o = (size_t)n;
+
+    bool first = true;
+    static const uint8_t bits[] = {
+        RFORK_ATTR_SYSHEAP, RFORK_ATTR_PURGEABLE, RFORK_ATTR_LOCKED,     RFORK_ATTR_PROTECTED,
+        RFORK_ATTR_PRELOAD, RFORK_ATTR_CHANGED,   RFORK_ATTR_COMPRESSED,
+    };
+    for (size_t i = 0; i < sizeof(bits) / sizeof(bits[0]); i++) {
+        if (attrs & bits[i]) {
+            const char *nm = attr_name(bits[i]);
+            int w = snprintf(out + o, cap - o, "%s\"%s\"", first ? "" : ",", nm);
+            if (w < 0 || (size_t)w >= cap - o)
+                return -EINVAL;
+            o += (size_t)w;
+            first = false;
+        }
+    }
+    // Surface any unknown reserved bits as "reserved_0xNN" entries so callers
+    // can still see them without us silently dropping the information.
+    uint8_t unknown = attrs & ~0x7F;
+    if (unknown) {
+        int w = snprintf(out + o, cap - o, "%s\"reserved_0x%02x\"", first ? "" : ",", unknown);
+        if (w < 0 || (size_t)w >= cap - o)
+            return -EINVAL;
+        o += (size_t)w;
+    }
+    int w = snprintf(out + o, cap - o, "],\"size\":%zu}\n", size);
+    if (w < 0 || (size_t)w >= cap - o)
+        return -EINVAL;
+    o += (size_t)w;
+    return (int)o;
+}

--- a/src/core/storage/resource_fork.h
+++ b/src/core/storage/resource_fork.h
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) pappadf
+
+// resource_fork.h
+// Read-only parser for the classic-Mac resource-fork on-disk format.  Given
+// a contiguous buffer of fork bytes, it surfaces the type list, ref list,
+// and per-resource bytes/name/attrs through a small C API.  Consumed by
+// image_vfs.c (synthetic /rsrc/<TYPE>/<id> path tree) and the upcoming
+// `re` orchestrator.
+//
+// The parser does not copy resource bytes — the supplied fork buffer must
+// outlive the returned rfork_t.  The parser does build a small index over
+// the type list, ref list, and name list so lookups are O(types) + O(ids)
+// rather than scanning the fork on every call.
+//
+// On-disk format (big-endian throughout):
+//   +0   data_offset     (u32) — byte offset of data area in fork
+//   +4   map_offset      (u32) — byte offset of map area in fork
+//   +8   data_length     (u32) — size of data area
+//   +12  map_length      (u32) — size of map area
+//   data area:           per resource: 4-byte length (u32 BE) + length bytes
+//   map area:
+//     +0..15  copy of fork header (reserved)
+//     +16..21 reserved
+//     +22..23 fork attrs (u16)
+//     +24..25 offset to type list, relative to map start (u16)
+//     +26..27 offset to name list, relative to map start (u16)
+//     [at type-list offset]:
+//        +0..1   num types - 1 (u16) — yes, minus one
+//        +2.. 8 bytes per type:
+//          +0  type 4-CC
+//          +4  count - 1 (u16) — minus one again
+//          +6  ref-list offset, relative to type-list start (u16)
+//        ref list per type:
+//          +0  id            (i16)
+//          +2  name offset   (i16, -1 = no name; relative to name-list start)
+//          +4  attrs byte + 24-bit data offset (relative to data-area start)
+//          +8  reserved      (u32)
+//     [at name-list offset]:
+//        Pascal strings (1-byte length + MacRoman bytes)
+
+#pragma once
+
+#ifndef GS_RESOURCE_FORK_H
+#define GS_RESOURCE_FORK_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// Resource attrs byte bits, from Inside Macintosh.
+#define RFORK_ATTR_SYSHEAP    0x40
+#define RFORK_ATTR_PURGEABLE  0x20
+#define RFORK_ATTR_LOCKED     0x10
+#define RFORK_ATTR_PROTECTED  0x08
+#define RFORK_ATTR_PRELOAD    0x04
+#define RFORK_ATTR_CHANGED    0x02
+#define RFORK_ATTR_COMPRESSED 0x01
+
+typedef struct rfork rfork_t;
+
+// Parse a resource fork from a buffer.  The buffer must outlive the
+// returned rfork_t (no copy).  Returns NULL on corruption with *errmsg_out
+// set to a static string describing the failure.
+rfork_t *rfork_parse(const uint8_t *fork_bytes, size_t fork_len, const char **errmsg_out);
+void rfork_free(rfork_t *rf);
+
+// Top-of-fork attrs word (the "fork attributes" field at map+22).
+uint16_t rfork_attrs(const rfork_t *rf);
+
+// Enumerate type 4-CCs (catalog order).  rfork_type_at returns a pointer
+// to 4 bytes owned by the rfork_t (no copy); the bytes are MacRoman.
+size_t rfork_num_types(const rfork_t *rf);
+const uint8_t *rfork_type_at(const rfork_t *rf, size_t idx);
+
+// Enumerate IDs under a type (ref-list order).  Returns 0 if the type is
+// not present in the fork.
+size_t rfork_num_resources(const rfork_t *rf, const uint8_t type[4]);
+int16_t rfork_id_at(const rfork_t *rf, const uint8_t type[4], size_t idx);
+
+// Resolve one resource.  Returns 0 on hit and populates *bytes_out (pointer
+// into the fork buffer), *size_out, *name_out (UTF-8, NUL-terminated; "" if
+// no name), and *attrs_out.  Returns -ENOENT on miss.  Any out parameter
+// may be NULL.
+int rfork_lookup(const rfork_t *rf, const uint8_t type[4], int16_t id, const uint8_t **bytes_out, size_t *size_out,
+                 const char **name_out, uint8_t *attrs_out);
+
+// === Path-component helpers (used by image_vfs.c and re/) ===================
+
+// Format a 4-CC type as a UTF-8 path component (MacRoman -> UTF-8).
+// Always NUL-terminates when cap > 0.
+void rfork_type_to_path(const uint8_t type[4], char *out, size_t cap);
+
+// Parse a UTF-8 path component back into a 4-CC (MacRoman).  Most callers
+// pass plain-ASCII type names like "CODE", "vers", "STR " (with trailing
+// space) — the inverse transcoder rejects components that don't decode to
+// exactly four MacRoman bytes.  Returns 0 on success, -EINVAL otherwise.
+int rfork_type_from_path(const char *path_component, uint8_t out[4]);
+
+// Format a signed-16-bit resource ID into a base-10 path component
+// ("128", "0", "-16").  Always NUL-terminates when cap > 0.
+void rfork_id_to_path(int16_t id, char *out, size_t cap);
+
+// Parse a base-10 path component as a resource ID.  Rejects empty input,
+// trailing junk, and values outside the int16 range.  Returns 0 on
+// success, -EINVAL otherwise.
+int rfork_id_from_path(const char *path_component, int16_t *out);
+
+// Format the .info sidecar JSON for a resource.  Output shape:
+//   {"name":"Foo","attrs":["preload","locked"],"size":1576}\n
+// Returns the number of bytes written (excluding NUL), or -EINVAL if the
+// buffer is too small.
+int rfork_info_format(const char *name, uint8_t attrs, size_t size, char *out, size_t cap);
+
+#endif // GS_RESOURCE_FORK_H

--- a/src/core/storage/rsrc_dcmp.c
+++ b/src/core/storage/rsrc_dcmp.c
@@ -1,0 +1,674 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) pappadf
+
+// rsrc_dcmp.c
+// Apple System 7 "DonnBits" (dcmp 0) decompressor, ported from the
+// open-sourced Apple assembly in
+//   gs-archive/sys71src-main/Patches/DeCompressDefProc.a
+//   gs-archive/sys71src-main/Patches/DeCompressCommon.A
+//   gs-archive/sys71src-main/Internal/Asm/Decompression.a
+// © 1990-1991 Apple Computer (Donn Denman), released as part of the
+// System 7 source drop.
+//
+// On-disk layout of a compressed resource (header version 8):
+//   +0   signature (u32 BE) = 0xA89F6572
+//   +4   header_length (u16 BE) = 0x12 (18 bytes)
+//   +6   header_version (u8) = 8
+//   +7   extended_attrs (u8) — compression sub-flags (unused here)
+//   +8   actual_size (u32 BE) — uncompressed byte count
+//   +12  var_table_ratio (u8) — 256ths-of-actual_size sized for var table
+//   +13  overrun (u8) — extra bytes the decompressor may write
+//   +14  dcmp_id (i16 BE) — 0 = DonnBits, 2 = GreggyBits, ...
+//   +16  ctable_id (i16 BE) — auxiliary table (unused for dcmp 0)
+//   +18  compressed payload starts here
+//
+// The payload is a stream of single-byte opcodes; each opcode either
+// emits 16-bit words into the output buffer, slurps additional bytes
+// from the input, or both.  The dispatch table is fixed at 256 entries:
+//
+//   0x00         LitWithLength      — encoded length N words, then 2N literal bytes
+//   0x01..0x0F   LiteralN           — copies 2..30 literal bytes (N=opcode*2)
+//   0x10         RememberWithLength — same as 0x00, but also stores in var table
+//   0x11..0x1F   RememberN          — copies + remembers 2..30 literal bytes
+//   0x20         ReuseByteLength    — 1-byte index + 40 → fetch from var table
+//   0x21         ReuseByte2Length   — 1-byte index + 40 + 256
+//   0x22         ReuseWordLength    — 2-byte index + 40
+//   0x23..0x4A   ReuseData0..39     — direct fetch, var index = opcode - 0x23
+//   0x4B..0xFD   constant-word emit — output one fixed 16-bit word (see table)
+//   0xFE         HandleExtensions   — second byte selects sub-opcode (jump table,
+//                                     entry vector, run-length, diff-encoded)
+//   0xFF         end-of-stream      — terminate decompression
+//
+// The var table doubles as the LZ-style dictionary.  RememberN stuffs
+// the literal that was just emitted into the table; subsequent
+// ReuseData* opcodes pull it back out.  Initial table layout:
+//   +0  next-slot index (u16)
+//   +2  VarsList[0] = table_size (sentinel for the back-growing data)
+//   +4..  VarsList[1..], one u16 per remembered string
+//   data for each string lives at the END of the table, growing
+//   downward.  String N occupies bytes [VarsList[N+1], VarsList[N]) of
+//   the table buffer (where VarsList[N+1] is set when N is remembered).
+
+#include "rsrc_dcmp.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+// ---- Big-endian field readers --------------------------------------------
+
+static uint16_t be_u16(const uint8_t *p) {
+    return (uint16_t)((p[0] << 8) | p[1]);
+}
+static uint32_t be_u32(const uint8_t *p) {
+    return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) | ((uint32_t)p[2] << 8) | p[3];
+}
+
+bool rsrc_dcmp_is_compressed(const uint8_t *bytes, size_t len) {
+    return bytes && len >= 4 && be_u32(bytes) == RSRC_DCMP_MAGIC;
+}
+
+// ---- Constant-word emit table (opcodes 0x4B..0xFD) ------------------------
+//
+// 179 entries, transcribed verbatim from DeCompressDefProc.a.  The first
+// entry (originally `Clr.W (A1)+`) emits 0x0000; the remaining 178 use
+// `Move.W #$xxxx,(A1)+`.  Reproducing this table 1:1 with the assembly
+// is mandatory — any deviation would silently corrupt every decompressed
+// output that uses these opcodes (which is most of them).
+static const uint16_t g_const_words[179] = {
+    0x0000, 0x4EBA, 0x0008, 0x4E75, 0x000C, 0x4EAD, 0x2053, 0x2F0B, // 0x4B..0x52
+    0x6100, 0x0010, 0x7000, 0x2F00, 0x486E, 0x2050, 0x206E, 0x2F2E, // 0x53..0x5A
+    0xFFFC, 0x48E7, 0x3F3C, 0x0004, 0xFFF8, 0x2F0C, 0x2006, 0x4EED, // 0x5B..0x62
+    0x4E56, 0x2068, 0x4E5E, 0x0001, 0x588F, 0x4FEF, 0x0002, 0x0018, // 0x63..0x6A
+    0x6000, 0xFFFF, 0x508F, 0x4E90, 0x0006, 0x266E, 0x0014, 0xFFF4, // 0x6B..0x72
+    0x4CEE, 0x000A, 0x000E, 0x41EE, 0x4CDF, 0x48C0, 0xFFF0, 0x2D40, // 0x73..0x7A
+    0x0012, 0x302E, 0x7001, 0x2F28, 0x2054, 0x6700, 0x0020, 0x001C, // 0x7B..0x82
+    0x205F, 0x1800, 0x266F, 0x4878, 0x0016, 0x41FA, 0x303C, 0x2840, // 0x83..0x8A
+    0x7200, 0x286E, 0x200C, 0x6600, 0x206B, 0x2F07, 0x558F, 0x0028, // 0x8B..0x92
+    0xFFFE, 0xFFEC, 0x22D8, 0x200B, 0x000F, 0x598F, 0x2F3C, 0xFF00, // 0x93..0x9A
+    0x0118, 0x81E1, 0x4A00, 0x4EB0, 0xFFE8, 0x48C7, 0x0003, 0x0022, // 0x9B..0xA2
+    0x0007, 0x001A, 0x6706, 0x6708, 0x4EF9, 0x0024, 0x2078, 0x0800, // 0xA3..0xAA
+    0x6604, 0x002A, 0x4ED0, 0x3028, 0x265F, 0x6704, 0x0030, 0x43EE, // 0xAB..0xB2
+    0x3F00, 0x201F, 0x001E, 0xFFF6, 0x202E, 0x42A7, 0x2007, 0xFFFA, // 0xB3..0xBA
+    0x6002, 0x3D40, 0x0C40, 0x6606, 0x0026, 0x2D48, 0x2F01, 0x70FF, // 0xBB..0xC2
+    0x6004, 0x1880, 0x4A40, 0x0040, 0x002C, 0x2F08, 0x0011, 0xFFE4, // 0xC3..0xCA
+    0x2140, 0x2640, 0xFFF2, 0x426E, 0x4EB9, 0x3D7C, 0x0038, 0x000D, // 0xCB..0xD2
+    0x6006, 0x422E, 0x203C, 0x670C, 0x2D68, 0x6608, 0x4A2E, 0x4AAE, // 0xD3..0xDA
+    0x002E, 0x4840, 0x225F, 0x2200, 0x670A, 0x3007, 0x4267, 0x0032, // 0xDB..0xE2
+    0x2028, 0x0009, 0x487A, 0x0200, 0x2F2B, 0x0005, 0x226E, 0x6602, // 0xE3..0xEA
+    0xE580, 0x670E, 0x660A, 0x0050, 0x3E00, 0x660C, 0x2E00, 0xFFEE, // 0xEB..0xF2
+    0x206D, 0x2040, 0xFFE0, 0x5340, 0x6008, 0x0480, 0x0068, 0x0B7C, // 0xF3..0xFA
+    0x4400, 0x41E8, 0x4841, // 0xFB..0xFD
+};
+
+// ---- Streaming I/O contexts -----------------------------------------------
+//
+// `ic_t` is the input cursor over the compressed payload; `oc_t` is the
+// output cursor over the allocated inflated buffer.  All bounds checks
+// route through ic_get* / oc_put*, so a malformed stream produces a
+// clean -1 return rather than walking off either buffer.
+
+typedef struct {
+    const uint8_t *p;
+    size_t len;
+    size_t off;
+} ic_t;
+
+typedef struct {
+    uint8_t *p;
+    size_t cap;
+    size_t off;
+} oc_t;
+
+static int ic_get_u8(ic_t *ic, uint8_t *out) {
+    if (ic->off >= ic->len)
+        return -1;
+    *out = ic->p[ic->off++];
+    return 0;
+}
+static int ic_get_n(ic_t *ic, size_t n, const uint8_t **out) {
+    if (ic->off + n > ic->len)
+        return -1;
+    *out = ic->p + ic->off;
+    ic->off += n;
+    return 0;
+}
+static int oc_put_u8(oc_t *oc, uint8_t b) {
+    if (oc->off >= oc->cap)
+        return -1;
+    oc->p[oc->off++] = b;
+    return 0;
+}
+static int oc_put_u16_be(oc_t *oc, uint16_t v) {
+    if (oc->off + 2 > oc->cap)
+        return -1;
+    oc->p[oc->off++] = (uint8_t)(v >> 8);
+    oc->p[oc->off++] = (uint8_t)v;
+    return 0;
+}
+static int oc_put_n(oc_t *oc, const uint8_t *src, size_t n) {
+    if (oc->off + n > oc->cap)
+        return -1;
+    memcpy(oc->p + oc->off, src, n);
+    oc->off += n;
+    return 0;
+}
+
+// ---- GetEncodedValue ------------------------------------------------------
+//
+// Variable-length signed-integer encoding, lifted from DeCompressCommon.A:
+//   Tag         Range            Bytes consumed
+//   0..127      0..127           1
+//   128..254    -16384..16127    2  (signed 16-bit, packed)
+//   255         32-bit           5  (literal big-endian int32)
+
+static int get_encoded(ic_t *ic, int32_t *out) {
+    uint8_t b0;
+    if (ic_get_u8(ic, &b0) < 0)
+        return -1;
+    if (b0 < 0x80) {
+        *out = b0;
+        return 0;
+    }
+    if (b0 == 0xFF) {
+        const uint8_t *p;
+        if (ic_get_n(ic, 4, &p) < 0)
+            return -1;
+        *out = (int32_t)(((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) | ((uint32_t)p[2] << 8) | p[3]);
+        return 0;
+    }
+    // 2-byte form: value = signed16 of ((b0 - 0xC0) << 8) | b1
+    uint8_t b1;
+    if (ic_get_u8(ic, &b1) < 0)
+        return -1;
+    int8_t hi = (int8_t)((int)b0 - 0xC0); // -64..62
+    int16_t v = (int16_t)(((int16_t)hi << 8) | b1);
+    *out = (int32_t)v;
+    return 0;
+}
+
+// ---- Variable table -------------------------------------------------------
+//
+// Layout (matches Apple's source exactly so a comparison against the
+// disassembled DeCompressDefProc binary would line up):
+//   +0..1  next-slot index (byte offset within the table where the
+//          NEXT VarsList[] entry will be written; starts at 4)
+//   +2..3  VarsList[0] = initial sentinel = table size (so the first
+//          remembered string's offset is computed as table_size - len)
+//   +4..   VarsList[1..], one u16 per remembered string (the offset
+//          where that string's data starts inside the table)
+// Remembered string data grows backwards from the table's end.
+
+typedef struct {
+    uint8_t *buf;
+    size_t size;
+} vt_t;
+
+static void vt_init(vt_t *vt, uint8_t *buf, size_t size) {
+    vt->buf = buf;
+    vt->size = size;
+    memset(buf, 0, size);
+    if (size >= 4) {
+        // next-slot index = 4 (the "VarsList[1]" slot)
+        buf[0] = 0;
+        buf[1] = 4;
+        // VarsList[0] = size (sentinel)
+        buf[2] = (uint8_t)(size >> 8);
+        buf[3] = (uint8_t)size;
+    }
+}
+
+// RememberData — stuff `len` bytes pointed to by `data` into the var table
+// as a new variable.  The new entry is added to the index list (forward
+// growth) with its data copied to the END of the table (backward growth).
+// Returns 0 on success, -1 on table overflow.
+static int vt_remember(vt_t *vt, const uint8_t *data, size_t len) {
+    if (vt->size < 4)
+        return -1;
+    uint16_t next_idx = be_u16(vt->buf);
+    if (next_idx + 2 > vt->size)
+        return -1; // index list would collide with the data area
+    // Previous entry's offset = end of the new string.
+    uint16_t prev_off = be_u16(vt->buf + next_idx - 2);
+    if (len > prev_off)
+        return -1; // data area exhausted
+    uint16_t new_off = (uint16_t)(prev_off - len);
+    // Index list and data area must not overlap.
+    if (new_off < next_idx + 2)
+        return -1;
+    // Write the new offset into the index list.
+    vt->buf[next_idx] = (uint8_t)(new_off >> 8);
+    vt->buf[next_idx + 1] = (uint8_t)new_off;
+    // Bump next-slot.
+    uint16_t new_next = (uint16_t)(next_idx + 2);
+    vt->buf[0] = (uint8_t)(new_next >> 8);
+    vt->buf[1] = (uint8_t)new_next;
+    // Copy the data into place.
+    memcpy(vt->buf + new_off, data, len);
+    return 0;
+}
+
+// FetchData — look up entry `idx` (0-based) and return a pointer into the
+// var-table buffer + the length of that variable.  Returns -1 if the index
+// goes past `next-slot`, indicating a corrupt stream.
+static int vt_fetch(const vt_t *vt, uint32_t idx, const uint8_t **data, size_t *len) {
+    if (vt->size < 4)
+        return -1;
+    uint16_t next_idx = be_u16(vt->buf);
+    // VarsList[idx] is at byte offset 2 + idx*2; VarsList[idx+1] at +2*idx+4.
+    size_t a_off = (size_t)2 + (size_t)idx * 2;
+    size_t b_off = a_off + 2;
+    if (b_off + 2 > next_idx)
+        return -1;
+    uint16_t a = be_u16(vt->buf + a_off); // string end
+    uint16_t b = be_u16(vt->buf + b_off); // string start
+    if (b > a || a > vt->size)
+        return -1;
+    *data = vt->buf + b;
+    *len = (size_t)(a - b);
+    return 0;
+}
+
+// ---- Extension dispatch (opcode 0xFE) -------------------------------------
+//
+// HandleExtensions reads a second byte to pick the variant:
+//   0  JumpTableTrans   — expand a CODE-0-style jump table (seg, count, deltas)
+//   1  EntryVectorTrans — expand an A5-relative entry vector
+//   2  RunLengthByte    — value + count, emit `count+1` bytes of value
+//   3  RunLengthWord    — value + count, emit `count+1` words of value
+//   4  DiffWordTrans    — value + count, emit words with byte-sized deltas
+//   5  DiffEncWordTrans — value + count, emit words with encoded deltas
+//   6  DiffEncLongTrans — value + count, emit longs with encoded deltas
+//
+// All seven sub-opcodes use the same encoded-integer reader, so each is
+// just a small inner loop.
+
+static int do_jt_trans(ic_t *ic, oc_t *oc) {
+    int32_t seg, count, delta;
+    if (get_encoded(ic, &seg) < 0)
+        return -1;
+    if (get_encoded(ic, &count) < 0)
+        return -1;
+    // The assembly initialises `offset` to 6 (bias absorbed by SubQ #6
+    // before adding each delta), and emits `count` standard JT entries
+    // followed by one trailing partial entry (the "_LoadSeg only" form).
+    int32_t offset = 6;
+    for (int32_t i = 0; i < count; i++) {
+        if (get_encoded(ic, &delta) < 0)
+            return -1;
+        offset += (delta - 6);
+        // 8-byte JT entry: 3F3C <seg> A9F0 <offset>
+        if (oc_put_u16_be(oc, 0x3F3C) < 0 || oc_put_u16_be(oc, (uint16_t)seg) < 0 || oc_put_u16_be(oc, 0xA9F0) < 0 ||
+            oc_put_u16_be(oc, (uint16_t)offset) < 0)
+            return -1;
+    }
+    // Trailing partial entry — 3F3C <seg> A9F0, no offset.  Inside
+    // Macintosh notes this is how CODE 0 marks the table's tail.
+    if (oc_put_u16_be(oc, 0x3F3C) < 0 || oc_put_u16_be(oc, (uint16_t)seg) < 0 || oc_put_u16_be(oc, 0xA9F0) < 0)
+        return -1;
+    return 0;
+}
+
+static int do_entry_vector(ic_t *ic, oc_t *oc) {
+    int32_t branch, delta_const, count, off;
+    if (get_encoded(ic, &branch) < 0)
+        return -1;
+    if (get_encoded(ic, &delta_const) < 0)
+        return -1;
+    if (get_encoded(ic, &count) < 0)
+        return -1;
+    if (get_encoded(ic, &off) < 0)
+        return -1;
+    // 8-byte entry: 6100 <branch> 4EED <off>; for each subsequent entry,
+    // branch decreases by 8 and off either gets the constant delta added
+    // or comes from the next encoded value.
+    int32_t cur_branch = branch;
+    int32_t cur_off = off;
+    for (int32_t i = 0; i <= count; i++) {
+        if (oc_put_u16_be(oc, 0x6100) < 0 || oc_put_u16_be(oc, (uint16_t)cur_branch) < 0 ||
+            oc_put_u16_be(oc, 0x4EED) < 0 || oc_put_u16_be(oc, (uint16_t)cur_off) < 0)
+            return -1;
+        cur_branch -= 8;
+        if (i < count) {
+            if (delta_const != 0) {
+                cur_off += delta_const;
+            } else {
+                int32_t next;
+                if (get_encoded(ic, &next) < 0)
+                    return -1;
+                cur_off = next;
+            }
+        }
+    }
+    return 0;
+}
+
+static int do_runlen_byte(ic_t *ic, oc_t *oc) {
+    int32_t value, count;
+    if (get_encoded(ic, &value) < 0)
+        return -1;
+    if (get_encoded(ic, &count) < 0)
+        return -1;
+    for (int32_t i = 0; i <= count; i++)
+        if (oc_put_u8(oc, (uint8_t)value) < 0)
+            return -1;
+    return 0;
+}
+
+static int do_runlen_word(ic_t *ic, oc_t *oc) {
+    int32_t value, count;
+    if (get_encoded(ic, &value) < 0)
+        return -1;
+    if (get_encoded(ic, &count) < 0)
+        return -1;
+    for (int32_t i = 0; i <= count; i++)
+        if (oc_put_u16_be(oc, (uint16_t)value) < 0)
+            return -1;
+    return 0;
+}
+
+static int do_diff_word(ic_t *ic, oc_t *oc) {
+    int32_t value, count;
+    if (get_encoded(ic, &value) < 0)
+        return -1;
+    if (get_encoded(ic, &count) < 0)
+        return -1;
+    if (oc_put_u16_be(oc, (uint16_t)value) < 0)
+        return -1;
+    for (int32_t i = 0; i < count; i++) {
+        uint8_t db;
+        if (ic_get_u8(ic, &db) < 0)
+            return -1;
+        value += (int8_t)db; // sign-extend per `Ext.W` in the original
+        if (oc_put_u16_be(oc, (uint16_t)value) < 0)
+            return -1;
+    }
+    return 0;
+}
+
+static int do_diff_enc_word(ic_t *ic, oc_t *oc) {
+    int32_t value, count;
+    if (get_encoded(ic, &value) < 0)
+        return -1;
+    if (get_encoded(ic, &count) < 0)
+        return -1;
+    if (oc_put_u16_be(oc, (uint16_t)value) < 0)
+        return -1;
+    for (int32_t i = 0; i < count; i++) {
+        int32_t d;
+        if (get_encoded(ic, &d) < 0)
+            return -1;
+        value += d;
+        if (oc_put_u16_be(oc, (uint16_t)value) < 0)
+            return -1;
+    }
+    return 0;
+}
+
+static int do_diff_enc_long(ic_t *ic, oc_t *oc) {
+    int32_t value, count;
+    if (get_encoded(ic, &value) < 0)
+        return -1;
+    if (get_encoded(ic, &count) < 0)
+        return -1;
+    uint32_t v32 = (uint32_t)value;
+    if (oc_put_u8(oc, (uint8_t)(v32 >> 24)) < 0 || oc_put_u8(oc, (uint8_t)(v32 >> 16)) < 0 ||
+        oc_put_u8(oc, (uint8_t)(v32 >> 8)) < 0 || oc_put_u8(oc, (uint8_t)v32) < 0)
+        return -1;
+    for (int32_t i = 0; i < count; i++) {
+        int32_t d;
+        if (get_encoded(ic, &d) < 0)
+            return -1;
+        v32 += (uint32_t)d;
+        if (oc_put_u8(oc, (uint8_t)(v32 >> 24)) < 0 || oc_put_u8(oc, (uint8_t)(v32 >> 16)) < 0 ||
+            oc_put_u8(oc, (uint8_t)(v32 >> 8)) < 0 || oc_put_u8(oc, (uint8_t)v32) < 0)
+            return -1;
+    }
+    return 0;
+}
+
+static int do_extension(ic_t *ic, oc_t *oc) {
+    uint8_t ext;
+    if (ic_get_u8(ic, &ext) < 0)
+        return -1;
+    switch (ext) {
+    case 0:
+        return do_jt_trans(ic, oc);
+    case 1:
+        return do_entry_vector(ic, oc);
+    case 2:
+        return do_runlen_byte(ic, oc);
+    case 3:
+        return do_runlen_word(ic, oc);
+    case 4:
+        return do_diff_word(ic, oc);
+    case 5:
+        return do_diff_enc_word(ic, oc);
+    case 6:
+        return do_diff_enc_long(ic, oc);
+    default:
+        return -1;
+    }
+}
+
+// ---- Main dispatch loop ---------------------------------------------------
+//
+// Opcodes 0x01..0x0F (Literal2..30) and 0x11..0x1F (Remember2..30) each
+// carry their literal-byte count in the opcode: 2 * (opcode & 0x0F).
+// The assembly hard-codes 15 entries each via MoveQ; we collapse those
+// into the arithmetic since the table is otherwise identical.
+
+#define MAX_1BYTE_REUSE 40
+
+static int unpack_loop(ic_t *ic, oc_t *oc, vt_t *vt) {
+    while (1) {
+        uint8_t op;
+        if (ic_get_u8(ic, &op) < 0)
+            return -1;
+        if (op == 0xFF)
+            return 0; // ExitUnpack — clean end of stream
+
+        if (op == 0x00 || op == 0x10) {
+            // {Lit,Remember}WithLength: encoded N → 2N literal bytes
+            int32_t n_words;
+            if (get_encoded(ic, &n_words) < 0)
+                return -1;
+            if (n_words < 0 || (uint32_t)n_words > 0x100000)
+                return -1;
+            size_t nbytes = (size_t)n_words * 2;
+            const uint8_t *src;
+            if (ic_get_n(ic, nbytes, &src) < 0)
+                return -1;
+            if (op == 0x10) {
+                if (vt_remember(vt, src, nbytes) < 0)
+                    return -1;
+            }
+            if (oc_put_n(oc, src, nbytes) < 0)
+                return -1;
+            continue;
+        }
+
+        if (op <= 0x0F) {
+            // Literal2..Literal30: copy (op*2) literal bytes
+            size_t nbytes = (size_t)op * 2;
+            const uint8_t *src;
+            if (ic_get_n(ic, nbytes, &src) < 0)
+                return -1;
+            if (oc_put_n(oc, src, nbytes) < 0)
+                return -1;
+            continue;
+        }
+
+        if (op <= 0x1F) {
+            // Remember2..Remember30: copy + store
+            size_t nbytes = (size_t)(op - 0x10) * 2;
+            const uint8_t *src;
+            if (ic_get_n(ic, nbytes, &src) < 0)
+                return -1;
+            if (vt_remember(vt, src, nbytes) < 0)
+                return -1;
+            if (oc_put_n(oc, src, nbytes) < 0)
+                return -1;
+            continue;
+        }
+
+        if (op == 0x20) {
+            // ReuseByteLength: 1 byte index + 40
+            uint8_t b;
+            if (ic_get_u8(ic, &b) < 0)
+                return -1;
+            uint32_t idx = (uint32_t)b + MAX_1BYTE_REUSE;
+            const uint8_t *d;
+            size_t n;
+            if (vt_fetch(vt, idx, &d, &n) < 0)
+                return -1;
+            if (oc_put_n(oc, d, n) < 0)
+                return -1;
+            continue;
+        }
+        if (op == 0x21) {
+            // ReuseByte2Length: 1 byte index + 40 + 256
+            uint8_t b;
+            if (ic_get_u8(ic, &b) < 0)
+                return -1;
+            uint32_t idx = (uint32_t)b + MAX_1BYTE_REUSE + 256;
+            const uint8_t *d;
+            size_t n;
+            if (vt_fetch(vt, idx, &d, &n) < 0)
+                return -1;
+            if (oc_put_n(oc, d, n) < 0)
+                return -1;
+            continue;
+        }
+        if (op == 0x22) {
+            // ReuseWordLength: 2-byte BE index + 40
+            uint8_t hi, lo;
+            if (ic_get_u8(ic, &hi) < 0)
+                return -1;
+            if (ic_get_u8(ic, &lo) < 0)
+                return -1;
+            uint32_t idx = (((uint32_t)hi << 8) | lo) + MAX_1BYTE_REUSE;
+            const uint8_t *d;
+            size_t n;
+            if (vt_fetch(vt, idx, &d, &n) < 0)
+                return -1;
+            if (oc_put_n(oc, d, n) < 0)
+                return -1;
+            continue;
+        }
+
+        if (op <= 0x4A) {
+            // ReuseData0..39: direct index = opcode - 0x23
+            uint32_t idx = (uint32_t)(op - 0x23);
+            const uint8_t *d;
+            size_t n;
+            if (vt_fetch(vt, idx, &d, &n) < 0)
+                return -1;
+            if (oc_put_n(oc, d, n) < 0)
+                return -1;
+            continue;
+        }
+
+        if (op <= 0xFD) {
+            // Constant-word emit: output one fixed 16-bit word
+            uint16_t w = g_const_words[op - 0x4B];
+            if (oc_put_u16_be(oc, w) < 0)
+                return -1;
+            continue;
+        }
+
+        if (op == 0xFE) {
+            if (do_extension(ic, oc) < 0)
+                return -1;
+            continue;
+        }
+        // Unreachable — opcode 0xFF handled above.
+        return -1;
+    }
+}
+
+// ---- Public entry point ---------------------------------------------------
+
+uint8_t *rsrc_dcmp_decompress(const uint8_t *compressed, size_t compressed_len, size_t *out_len, const char **errmsg) {
+#define FAIL(msg)                                                                                                      \
+    do {                                                                                                               \
+        if (errmsg)                                                                                                    \
+            *errmsg = (msg);                                                                                           \
+        free(uncompressed);                                                                                            \
+        free(vtbuf);                                                                                                   \
+        return NULL;                                                                                                   \
+    } while (0)
+    if (out_len)
+        *out_len = 0;
+    if (errmsg)
+        *errmsg = NULL;
+    uint8_t *uncompressed = NULL;
+    uint8_t *vtbuf = NULL;
+
+    if (!compressed || compressed_len < 18)
+        FAIL("truncated header");
+    if (be_u32(compressed) != RSRC_DCMP_MAGIC)
+        FAIL("not compressed");
+
+    uint16_t hdr_len = be_u16(compressed + 4);
+    uint8_t hdr_ver = compressed[6];
+    uint32_t actual_size = be_u32(compressed + 8);
+    uint8_t var_ratio = compressed[12];
+    uint8_t overrun = compressed[13];
+    int16_t dcmp_id = (int16_t)be_u16(compressed + 14);
+
+    if (hdr_len < 18 || hdr_len > compressed_len)
+        FAIL("truncated header");
+    if (hdr_ver != 8)
+        FAIL("unsupported version"); // GreggyBits (header version 9) routes here too
+    if (dcmp_id != 0)
+        FAIL("unsupported dcmp");
+
+    // Output buffer: actual_size + overrun (the assembly explicitly
+    // permits the decompressor to overshoot by `overrun` bytes during
+    // operation; we honour that for byte-identical behaviour).
+    size_t out_cap = (size_t)actual_size + (size_t)overrun;
+    uncompressed = malloc(out_cap > 0 ? out_cap : 1);
+    if (!uncompressed)
+        FAIL("out of memory");
+
+    // Var table: actual_size * var_ratio / 256, rounded up to even.
+    // The original code allocates "VarTableSize" bytes; the ratio comes
+    // straight from the header.  Apple's compressor sets this so the
+    // table is large enough to hold every Remember* literal plus the
+    // index list.
+    size_t vt_size = ((size_t)actual_size * (size_t)var_ratio) / 256;
+    if (vt_size < 4)
+        vt_size = 4; // minimum to hold NextVarIndex + VarsList[0]
+    if (vt_size & 1)
+        vt_size++;
+    vtbuf = malloc(vt_size);
+    if (!vtbuf)
+        FAIL("out of memory");
+
+    vt_t vt;
+    vt_init(&vt, vtbuf, vt_size);
+    ic_t ic = {compressed + hdr_len, compressed_len - hdr_len, 0};
+    oc_t oc = {uncompressed, out_cap, 0};
+
+    if (unpack_loop(&ic, &oc, &vt) < 0)
+        FAIL("corrupt stream");
+
+    // The assembly's compressor pads the output to `actual_size`, so
+    // any difference indicates either truncated input or a parser bug.
+    // Truncate to actual_size for the caller — overrun is a working-
+    // buffer concession, not part of the resource's contract.
+    free(vtbuf);
+    vtbuf = NULL;
+
+    if (oc.off < actual_size) {
+        // Pad with zeros — the assembly leaves the trailing buffer as
+        // whatever was already there, but defined zero is friendlier
+        // for callers.
+        memset(uncompressed + oc.off, 0, actual_size - oc.off);
+    }
+    if (out_len)
+        *out_len = actual_size;
+    return uncompressed;
+#undef FAIL
+}

--- a/src/core/storage/rsrc_dcmp.c
+++ b/src/core/storage/rsrc_dcmp.c
@@ -10,17 +10,28 @@
 // © 1990-1991 Apple Computer (Donn Denman), released as part of the
 // System 7 source drop.
 //
-// On-disk layout of a compressed resource (header version 8):
-//   +0   signature (u32 BE) = 0xA89F6572
-//   +4   header_length (u16 BE) = 0x12 (18 bytes)
-//   +6   header_version (u8) = 8
-//   +7   extended_attrs (u8) — compression sub-flags (unused here)
-//   +8   actual_size (u32 BE) — uncompressed byte count
-//   +12  var_table_ratio (u8) — 256ths-of-actual_size sized for var table
-//   +13  overrun (u8) — extra bytes the decompressor may write
-//   +14  dcmp_id (i16 BE) — 0 = DonnBits, 2 = GreggyBits, ...
-//   +16  ctable_id (i16 BE) — auxiliary table (unused for dcmp 0)
-//   +18  compressed payload starts here
+// On-disk layout of a compressed resource:
+//
+//   Common header (bytes 0..11, both versions):
+//     +0   signature (u32 BE) = 0xA89F6572
+//     +4   header_length (u16 BE) = 0x12 (18 bytes)
+//     +6   header_version (u8) = 8 (DonnBits) or 9 (GreggyBits)
+//     +7   extended_attrs (u8)
+//     +8   actual_size (u32 BE) — uncompressed byte count
+//
+//   Version-8 extension (bytes 12..17 — DonnBits format):
+//     +12  var_table_ratio (u8) — 256ths-of-actual_size sized for var table
+//     +13  overrun (u8) — extra bytes the decompressor may write
+//     +14  dcmp_id (i16 BE) — 0 = DonnBits
+//     +16  ctable_id (i16 BE) — auxiliary table
+//
+//   Version-9 extension (bytes 12..17 — GreggyBits and later formats):
+//     +12  dcmp_id (i16 BE) — 2 = GreggyBits, others = custom
+//     +14  decompress_slop (i16 BE)
+//     +16  byte_table_size (u8) — number-of-words minus 1
+//     +17  compress_flags (u8) — bit 0 = byteTableSaved, bit 1 = bitmappedData
+//
+//   +18  compressed payload starts here (both versions)
 //
 // The payload is a stream of single-byte opcodes; each opcode either
 // emits 16-bit words into the output buffer, slurps additional bytes
@@ -587,6 +598,207 @@ static int unpack_loop(ic_t *ic, oc_t *oc, vt_t *vt) {
     }
 }
 
+// ===========================================================================
+// dcmp 2 — GreggyBits (Greg Marriott, 1990-1991)
+// ===========================================================================
+//
+// Ported from gs-archive/sys71src-main/Patches/GreggyBitsDefProc.a.
+// The algorithm:
+//   1. Each output word is either looked up via a byte->word translation
+//      table, or copied verbatim (two raw input bytes -> one output word).
+//   2. The table is either the 256-entry static_table baked in below
+//      (when compressFlags bit 0 is clear), or read from the start of
+//      the payload as `byte_table_size + 1` 16-bit words (bit 0 set).
+//   3. Two encoding modes:
+//      - Non-bitmapped (bit 1 clear): every input byte is an index into
+//        the table; payload length == output word count.  If actual_size
+//        is odd, the very last byte of the payload becomes the final
+//        odd output byte verbatim.
+//      - Bitmapped (bit 1 set): payload is a sequence of "8-word runs".
+//        Each run starts with one bitmap byte; bits 7..0 of that bitmap
+//        choose, for each of the next 8 output words: bit set = 1 input
+//        byte indexed into the table; bit clear = 2 input bytes copied
+//        verbatim.  The final run may be shorter than 8 words (size mod
+//        8); odd `actual_size` adds a final literal byte as above.
+
+// The 256-entry static byte->word table, lifted verbatim from
+// GreggyBitsDefProc.a (StaticTable + DC.W rows).  Each byte index
+// produces one 16-bit big-endian output word; the table holds the most
+// common 16-bit values observed by Greg's analysis (small constants,
+// frequent 68k opcodes, common A-line traps).
+static const uint16_t g_greggy_static[256] = {
+    0x0000, 0x0008, 0x4EBA, 0x206E, 0x4E75, 0x000C, 0x0004, 0x7000, // 0x00..0x07
+    0x0010, 0x0002, 0x486E, 0xFFFC, 0x6000, 0x0001, 0x48E7, 0x2F2E, // 0x08..0x0F
+    0x4E56, 0x0006, 0x4E5E, 0x2F00, 0x6100, 0xFFF8, 0x2F0B, 0xFFFF, // 0x10..0x17
+    0x0014, 0x000A, 0x0018, 0x205F, 0x000E, 0x2050, 0x3F3C, 0xFFF4, // 0x18..0x1F
+    0x4CEE, 0x302E, 0x6700, 0x4CDF, 0x266E, 0x0012, 0x001C, 0x4267, // 0x20..0x27
+    0xFFF0, 0x303C, 0x2F0C, 0x0003, 0x4ED0, 0x0020, 0x7001, 0x0016, // 0x28..0x2F
+    0x2D40, 0x48C0, 0x2078, 0x7200, 0x588F, 0x6600, 0x4FEF, 0x42A7, // 0x30..0x37
+    0x6706, 0xFFFA, 0x558F, 0x286E, 0x3F00, 0xFFFE, 0x2F3C, 0x6704, // 0x38..0x3F
+    0x598F, 0x206B, 0x0024, 0x201F, 0x41FA, 0x81E1, 0x6604, 0x6708, // 0x40..0x47
+    0x001A, 0x4EB9, 0x508F, 0x202E, 0x0007, 0x4EB0, 0xFFF2, 0x3D40, // 0x48..0x4F
+    0x001E, 0x2068, 0x6606, 0xFFF6, 0x4EF9, 0x0800, 0x0C40, 0x3D7C, // 0x50..0x57
+    0xFFEC, 0x0005, 0x203C, 0xFFE8, 0xDEFC, 0x4A2E, 0x0030, 0x0028, // 0x58..0x5F
+    0x2F08, 0x200B, 0x6002, 0x426E, 0x2D48, 0x2053, 0x2040, 0x1800, // 0x60..0x67
+    0x6004, 0x41EE, 0x2F28, 0x2F01, 0x670A, 0x4840, 0x2007, 0x6608, // 0x68..0x6F
+    0x0118, 0x2F07, 0x3028, 0x3F2E, 0x302B, 0x226E, 0x2F2B, 0x002C, // 0x70..0x77
+    0x670C, 0x225F, 0x6006, 0x00FF, 0x3007, 0xFFEE, 0x5340, 0x0040, // 0x78..0x7F
+    0xFFE4, 0x4A40, 0x660A, 0x000F, 0x4EAD, 0x70FF, 0x22D8, 0x486B, // 0x80..0x87
+    0x0022, 0x204B, 0x670E, 0x4AAE, 0x4E90, 0xFFE0, 0xFFC0, 0x002A, // 0x88..0x8F
+    0x2740, 0x6702, 0x51C8, 0x02B6, 0x487A, 0x2278, 0xB06E, 0xFFE6, // 0x90..0x97
+    0x0009, 0x322E, 0x3E00, 0x4841, 0xFFEA, 0x43EE, 0x4E71, 0x7400, // 0x98..0x9F
+    0x2F2C, 0x206C, 0x003C, 0x0026, 0x0050, 0x1880, 0x301F, 0x2200, // 0xA0..0xA7
+    0x660C, 0xFFDA, 0x0038, 0x6602, 0x302C, 0x200C, 0x2D6E, 0x4240, // 0xA8..0xAF
+    0xFFE2, 0xA9F0, 0xFF00, 0x377C, 0xE580, 0xFFDC, 0x4868, 0x594F, // 0xB0..0xB7
+    0x0034, 0x3E1F, 0x6008, 0x2F06, 0xFFDE, 0x600A, 0x7002, 0x0032, // 0xB8..0xBF
+    0xFFCC, 0x0080, 0x2251, 0x101F, 0x317C, 0xA029, 0xFFD8, 0x5240, // 0xC0..0xC7
+    0x0100, 0x6710, 0xA023, 0xFFCE, 0xFFD4, 0x2006, 0x4878, 0x002E, // 0xC8..0xCF
+    0x504F, 0x43FA, 0x6712, 0x7600, 0x41E8, 0x4A6E, 0x20D9, 0x005A, // 0xD0..0xD7
+    0x7FFF, 0x51CA, 0x005C, 0x2E00, 0x0240, 0x48C7, 0x6714, 0x0C80, // 0xD8..0xDF
+    0x2E9F, 0xFFD6, 0x8000, 0x1000, 0x4842, 0x4A6B, 0xFFD2, 0x0048, // 0xE0..0xE7
+    0x4A47, 0x4ED1, 0x206F, 0x0041, 0x600C, 0x2A78, 0x422E, 0x3200, // 0xE8..0xEF
+    0x6574, 0x6716, 0x0044, 0x486D, 0x2008, 0x486C, 0x0B7C, 0x2640, // 0xF0..0xF7
+    0x0400, 0x0068, 0x206D, 0x000D, 0x2A40, 0x000B, 0x003E, 0x0220, // 0xF8..0xFF
+};
+
+#define GREGGY_BYTE_TABLE_SAVED 0x01u // payload begins with a dynamic table
+#define GREGGY_BITMAPPED_DATA   0x02u // mixed compressed/uncompressed runs
+
+// Run the GreggyBits (dcmp 2) decompression.  `payload`/`payload_len`
+// are the bytes *after* the 18-byte common header.  `actual_size` is
+// the target output byte count; `byte_table_size_field` is the raw
+// `byte_table_size` byte from the header (interpreted as +1 -> word
+// count when the dynamic-table flag is set); `compress_flags` is the
+// header's compressFlags byte.  Returns 0 on success and fills
+// `out_uncompressed` (caller-provided, capacity `actual_size`).
+static int dcmp2_decompress(const uint8_t *payload, size_t payload_len, uint8_t *out, size_t actual_size,
+                            uint8_t byte_table_size_field, uint8_t compress_flags) {
+    // Decide which table to read indices through.
+    const uint16_t *table = g_greggy_static;
+    uint16_t dyn_table[256];
+    ic_t ic = {payload, payload_len, 0};
+    if (compress_flags & GREGGY_BYTE_TABLE_SAVED) {
+        // Dynamic table: read (byte_table_size_field + 1) 16-bit words
+        // from the payload into dyn_table[0..N-1].  Entries past that
+        // stay at zero, matching the assembly's BlockMove of exactly
+        // the declared word count.
+        size_t nwords = (size_t)byte_table_size_field + 1;
+        if (nwords > 256)
+            nwords = 256;
+        memset(dyn_table, 0, sizeof(dyn_table));
+        for (size_t i = 0; i < nwords; i++) {
+            uint8_t hi, lo;
+            if (ic_get_u8(&ic, &hi) < 0)
+                return -1;
+            if (ic_get_u8(&ic, &lo) < 0)
+                return -1;
+            dyn_table[i] = (uint16_t)((hi << 8) | lo);
+        }
+        table = dyn_table;
+    }
+
+    // Output cursor.
+    oc_t oc = {out, actual_size, 0};
+    size_t total_words = actual_size / 2;
+    bool odd_extra = (actual_size & 1) != 0;
+
+    if (!(compress_flags & GREGGY_BITMAPPED_DATA)) {
+        // Non-bitmapped: every input byte is a table index.
+        for (size_t w = 0; w < total_words; w++) {
+            uint8_t idx;
+            if (ic_get_u8(&ic, &idx) < 0)
+                return -1;
+            if (oc_put_u16_be(&oc, table[idx]) < 0)
+                return -1;
+        }
+        if (odd_extra) {
+            uint8_t b;
+            if (ic_get_u8(&ic, &b) < 0)
+                return -1;
+            if (oc_put_u8(&oc, b) < 0)
+                return -1;
+        }
+        return 0;
+    }
+
+    // Bitmapped: process 8-word runs.  Each run begins with one bitmap
+    // byte (high bit = first word).  Set bit => 1 input byte indexed into
+    // the table; clear bit => 2 raw input bytes copied verbatim.
+    size_t full_runs = total_words / 8;
+    size_t last_run_words = total_words % 8;
+    for (size_t r = 0; r < full_runs; r++) {
+        uint8_t bitmap;
+        if (ic_get_u8(&ic, &bitmap) < 0)
+            return -1;
+        if (bitmap == 0) {
+            // Fast path: all 8 words are raw 2-byte literals.
+            for (int i = 0; i < 16; i++) {
+                uint8_t b;
+                if (ic_get_u8(&ic, &b) < 0)
+                    return -1;
+                if (oc_put_u8(&oc, b) < 0)
+                    return -1;
+            }
+            continue;
+        }
+        for (int i = 0; i < 8; i++) {
+            bool compressed = (bitmap & 0x80) != 0;
+            bitmap = (uint8_t)(bitmap << 1);
+            if (compressed) {
+                uint8_t idx;
+                if (ic_get_u8(&ic, &idx) < 0)
+                    return -1;
+                if (oc_put_u16_be(&oc, table[idx]) < 0)
+                    return -1;
+            } else {
+                uint8_t b0, b1;
+                if (ic_get_u8(&ic, &b0) < 0)
+                    return -1;
+                if (ic_get_u8(&ic, &b1) < 0)
+                    return -1;
+                if (oc_put_u8(&oc, b0) < 0)
+                    return -1;
+                if (oc_put_u8(&oc, b1) < 0)
+                    return -1;
+            }
+        }
+    }
+    if (last_run_words > 0) {
+        uint8_t bitmap;
+        if (ic_get_u8(&ic, &bitmap) < 0)
+            return -1;
+        for (size_t i = 0; i < last_run_words; i++) {
+            bool compressed = (bitmap & 0x80) != 0;
+            bitmap = (uint8_t)(bitmap << 1);
+            if (compressed) {
+                uint8_t idx;
+                if (ic_get_u8(&ic, &idx) < 0)
+                    return -1;
+                if (oc_put_u16_be(&oc, table[idx]) < 0)
+                    return -1;
+            } else {
+                uint8_t b0, b1;
+                if (ic_get_u8(&ic, &b0) < 0)
+                    return -1;
+                if (ic_get_u8(&ic, &b1) < 0)
+                    return -1;
+                if (oc_put_u8(&oc, b0) < 0)
+                    return -1;
+                if (oc_put_u8(&oc, b1) < 0)
+                    return -1;
+            }
+        }
+    }
+    if (odd_extra) {
+        uint8_t b;
+        if (ic_get_u8(&ic, &b) < 0)
+            return -1;
+        if (oc_put_u8(&oc, b) < 0)
+            return -1;
+    }
+    return 0;
+}
+
 // ---- Public entry point ---------------------------------------------------
 
 uint8_t *rsrc_dcmp_decompress(const uint8_t *compressed, size_t compressed_len, size_t *out_len, const char **errmsg) {
@@ -613,62 +825,88 @@ uint8_t *rsrc_dcmp_decompress(const uint8_t *compressed, size_t compressed_len, 
     uint16_t hdr_len = be_u16(compressed + 4);
     uint8_t hdr_ver = compressed[6];
     uint32_t actual_size = be_u32(compressed + 8);
-    uint8_t var_ratio = compressed[12];
-    uint8_t overrun = compressed[13];
-    int16_t dcmp_id = (int16_t)be_u16(compressed + 14);
 
     if (hdr_len < 18 || hdr_len > compressed_len)
         FAIL("truncated header");
-    if (hdr_ver != 8)
-        FAIL("unsupported version"); // GreggyBits (header version 9) routes here too
-    if (dcmp_id != 0)
-        FAIL("unsupported dcmp");
 
-    // Output buffer: actual_size + overrun (the assembly explicitly
-    // permits the decompressor to overshoot by `overrun` bytes during
-    // operation; we honour that for byte-identical behaviour).
-    size_t out_cap = (size_t)actual_size + (size_t)overrun;
-    uncompressed = malloc(out_cap > 0 ? out_cap : 1);
-    if (!uncompressed)
-        FAIL("out of memory");
-
-    // Var table: actual_size * var_ratio / 256, rounded up to even.
-    // The original code allocates "VarTableSize" bytes; the ratio comes
-    // straight from the header.  Apple's compressor sets this so the
-    // table is large enough to hold every Remember* literal plus the
-    // index list.
-    size_t vt_size = ((size_t)actual_size * (size_t)var_ratio) / 256;
-    if (vt_size < 4)
-        vt_size = 4; // minimum to hold NextVarIndex + VarsList[0]
-    if (vt_size & 1)
-        vt_size++;
-    vtbuf = malloc(vt_size);
-    if (!vtbuf)
-        FAIL("out of memory");
-
-    vt_t vt;
-    vt_init(&vt, vtbuf, vt_size);
-    ic_t ic = {compressed + hdr_len, compressed_len - hdr_len, 0};
-    oc_t oc = {uncompressed, out_cap, 0};
-
-    if (unpack_loop(&ic, &oc, &vt) < 0)
-        FAIL("corrupt stream");
-
-    // The assembly's compressor pads the output to `actual_size`, so
-    // any difference indicates either truncated input or a parser bug.
-    // Truncate to actual_size for the caller — overrun is a working-
-    // buffer concession, not part of the resource's contract.
-    free(vtbuf);
-    vtbuf = NULL;
-
-    if (oc.off < actual_size) {
-        // Pad with zeros — the assembly leaves the trailing buffer as
-        // whatever was already there, but defined zero is friendlier
-        // for callers.
-        memset(uncompressed + oc.off, 0, actual_size - oc.off);
+    // v8 puts dcmp_id at +14; v9 puts it at +12 (overlaying v8's
+    // var_table_ratio + overrun fields — see the header docs at the
+    // top of this file).
+    int16_t dcmp_id;
+    if (hdr_ver == 8) {
+        dcmp_id = (int16_t)be_u16(compressed + 14);
+    } else if (hdr_ver == 9) {
+        dcmp_id = (int16_t)be_u16(compressed + 12);
+    } else {
+        FAIL("unsupported version");
     }
-    if (out_len)
-        *out_len = actual_size;
-    return uncompressed;
+
+    // ---- dcmp 0 — DonnBits (v8) ------------------------------------------
+    if (dcmp_id == 0 && hdr_ver == 8) {
+        uint8_t var_ratio = compressed[12];
+        uint8_t overrun = compressed[13];
+
+        // Output buffer: actual_size + overrun (the assembly explicitly
+        // permits the decompressor to overshoot by `overrun` bytes during
+        // operation; we honour that for byte-identical behaviour).
+        size_t out_cap = (size_t)actual_size + (size_t)overrun;
+        uncompressed = malloc(out_cap > 0 ? out_cap : 1);
+        if (!uncompressed)
+            FAIL("out of memory");
+
+        // Var table: actual_size * var_ratio / 256, rounded up to even.
+        // The original code allocates "VarTableSize" bytes; the ratio comes
+        // straight from the header.  Apple's compressor sets this so the
+        // table is large enough to hold every Remember* literal plus the
+        // index list.
+        size_t vt_size = ((size_t)actual_size * (size_t)var_ratio) / 256;
+        if (vt_size < 4)
+            vt_size = 4;
+        if (vt_size & 1)
+            vt_size++;
+        vtbuf = malloc(vt_size);
+        if (!vtbuf)
+            FAIL("out of memory");
+
+        vt_t vt;
+        vt_init(&vt, vtbuf, vt_size);
+        ic_t ic = {compressed + hdr_len, compressed_len - hdr_len, 0};
+        oc_t oc = {uncompressed, out_cap, 0};
+
+        if (unpack_loop(&ic, &oc, &vt) < 0)
+            FAIL("corrupt stream");
+
+        free(vtbuf);
+        vtbuf = NULL;
+        if (oc.off < actual_size)
+            memset(uncompressed + oc.off, 0, actual_size - oc.off);
+        if (out_len)
+            *out_len = actual_size;
+        return uncompressed;
+    }
+
+    // ---- dcmp 2 — GreggyBits (v9) ----------------------------------------
+    if (dcmp_id == 2 && hdr_ver == 9) {
+        uint8_t byte_table_size = compressed[16];
+        uint8_t compress_flags = compressed[17];
+        uncompressed = calloc(actual_size > 0 ? actual_size : 1, 1);
+        if (!uncompressed)
+            FAIL("out of memory");
+        if (dcmp2_decompress(compressed + hdr_len, compressed_len - hdr_len, uncompressed, actual_size, byte_table_size,
+                             compress_flags) < 0)
+            FAIL("corrupt stream");
+        if (out_len)
+            *out_len = actual_size;
+        return uncompressed;
+    }
+
+    // Any other (dcmp_id, version) combo is currently unsupported.  This
+    // includes dcmp 0 in a v9 wrapper (custom Donn variant) and the various
+    // third-party dcmp ids (1, 3, 7, 8, 0x10+) that ship in System file
+    // extensions.  The caller falls through to raw compressed bytes —
+    // .info still surfaces the compressed flag, and re.dump's disasm pass
+    // shows compressed-payload garbage in the .s file (with a header
+    // comment) but does not crash.
+    FAIL("unsupported dcmp");
 #undef FAIL
 }

--- a/src/core/storage/rsrc_dcmp.h
+++ b/src/core/storage/rsrc_dcmp.h
@@ -5,18 +5,24 @@
 // Decompression for Apple System 7 compressed resources (the format
 // signalled by the 0xA89F6572 signature in the resource bytes).
 //
-// Supports the two stock Apple decompressors that ship with System 7:
-//   - dcmp 0 — "DonnBits" (Donn Denman), the default decompressor
-// (GreggyBits / dcmp 2 is not yet implemented; surfaces as an error
-// so callers can fall through to the raw bytes rather than feed
-// garbage into a disassembler.)
+// Supports the two stock Apple decompressors that ship with System 7
+// (and the two header layouts they pair with):
+//   - header version 8 + dcmp 0 — DonnBits (Donn Denman, 1990-1991)
+//   - header version 9 + dcmp 2 — GreggyBits (Greg Marriott, 1990-1991)
 //
-// Algorithm and tables are ported from Apple's open-sourced assembly
-// in `Patches/DeCompressDefProc.a` + `Patches/DeCompressCommon.A` (©
-// 1990-1991 Apple, released as part of the Mac OS / System 7 source
-// drops).  Op-code dispatch, encoded-value layout, var-table mechanics,
-// and the 179-entry constant-word emit table are reproduced verbatim;
-// the assembly's `Bsr` / `Bra` flow is rewritten as a plain C switch.
+// Algorithms ported from Apple's open-sourced assembly in
+//   Patches/DeCompressDefProc.a + Patches/DeCompressCommon.A  (dcmp 0)
+//   Patches/GreggyBitsDefProc.a                                (dcmp 2)
+// (© 1990-1991 Apple, released as part of the Mac OS / System 7 source
+// drops).  Constant-word emit tables, opcode dispatch, var-table
+// mechanics, and the 256-word GreggyBits static table are reproduced
+// verbatim; the assembly's `Bsr` / `Bra` flow is rewritten as a plain
+// C switch.
+//
+// Other dcmp ids (1, 3, 7, 8, custom dcmps shipped in extensions) are
+// not implemented and produce an "unsupported dcmp" error so callers
+// can fall through to the raw bytes rather than feed garbage to a
+// disassembler.
 
 #pragma once
 

--- a/src/core/storage/rsrc_dcmp.h
+++ b/src/core/storage/rsrc_dcmp.h
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) pappadf
+
+// rsrc_dcmp.h
+// Decompression for Apple System 7 compressed resources (the format
+// signalled by the 0xA89F6572 signature in the resource bytes).
+//
+// Supports the two stock Apple decompressors that ship with System 7:
+//   - dcmp 0 — "DonnBits" (Donn Denman), the default decompressor
+// (GreggyBits / dcmp 2 is not yet implemented; surfaces as an error
+// so callers can fall through to the raw bytes rather than feed
+// garbage into a disassembler.)
+//
+// Algorithm and tables are ported from Apple's open-sourced assembly
+// in `Patches/DeCompressDefProc.a` + `Patches/DeCompressCommon.A` (©
+// 1990-1991 Apple, released as part of the Mac OS / System 7 source
+// drops).  Op-code dispatch, encoded-value layout, var-table mechanics,
+// and the 179-entry constant-word emit table are reproduced verbatim;
+// the assembly's `Bsr` / `Bra` flow is rewritten as a plain C switch.
+
+#pragma once
+
+#ifndef GS_RSRC_DCMP_H
+#define GS_RSRC_DCMP_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// Magic value at offset 0 of every System-7-compressed resource.
+// `0xA89F` is the 68k `_Unimplemented` trap — chosen as the sentinel
+// because real code never starts with it.  The trailing `0x6572` is
+// the literal ASCII pair 'er' (probably "extended resource", not
+// formally documented anywhere).
+#define RSRC_DCMP_MAGIC 0xA89F6572u
+
+// Quick test: returns true iff `bytes` begins with the compressed-
+// resource signature.  Cheap (4-byte comparison); safe to call on
+// arbitrarily short buffers.
+bool rsrc_dcmp_is_compressed(const uint8_t *bytes, size_t len);
+
+// Decompress `compressed_len` bytes from `compressed` (must begin with
+// the dcmp magic).  On success returns a freshly malloc'd buffer of
+// exactly `*out_len` bytes (which equals the `actualSize` field from
+// the header).  On failure returns NULL and sets `*errmsg` to a static
+// string.  Caller free()s the returned buffer.
+//
+// Failure modes (errmsg values):
+//   - "not compressed"          — magic doesn't match
+//   - "truncated header"        — header_length goes past the buffer
+//   - "unsupported version"     — only header version 8 is implemented
+//   - "unsupported dcmp"        — dcmp_id != 0 (no GreggyBits yet)
+//   - "corrupt stream"          — opcode walk fell off the input
+//   - "out of memory"
+uint8_t *rsrc_dcmp_decompress(const uint8_t *compressed, size_t compressed_len, size_t *out_len, const char **errmsg);
+
+#endif // GS_RSRC_DCMP_H

--- a/src/core/vfs/image_vfs.c
+++ b/src/core/vfs/image_vfs.c
@@ -17,6 +17,7 @@
 #include "image_apm.h"
 #include "image_hfs.h"
 #include "image_ufs.h"
+#include "resource_fork.h"
 
 #include <errno.h>
 #include <limits.h>
@@ -60,6 +61,105 @@ struct image_mount {
 };
 
 static image_mount_t g_mounts[IMAGE_VFS_MAX_MOUNTS];
+
+// ---- Resource-fork LRU cache ---------------------------------------------
+// Parsed resource maps are held here so repeated reads through the
+// synthetic /rsrc/<TYPE>/<id> tree don't re-parse the fork each time.
+// Capacity is intentionally small — typical workflows touch one app at a
+// time, occasionally a handful, so eight slots cover the common cases
+// without holding entire fork buffers around forever.  The cache is
+// invalidated when the parent mount is destroyed; image_vfs is otherwise
+// read-only, so no other invalidation hooks are needed today.
+
+#define RSRC_CACHE_CAPACITY 8
+
+typedef struct rsrc_cache_entry {
+    const image_mount_t *mount; // identity (NULL = slot empty)
+    uint32_t hfs_cnid; // file CNID within the volume
+    uint8_t *fork_buf; // owned: the read fork bytes
+    size_t fork_len;
+    rfork_t *parsed; // owned: parsed map index
+    uint64_t lru_tick; // monotonic last-touch counter
+} rsrc_cache_entry_t;
+
+static rsrc_cache_entry_t g_rsrc_cache[RSRC_CACHE_CAPACITY];
+static uint64_t g_rsrc_lru_counter;
+
+// Drop one cache entry.  Safe on an empty slot.
+static void rsrc_cache_evict(rsrc_cache_entry_t *e) {
+    if (!e || !e->mount)
+        return;
+    rfork_free(e->parsed);
+    free(e->fork_buf);
+    memset(e, 0, sizeof(*e));
+}
+
+// Drop every entry associated with `m`.  Called from mount_destroy().
+static void rsrc_cache_drop_for_mount(const image_mount_t *m) {
+    for (size_t i = 0; i < RSRC_CACHE_CAPACITY; i++) {
+        if (g_rsrc_cache[i].mount == m)
+            rsrc_cache_evict(&g_rsrc_cache[i]);
+    }
+}
+
+// Find an existing cache entry for (mount, cnid).  Bumps the LRU tick on
+// hit.  Returns NULL on miss.
+static rsrc_cache_entry_t *rsrc_cache_find(const image_mount_t *m, uint32_t cnid) {
+    for (size_t i = 0; i < RSRC_CACHE_CAPACITY; i++) {
+        if (g_rsrc_cache[i].mount == m && g_rsrc_cache[i].hfs_cnid == cnid) {
+            g_rsrc_cache[i].lru_tick = ++g_rsrc_lru_counter;
+            return &g_rsrc_cache[i];
+        }
+    }
+    return NULL;
+}
+
+// Pick a slot to use for a new entry: prefer empty, otherwise evict the LRU.
+static rsrc_cache_entry_t *rsrc_cache_pick(void) {
+    rsrc_cache_entry_t *victim = &g_rsrc_cache[0];
+    for (size_t i = 0; i < RSRC_CACHE_CAPACITY; i++) {
+        if (!g_rsrc_cache[i].mount)
+            return &g_rsrc_cache[i];
+        if (g_rsrc_cache[i].lru_tick < victim->lru_tick)
+            victim = &g_rsrc_cache[i];
+    }
+    rsrc_cache_evict(victim);
+    return victim;
+}
+
+// Read+parse the resource fork for (mount, hfs, dirent.rsrc_fork) and
+// return the cache entry.  cnid is used as the cache key.  Returns NULL on
+// any failure (read error, OOM, corrupt fork).
+static rsrc_cache_entry_t *rsrc_cache_acquire(image_mount_t *m, hfs_volume_t *hfs, const hfs_dirent_t *d) {
+    if (!d || d->rsrc_fork.logical_size == 0)
+        return NULL;
+    rsrc_cache_entry_t *e = rsrc_cache_find(m, d->cnid);
+    if (e)
+        return e;
+    size_t flen = (size_t)d->rsrc_fork.logical_size;
+    uint8_t *buf = malloc(flen);
+    if (!buf)
+        return NULL;
+    size_t got = 0;
+    if (hfs_read_fork(hfs, &d->rsrc_fork, 0, buf, flen, &got) != 0 || got != flen) {
+        free(buf);
+        return NULL;
+    }
+    const char *errmsg = NULL;
+    rfork_t *rf = rfork_parse(buf, flen, &errmsg);
+    if (!rf) {
+        free(buf);
+        return NULL;
+    }
+    e = rsrc_cache_pick();
+    e->mount = m;
+    e->hfs_cnid = d->cnid;
+    e->fork_buf = buf;
+    e->fork_len = flen;
+    e->parsed = rf;
+    e->lru_tick = ++g_rsrc_lru_counter;
+    return e;
+}
 
 // ---- Helpers --------------------------------------------------------------
 
@@ -149,6 +249,7 @@ static void release_fs_state(image_mount_t *m) {
 
 // Tear down a mount without regard for refcount (callers must guard).
 static void mount_destroy(image_mount_t *m) {
+    rsrc_cache_drop_for_mount(m);
     release_fs_state(m);
     if (m->apm)
         image_apm_free(m->apm);
@@ -462,12 +563,117 @@ static int parse_image_path(const char *path, image_path_t *out) {
     return 0;
 }
 
+// ---- Synthetic resource-tree path classification --------------------------
+//
+// Classifies the *suffix* of an in-image HFS path.  Given the full split
+// component list, we look for the first occurrence of "rsrc" or "finf" and,
+// if found, treat the components after it as either a fork suffix or a
+// walk into the synthetic /rsrc/<TYPE>/<id>[.info] tree.  Callers retry
+// with a literal HFS interpretation when this lookup misses, mirroring
+// the pre-existing fork-suffix retry path.
+
+typedef enum {
+    SYNTH_NONE = 0, // No synthetic suffix; treat whole path literally.
+    SYNTH_FINF, // <file>/finf — 32-byte Finder info blob (existing).
+    SYNTH_RSRC_DIR, // <file>/rsrc — directory enumerating resource types.
+    SYNTH_RSRC_RAW, // <file>/rsrc/_raw — raw fork bytes (previously /rsrc).
+    SYNTH_RSRC_TYPE_DIR, // <file>/rsrc/<TYPE> — directory of IDs.
+    SYNTH_RSRC_DATA, // <file>/rsrc/<TYPE>/<id> — resource bytes.
+    SYNTH_RSRC_INFO, // <file>/rsrc/<TYPE>/<id>.info — JSON sidecar.
+} synth_kind_t;
+
+// Classify trailing components.  `n_components` is the full count; on
+// success `*file_core_count` is the number of leading components that
+// make up the HFS file path, `*type_out` (4 bytes) is the resource type
+// for type-scoped kinds, and `*id_out` is the resource ID for resource-
+// scoped kinds.  Returns SYNTH_NONE if the path looks literal.
+static synth_kind_t classify_synth(const char *const *components, size_t n_components, size_t *file_core_count,
+                                   uint8_t type_out[4], int16_t *id_out) {
+    if (file_core_count)
+        *file_core_count = n_components;
+    if (n_components == 0)
+        return SYNTH_NONE;
+
+    // Search left-to-right for "rsrc" or "finf"; the first hit anchors the
+    // synthetic split.  An HFS filename that literally equals "rsrc" or
+    // "finf" would match here too, but the caller retries with the full
+    // literal path on miss so the literal interpretation still wins when
+    // the synthetic one fails.
+    size_t anchor = n_components;
+    bool is_finf = false;
+    for (size_t i = 0; i < n_components; i++) {
+        const char *c = components[i];
+        if (strcmp(c, "rsrc") == 0) {
+            anchor = i;
+            is_finf = false;
+            break;
+        }
+        if (strcmp(c, "finf") == 0) {
+            anchor = i;
+            is_finf = true;
+            break;
+        }
+    }
+    if (anchor == n_components)
+        return SYNTH_NONE;
+    if (file_core_count)
+        *file_core_count = anchor;
+    size_t after = n_components - anchor - 1;
+
+    if (is_finf)
+        return (after == 0) ? SYNTH_FINF : SYNTH_NONE;
+
+    if (after == 0)
+        return SYNTH_RSRC_DIR;
+    if (after == 1) {
+        const char *next = components[anchor + 1];
+        if (strcmp(next, "_raw") == 0)
+            return SYNTH_RSRC_RAW;
+        if (type_out && rfork_type_from_path(next, type_out) == 0)
+            return SYNTH_RSRC_TYPE_DIR;
+        return SYNTH_NONE;
+    }
+    if (after == 2) {
+        const char *type_str = components[anchor + 1];
+        const char *id_str = components[anchor + 2];
+        if (!type_out || rfork_type_from_path(type_str, type_out) != 0)
+            return SYNTH_NONE;
+        size_t id_len = strlen(id_str);
+        const char *info_suffix = ".info";
+        const size_t info_suffix_len = 5;
+        if (id_len > info_suffix_len && strcmp(id_str + id_len - info_suffix_len, info_suffix) == 0) {
+            // Strip the ".info" suffix and parse the remainder as an ID.
+            char id_only[32];
+            if (id_len - info_suffix_len >= sizeof(id_only))
+                return SYNTH_NONE;
+            memcpy(id_only, id_str, id_len - info_suffix_len);
+            id_only[id_len - info_suffix_len] = '\0';
+            if (!id_out || rfork_id_from_path(id_only, id_out) != 0)
+                return SYNTH_NONE;
+            return SYNTH_RSRC_INFO;
+        }
+        if (!id_out || rfork_id_from_path(id_str, id_out) != 0)
+            return SYNTH_NONE;
+        return SYNTH_RSRC_DATA;
+    }
+    return SYNTH_NONE;
+}
+
 // ---- Backend method implementations --------------------------------------
 
-// Dir handle: either a partition-list enumerator (at image root) or an HFS
-// directory iterator.
+// Dir handle: partition-list enumerator at the image root, an HFS or UFS
+// directory iterator, or one of the two synthetic-resource directory kinds
+// (DIR_RSRC_ROOT for /rsrc, DIR_RSRC_TYPE for /rsrc/<TYPE>).  The resource
+// kinds borrow an rfork_t* from the LRU cache; the cache outlives the dir
+// handle because the parent mount holds a refcount while the dir is open.
 struct vfs_dir {
-    enum { DIR_PART_LIST, DIR_HFS, DIR_UFS } kind;
+    enum {
+        DIR_PART_LIST,
+        DIR_HFS,
+        DIR_UFS,
+        DIR_RSRC_ROOT,
+        DIR_RSRC_TYPE,
+    } kind;
     image_mount_t *mount;
     // partition list
     uint32_t next_partition;
@@ -475,20 +681,49 @@ struct vfs_dir {
     hfs_dir_iter_t *hfs_iter;
     // UFS directory
     ufs_dir_iter_t *ufs_iter;
+    // Synthetic resource tree (DIR_RSRC_ROOT / DIR_RSRC_TYPE)
+    const rfork_t *rfork; // borrowed (cache entry stays live via mount refcount)
+    uint8_t rsrc_type[4]; // DIR_RSRC_TYPE only
+    size_t rsrc_next_idx; // next type idx (root) or next resource idx (type)
+    // Two-emission state machines so a single readdir call can stream both
+    // the resource entry and the matching .info sidecar without losing
+    // its place.
+    bool rsrc_emit_info_next; // DIR_RSRC_TYPE: emit .info after the .bin
+    bool rsrc_emit_raw_next; // DIR_RSRC_ROOT: emit _raw entry at the end
+    // Cached "size" hint for the upcoming .info emission so we don't have
+    // to re-look-up the resource on the follow-up call.
+    int16_t rsrc_pending_id;
+    size_t rsrc_pending_info_size;
 };
 
 // HFS finder info is 16 bytes per fork + 16 bytes extended = 32 bytes total.
 #define HFS_FINDER_INFO_SIZE 32
 
-// File handle: data/resource fork, synthetic Finder-info blob, or UFS inode.
+// File handle: data/resource fork, synthetic Finder-info blob, UFS inode,
+// or one of the new synthetic-resource leaf kinds.  FILE_RSRC_DATA borrows
+// a slice of the cached fork buffer; FILE_RSRC_INFO precomputes the JSON
+// once and reads out of an inline buffer.
 struct vfs_file {
     image_mount_t *mount;
-    enum { FILE_HFS_FORK, FILE_FINDER_INFO, FILE_UFS } kind;
+    enum {
+        FILE_HFS_FORK,
+        FILE_FINDER_INFO,
+        FILE_UFS,
+        FILE_RSRC_DATA,
+        FILE_RSRC_INFO,
+    } kind;
     hfs_volume_t *hfs;
     hfs_fork_t fork; // used for FILE_HFS_FORK
     uint8_t finder_info[HFS_FINDER_INFO_SIZE];
     ufs_volume_t *ufs; // used for FILE_UFS
     uint32_t ufs_ino;
+    // FILE_RSRC_DATA: pointer into the cached fork buffer.
+    const uint8_t *rsrc_bytes;
+    size_t rsrc_size;
+    // FILE_RSRC_INFO: precomputed JSON.  512 bytes accommodates a maximally
+    // long resource name (255) plus the attrs list and brackets.
+    char rsrc_info_buf[512];
+    size_t rsrc_info_len;
 };
 
 // Forward declarations for backend functions.
@@ -544,19 +779,13 @@ static int img_stat(void *ctx, const char *path, vfs_stat_t *out) {
         return 0;
     }
 
-    // HFS lookup path: peel off optional fork suffix first. Guard the
-    // `components[core - 1]` read with `core >= 1` so a zero-component
-    // path doesn't index components[-1] (UB).
-    bool rsrc = false, finf = false;
-    size_t core = ip.n_components;
-    if (core >= 1) {
-        const char *last = ip.components[core - 1];
-        if (strcmp(last, "rsrc") == 0 || strcmp(last, "finf") == 0) {
-            rsrc = strcmp(last, "rsrc") == 0;
-            finf = strcmp(last, "finf") == 0;
-            core--;
-        }
-    }
+    // HFS lookup path: classify any synthetic suffix first.  classify_synth
+    // returns SYNTH_NONE for literal paths and lets the file_core_count
+    // tell us how many leading components belong to the HFS file.
+    uint8_t syn_type[4] = {0};
+    int16_t syn_id = 0;
+    size_t core = 0;
+    synth_kind_t synth = classify_synth(ip.components, ip.n_components, &core, syn_type, &syn_id);
 
     if (p->fs_kind != APM_FS_HFS)
         return -ENOTDIR;
@@ -565,41 +794,82 @@ static int img_stat(void *ctx, const char *path, vfs_stat_t *out) {
     if (!hfs)
         return -EIO;
     hfs_dirent_t d = {0};
-    if (core == 0) {
-        // Fork suffix on the partition root makes no sense.
-        if (rsrc || finf)
-            return -ENOENT;
+    if (core == 0 && synth != SYNTH_NONE)
+        return -ENOENT; // synthetic suffix anchored at the partition root makes no sense
+    if (ip.n_components == 0) {
         out->mode = VFS_MODE_DIR;
         return 0;
     }
-    rc = hfs_lookup(hfs, ip.components, core, &d);
+    rc = hfs_lookup(hfs, ip.components, core ? core : ip.n_components, &d);
     if (rc < 0) {
-        // If the suffix lookup fails, maybe the last component was part of
-        // the filename (not a fork).  Retry with the full component list.
-        if ((rsrc || finf) && core < ip.n_components) {
+        // Synthetic lookup missed (filename literally contains "rsrc" or
+        // "finf"); retry the whole thing as a literal HFS path.
+        if (synth != SYNTH_NONE) {
             rc = hfs_lookup(hfs, ip.components, ip.n_components, &d);
-            if (rc == 0) {
-                rsrc = finf = false;
-            }
+            if (rc == 0)
+                synth = SYNTH_NONE;
         }
         if (rc < 0)
             return rc;
     }
 
-    if (rsrc) {
+    if (synth != SYNTH_NONE) {
+        // All synthetic kinds require a file (forks live on files).
         if (d.is_dir)
             return -ENOENT;
-        out->mode = VFS_MODE_FILE;
-        out->size = d.rsrc_fork.logical_size;
-        return 0;
-    }
-    if (finf) {
-        if (d.is_dir)
+        if (synth == SYNTH_FINF) {
+            out->mode = VFS_MODE_FILE;
+            out->size = HFS_FINDER_INFO_SIZE;
+            return 0;
+        }
+        if (synth == SYNTH_RSRC_RAW) {
+            out->mode = VFS_MODE_FILE;
+            out->size = d.rsrc_fork.logical_size;
+            return 0;
+        }
+        // /rsrc directory entries require a non-empty fork to enumerate.
+        if (d.rsrc_fork.logical_size == 0)
             return -ENOENT;
+        if (synth == SYNTH_RSRC_DIR) {
+            out->mode = VFS_MODE_DIR;
+            return 0;
+        }
+        // /rsrc/<TYPE> and deeper need the parsed map.
+        rsrc_cache_entry_t *e = rsrc_cache_acquire(m, hfs, &d);
+        if (!e)
+            return -EIO;
+        size_t n_res = rfork_num_resources(e->parsed, syn_type);
+        if (synth == SYNTH_RSRC_TYPE_DIR) {
+            if (n_res == 0)
+                return -ENOENT;
+            out->mode = VFS_MODE_DIR;
+            return 0;
+        }
+        // Resource bytes or .info sidecar.
+        const uint8_t *bytes = NULL;
+        size_t sz = 0;
+        const char *name = NULL;
+        uint8_t attrs = 0;
+        if (rfork_lookup(e->parsed, syn_type, syn_id, &bytes, &sz, &name, &attrs) < 0)
+            return -ENOENT;
+        if (synth == SYNTH_RSRC_DATA) {
+            out->mode = VFS_MODE_FILE;
+            out->size = sz;
+            return 0;
+        }
+        // SYNTH_RSRC_INFO: format the JSON to a scratch buffer to take its
+        // length.  Identical to what img_open will later do — duplicating
+        // 512 bytes of stack work on stat is fine; the caller can avoid it
+        // entirely by reading the file directly.
+        char tmp[512];
+        int w = rfork_info_format(name, attrs, sz, tmp, sizeof(tmp));
+        if (w < 0)
+            return -EIO;
         out->mode = VFS_MODE_FILE;
-        out->size = HFS_FINDER_INFO_SIZE;
+        out->size = (uint64_t)w;
         return 0;
     }
+
     out->mode = d.is_dir ? VFS_MODE_DIR : VFS_MODE_FILE;
     out->size = d.is_dir ? 0 : d.data_fork.logical_size;
     return 0;
@@ -675,6 +945,61 @@ static int img_opendir(void *ctx, const char *path, vfs_dir_t **out) {
         free(d);
         return -EIO;
     }
+    // Classify any synthetic suffix and try the synthetic interpretation
+    // first.  Synthetic directories we care about are /rsrc (root) and
+    // /rsrc/<TYPE>.  Anything else (including the literal HFS case) flows
+    // through hfs_opendir_cnid below.
+    uint8_t syn_type[4] = {0};
+    int16_t syn_id = 0;
+    size_t core = 0;
+    synth_kind_t synth = classify_synth(ip.components, ip.n_components, &core, syn_type, &syn_id);
+    (void)syn_id; // unused at opendir; per-resource leaves are files not dirs
+
+    if (synth == SYNTH_RSRC_DIR || synth == SYNTH_RSRC_TYPE_DIR) {
+        if (core == 0) {
+            free(d);
+            return -ENOENT;
+        }
+        hfs_dirent_t de = {0};
+        int lr = hfs_lookup(hfs, ip.components, core, &de);
+        if (lr < 0) {
+            // Retry literal in case the path looked synthetic but isn't.
+            lr = hfs_lookup(hfs, ip.components, ip.n_components, &de);
+            if (lr == 0)
+                synth = SYNTH_NONE;
+            else {
+                free(d);
+                return lr;
+            }
+        }
+        if (synth != SYNTH_NONE) {
+            if (de.is_dir || de.rsrc_fork.logical_size == 0) {
+                free(d);
+                return -ENOENT;
+            }
+            rsrc_cache_entry_t *e = rsrc_cache_acquire(m, hfs, &de);
+            if (!e) {
+                free(d);
+                return -EIO;
+            }
+            if (synth == SYNTH_RSRC_TYPE_DIR) {
+                if (rfork_num_resources(e->parsed, syn_type) == 0) {
+                    free(d);
+                    return -ENOENT;
+                }
+                d->kind = DIR_RSRC_TYPE;
+                memcpy(d->rsrc_type, syn_type, 4);
+            } else {
+                d->kind = DIR_RSRC_ROOT;
+            }
+            d->rfork = e->parsed;
+            d->rsrc_next_idx = 0;
+            m->refcount++;
+            *out = d;
+            return 0;
+        }
+    }
+
     uint32_t parent_cnid = HFS_ROOT_CNID;
     if (ip.n_components > 0) {
         hfs_dirent_t de = {0};
@@ -748,6 +1073,81 @@ static int img_readdir(vfs_dir_t *d, vfs_dirent_t *out) {
         out->has_stat = true;
         return 1;
     }
+    if (d->kind == DIR_RSRC_ROOT) {
+        size_t n_types = rfork_num_types(d->rfork);
+        if (d->rsrc_next_idx < n_types) {
+            const uint8_t *cc = rfork_type_at(d->rfork, d->rsrc_next_idx);
+            d->rsrc_next_idx++;
+            char buf[16];
+            rfork_type_to_path(cc, buf, sizeof(buf));
+            int w = snprintf(out->name, sizeof(out->name), "%s", buf);
+            if (w < 0 || (size_t)w >= sizeof(out->name))
+                return -ENAMETOOLONG;
+            out->st.mode = VFS_MODE_DIR;
+            out->st.readonly = true;
+            out->has_stat = true;
+            return 1;
+        }
+        // Emit the "_raw" escape-hatch entry once after the types are
+        // exhausted, then EOF.
+        if (!d->rsrc_emit_raw_next) {
+            d->rsrc_emit_raw_next = true;
+            int w = snprintf(out->name, sizeof(out->name), "_raw");
+            if (w < 0 || (size_t)w >= sizeof(out->name))
+                return -ENAMETOOLONG;
+            out->st.mode = VFS_MODE_FILE;
+            out->st.readonly = true;
+            out->has_stat = true;
+            return 1;
+        }
+        return 0;
+    }
+    if (d->kind == DIR_RSRC_TYPE) {
+        // Interleave each `<id>` entry with its `<id>.info` sidecar so
+        // listings group naturally.  rsrc_emit_info_next flags the second
+        // emission; rsrc_pending_* carries the id+info-size across calls.
+        if (d->rsrc_emit_info_next) {
+            char id_str[16];
+            rfork_id_to_path(d->rsrc_pending_id, id_str, sizeof(id_str));
+            int w = snprintf(out->name, sizeof(out->name), "%s.info", id_str);
+            if (w < 0 || (size_t)w >= sizeof(out->name))
+                return -ENAMETOOLONG;
+            out->st.mode = VFS_MODE_FILE;
+            out->st.readonly = true;
+            out->st.size = d->rsrc_pending_info_size;
+            out->has_stat = true;
+            d->rsrc_emit_info_next = false;
+            return 1;
+        }
+        size_t n_res = rfork_num_resources(d->rfork, d->rsrc_type);
+        if (d->rsrc_next_idx >= n_res)
+            return 0;
+        int16_t id = rfork_id_at(d->rfork, d->rsrc_type, d->rsrc_next_idx);
+        d->rsrc_next_idx++;
+        const uint8_t *bytes = NULL;
+        size_t sz = 0;
+        const char *name = NULL;
+        uint8_t attrs = 0;
+        if (rfork_lookup(d->rfork, d->rsrc_type, id, &bytes, &sz, &name, &attrs) < 0)
+            return -EIO; // shouldn't happen — id came from the same fork
+        char id_str[16];
+        rfork_id_to_path(id, id_str, sizeof(id_str));
+        int w = snprintf(out->name, sizeof(out->name), "%s", id_str);
+        if (w < 0 || (size_t)w >= sizeof(out->name))
+            return -ENAMETOOLONG;
+        out->st.mode = VFS_MODE_FILE;
+        out->st.size = sz;
+        out->st.readonly = true;
+        out->has_stat = true;
+        // Compute the sidecar size now so the next readdir call can emit
+        // the .info entry without re-reading the fork.
+        char tmp[512];
+        int sidecar = rfork_info_format(name, attrs, sz, tmp, sizeof(tmp));
+        d->rsrc_pending_info_size = (sidecar > 0) ? (size_t)sidecar : 0;
+        d->rsrc_pending_id = id;
+        d->rsrc_emit_info_next = true;
+        return 1;
+    }
     return -EINVAL;
 }
 
@@ -809,32 +1209,27 @@ static int img_open(void *ctx, const char *path, vfs_file_t **out) {
     if (p->fs_kind != APM_FS_HFS)
         return -ENOTDIR;
 
-    // Same fork-suffix peel as img_stat. The earlier `if (ip.n_components == 0)
-    // return -EISDIR` (around line 747) keeps `core >= 1` here today, but
-    // bracket the read so an ASAN run wouldn't trip on a future caller.
-    bool rsrc = false, finf = false;
-    size_t core = ip.n_components;
-    if (core >= 1) {
-        const char *last = ip.components[core - 1];
-        if (strcmp(last, "rsrc") == 0 || strcmp(last, "finf") == 0) {
-            rsrc = strcmp(last, "rsrc") == 0;
-            finf = strcmp(last, "finf") == 0;
-            core--;
-        }
-    }
+    // Classify synthetic suffix.  /rsrc on its own is a directory now and
+    // returns -EISDIR below; /rsrc/_raw maps to the old raw-fork-bytes
+    // behaviour; /rsrc/<TYPE> is a directory; the leaf cases produce
+    // FILE_RSRC_DATA / FILE_RSRC_INFO handles.
+    uint8_t syn_type[4] = {0};
+    int16_t syn_id = 0;
+    size_t core = 0;
+    synth_kind_t synth = classify_synth(ip.components, ip.n_components, &core, syn_type, &syn_id);
 
     hfs_volume_t *hfs = get_partition_hfs(m, ip.partition_idx);
     if (!hfs)
         return -EIO;
     hfs_dirent_t d = {0};
-    if (core == 0)
-        return -EISDIR;
-    rc = hfs_lookup(hfs, ip.components, core, &d);
+    if (core == 0 && synth != SYNTH_NONE)
+        return -ENOENT;
+    rc = hfs_lookup(hfs, ip.components, core ? core : ip.n_components, &d);
     if (rc < 0) {
-        if ((rsrc || finf) && core < ip.n_components) {
+        if (synth != SYNTH_NONE) {
             rc = hfs_lookup(hfs, ip.components, ip.n_components, &d);
             if (rc == 0)
-                rsrc = finf = false;
+                synth = SYNTH_NONE;
         }
         if (rc < 0)
             return rc;
@@ -842,17 +1237,55 @@ static int img_open(void *ctx, const char *path, vfs_file_t **out) {
     if (d.is_dir)
         return -EISDIR;
 
+    if (synth == SYNTH_RSRC_DIR || synth == SYNTH_RSRC_TYPE_DIR)
+        return -EISDIR;
+
     vfs_file_t *f = calloc(1, sizeof(*f));
     if (!f)
         return -ENOMEM;
     f->mount = m;
     f->hfs = hfs;
-    if (finf) {
+
+    if (synth == SYNTH_FINF) {
         f->kind = FILE_FINDER_INFO;
         memcpy(f->finder_info, d.finder_info, HFS_FINDER_INFO_SIZE);
+    } else if (synth == SYNTH_RSRC_RAW) {
+        f->kind = FILE_HFS_FORK;
+        f->fork = d.rsrc_fork;
+    } else if (synth == SYNTH_RSRC_DATA || synth == SYNTH_RSRC_INFO) {
+        if (d.rsrc_fork.logical_size == 0) {
+            free(f);
+            return -ENOENT;
+        }
+        rsrc_cache_entry_t *e = rsrc_cache_acquire(m, hfs, &d);
+        if (!e) {
+            free(f);
+            return -EIO;
+        }
+        const uint8_t *bytes = NULL;
+        size_t sz = 0;
+        const char *name = NULL;
+        uint8_t attrs = 0;
+        if (rfork_lookup(e->parsed, syn_type, syn_id, &bytes, &sz, &name, &attrs) < 0) {
+            free(f);
+            return -ENOENT;
+        }
+        if (synth == SYNTH_RSRC_DATA) {
+            f->kind = FILE_RSRC_DATA;
+            f->rsrc_bytes = bytes;
+            f->rsrc_size = sz;
+        } else {
+            f->kind = FILE_RSRC_INFO;
+            int w = rfork_info_format(name, attrs, sz, f->rsrc_info_buf, sizeof(f->rsrc_info_buf));
+            if (w < 0) {
+                free(f);
+                return -EIO;
+            }
+            f->rsrc_info_len = (size_t)w;
+        }
     } else {
         f->kind = FILE_HFS_FORK;
-        f->fork = rsrc ? d.rsrc_fork : d.data_fork;
+        f->fork = d.data_fork;
     }
     m->refcount++;
     *out = f;
@@ -870,6 +1303,30 @@ static int img_read(vfs_file_t *f, uint64_t off, void *buf, size_t n, size_t *nr
             size_t avail = HFS_FINDER_INFO_SIZE - (size_t)off;
             size_t take = n < avail ? n : avail;
             memcpy(buf, f->finder_info + off, take);
+            got = take;
+        }
+        if (nread)
+            *nread = got;
+        return 0;
+    }
+    if (f->kind == FILE_RSRC_DATA) {
+        size_t got = 0;
+        if (off < f->rsrc_size) {
+            size_t avail = f->rsrc_size - (size_t)off;
+            size_t take = n < avail ? n : avail;
+            memcpy(buf, f->rsrc_bytes + off, take);
+            got = take;
+        }
+        if (nread)
+            *nread = got;
+        return 0;
+    }
+    if (f->kind == FILE_RSRC_INFO) {
+        size_t got = 0;
+        if (off < f->rsrc_info_len) {
+            size_t avail = f->rsrc_info_len - (size_t)off;
+            size_t take = n < avail ? n : avail;
+            memcpy(buf, f->rsrc_info_buf + off, take);
             got = take;
         }
         if (nread)

--- a/tests/integration/vfs-rsrc/config.mk
+++ b/tests/integration/vfs-rsrc/config.mk
@@ -1,0 +1,8 @@
+# Integration test: synthetic /rsrc/<TYPE>/<id> path tree (PR 1 of the
+# resource-fork-as-VFS-tree proposal).  Exercises type enumeration, id
+# enumeration with .info sidecars, the _raw escape hatch, and the
+# round-trip of resource bytes reassembled from the per-resource files.
+
+TEST_NAME := VFS resource-fork tree
+TEST_DESC := Walk /rsrc/<TYPE>/<id> and .info sidecars on a System 6 floppy
+TEST_ROM := roms/Plus_v3.rom

--- a/tests/integration/vfs-rsrc/test.script
+++ b/tests/integration/vfs-rsrc/test.script
@@ -1,0 +1,44 @@
+# Integration test: synthetic resource-fork VFS tree.
+# Runner cd's into this directory; paths are relative.
+
+# Mount the System 6 floppy explicitly so the rest of the script uses a
+# stable image-VFS path.
+storage.probe ../../data/systems/System_6_0_8.dsk
+
+# /rsrc on a file with a non-empty resource fork must surface as a directory.
+storage.path_exists ../../data/systems/System_6_0_8.dsk/partition1/System\ Folder/Finder/rsrc
+
+# Resource types enumerate.  The classic Finder uses CODE / MENU / STR# /
+# vers / DLOG / ICN# / ... — we don't assert exact ordering here, just
+# expect the listing to come back non-empty.
+vfs.ls ../../data/systems/System_6_0_8.dsk/partition1/System\ Folder/Finder/rsrc/
+
+# CODE IDs enumerate; .info sidecars appear immediately after their bin.
+vfs.ls ../../data/systems/System_6_0_8.dsk/partition1/System\ Folder/Finder/rsrc/CODE/
+
+# vers/1 exists as bytes and as a .info sidecar.
+storage.path_exists ../../data/systems/System_6_0_8.dsk/partition1/System\ Folder/Finder/rsrc/vers/1
+storage.path_exists ../../data/systems/System_6_0_8.dsk/partition1/System\ Folder/Finder/rsrc/vers/1.info
+
+# .info sidecar JSON is small + well-formed.
+vfs.cat ../../data/systems/System_6_0_8.dsk/partition1/System\ Folder/Finder/rsrc/vers/1.info
+
+# _raw escape hatch exposes the full fork bytes.
+storage.path_exists ../../data/systems/System_6_0_8.dsk/partition1/System\ Folder/Finder/rsrc/_raw
+
+# Bogus type 4-CC cleanly returns ENOENT (no hang / crash).
+storage.path_exists ../../data/systems/System_6_0_8.dsk/partition1/System\ Folder/Finder/rsrc/BADX
+storage.path_exists ../../data/systems/System_6_0_8.dsk/partition1/System\ Folder/Finder/rsrc/CODE/9999
+
+# Folders never gain a synthetic /rsrc/... subtree.
+storage.path_exists ../../data/systems/System_6_0_8.dsk/partition1/System\ Folder/rsrc
+
+# Recursive copy of the synthetic tree out to the host.  Reads every leaf;
+# any path-resolution bug would surface as a failed cp.
+storage.cp -r ../../data/systems/System_6_0_8.dsk/partition1/System\ Folder/Finder/rsrc/ ${WORK_DIR}/rsrc-dump/
+vfs.ls ${WORK_DIR}/rsrc-dump
+
+# Drop the mount on the way out so the next test starts from a clean slate.
+storage.unmount ../../data/systems/System_6_0_8.dsk
+
+quit

--- a/tests/unit/suites/resfork/Makefile
+++ b/tests/unit/suites/resfork/Makefile
@@ -2,5 +2,6 @@ TEST_NAME := resfork
 TEST_SRCS := test.c
 TEST_HARNESS := isolated
 EXTRA_SRCS := ../../../../src/core/storage/resource_fork.c \
-              ../../../../src/core/storage/macroman.c
+              ../../../../src/core/storage/macroman.c \
+              ../../../../src/core/storage/rsrc_dcmp.c
 include ../../common.mk

--- a/tests/unit/suites/resfork/Makefile
+++ b/tests/unit/suites/resfork/Makefile
@@ -1,0 +1,6 @@
+TEST_NAME := resfork
+TEST_SRCS := test.c
+TEST_HARNESS := isolated
+EXTRA_SRCS := ../../../../src/core/storage/resource_fork.c \
+              ../../../../src/core/storage/macroman.c
+include ../../common.mk

--- a/tests/unit/suites/resfork/test.c
+++ b/tests/unit/suites/resfork/test.c
@@ -520,6 +520,71 @@ TEST(test_dcmp_rejects_wrong_dcmp_id) {
     ASSERT_TRUE(err != NULL);
 }
 
+TEST(test_dcmp2_greggy_static_nonbitmapped) {
+    // Header version 9 + dcmp 2 (GreggyBits), non-bitmapped, no dynamic
+    // table.  Each input byte indexes the static table.  We choose two
+    // known entries: index 0x00 -> 0x0000, index 0x04 -> 0x4E75 (RTS).
+    uint8_t payload[18 + 2] = {
+        0xA8, 0x9F, 0x65, 0x72, // signature
+        0x00, 0x12, // header_length = 18
+        0x09, // version 9 (GreggyBits)
+        0x00, // attrs
+        0x00, 0x00, 0x00, 0x04, // actual_size = 4 bytes (2 words)
+        0x00, 0x02, // dcmp_id = 2 (GreggyBits)
+        0x00, 0x00, // decompress_slop
+        0x00, // byte_table_size (irrelevant — no dynamic table)
+        0x00, // compress_flags: 0 = static table, non-bitmapped
+        // Payload: 2 bytes producing 2 output words.
+        0x00, // -> static[0x00] = 0x0000
+        0x04, // -> static[0x04] = 0x4E75
+    };
+    size_t out_len = 0;
+    const char *err = NULL;
+    uint8_t *out = rsrc_dcmp_decompress(payload, sizeof(payload), &out_len, &err);
+    ASSERT_TRUE(out != NULL);
+    ASSERT_EQ_INT(4, (int)out_len);
+    // Output: 0x0000 (BE) then 0x4E75 (BE) = 00 00 4E 75
+    uint8_t expected[4] = {0x00, 0x00, 0x4E, 0x75};
+    ASSERT_EQ_INT(0, memcmp(out, expected, 4));
+    free(out);
+}
+
+TEST(test_dcmp2_greggy_bitmapped) {
+    // GreggyBits with bitmapped data: one bitmap byte 0xC0 (bits 7+6 set)
+    // controls 8 output words: first 2 are compressed (1-byte index), next 6
+    // are uncompressed (2 bytes each).  We pad actual_size to exactly 8
+    // words so the run-loop hits the full-run path.
+    // Expected output: static[0x04] + static[0x05] + then 6 raw words.
+    uint8_t payload[] = {
+        0xA8, 0x9F, 0x65, 0x72, 0x00, 0x12, 0x09, 0x00, 0x00, 0x00, 0x00, 0x10, // actual_size = 16 bytes (8 words)
+        0x00, 0x02, // dcmp_id = 2
+        0x00, 0x00, // slop
+        0x00, // byte_table_size
+        0x02, // compress_flags: bitmappedData
+        // Payload: one bitmap byte, then mixed compressed/uncompressed.
+        0xC0, // bitmap: 11000000 — first 2 words compressed, next 6 raw
+        0x04, // -> static[0x04] = 0x4E75
+        0x05, // -> static[0x05] = 0x000C
+        0xAA, 0xBB, // raw word 0xAABB
+        0xCC, 0xDD, // raw word 0xCCDD
+        0xEE, 0xFF, // raw word 0xEEFF
+        0x11, 0x22, // raw word 0x1122
+        0x33, 0x44, // raw word 0x3344
+        0x55, 0x66, // raw word 0x5566
+    };
+    size_t out_len = 0;
+    uint8_t *out = rsrc_dcmp_decompress(payload, sizeof(payload), &out_len, NULL);
+    ASSERT_TRUE(out != NULL);
+    ASSERT_EQ_INT(16, (int)out_len);
+    uint8_t expected[16] = {
+        0x4E, 0x75, // static[0x04]
+        0x00, 0x0C, // static[0x05]
+        0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66,
+    };
+    ASSERT_EQ_INT(0, memcmp(out, expected, 16));
+    free(out);
+}
+
 TEST(test_dcmp_zero_pads_short_streams) {
     // actual_size = 10 but the stream emits 4 bytes before 0xFF — the
     // remaining 6 bytes must come back as zeros so callers see a buffer
@@ -556,6 +621,8 @@ int main(void) {
     RUN(test_dcmp_remember_then_reuse);
     RUN(test_dcmp_rejects_bad_magic);
     RUN(test_dcmp_rejects_wrong_dcmp_id);
+    RUN(test_dcmp2_greggy_static_nonbitmapped);
+    RUN(test_dcmp2_greggy_bitmapped);
     RUN(test_dcmp_zero_pads_short_streams);
     fprintf(stderr, "All resfork tests passed.\n");
     return 0;

--- a/tests/unit/suites/resfork/test.c
+++ b/tests/unit/suites/resfork/test.c
@@ -9,6 +9,7 @@
 // scenarios that must produce a defined error rather than a crash.
 
 #include "resource_fork.h"
+#include "rsrc_dcmp.h"
 #include "test_assert.h"
 
 #include <errno.h>
@@ -413,6 +414,130 @@ TEST(test_info_format) {
     ASSERT_TRUE(strstr(buf, "\\\\") != NULL);
 }
 
+// ---- dcmp 0 decompressor tests --------------------------------------------
+//
+// Build a minimal valid compressed payload by hand and confirm the
+// decompressor produces the expected output.  This exercises the
+// LiteralN opcode (variable-length literal copy) and the constant-word
+// emit table (three different table entries) plus the end-of-stream
+// terminator — covering the three most common opcode classes.
+
+TEST(test_dcmp_is_compressed) {
+    uint8_t magic[4] = {0xA8, 0x9F, 0x65, 0x72};
+    ASSERT_TRUE(rsrc_dcmp_is_compressed(magic, 4));
+    uint8_t notmagic[4] = {0xA8, 0x9F, 0x65, 0x71};
+    ASSERT_TRUE(!rsrc_dcmp_is_compressed(notmagic, 4));
+    ASSERT_TRUE(!rsrc_dcmp_is_compressed(NULL, 0));
+    ASSERT_TRUE(!rsrc_dcmp_is_compressed(magic, 3)); // too short
+}
+
+TEST(test_dcmp_roundtrip_minimal) {
+    // Header (18 bytes) + payload exercising LiteralN + constant-word emit.
+    // Payload semantics:
+    //   0x03 0x11 0x22 0x33 0x44 0x55 0x66   -> Literal6 emits 6 raw bytes
+    //   0x4C                                  -> const-word 0x4EBA (JSR.L)
+    //   0x4E                                  -> const-word 0x4E75 (RTS)
+    //   0x4D                                  -> const-word 0x0008
+    //   0xFF                                  -> end of stream
+    // Total emitted: 6 + 2 + 2 + 2 = 12 bytes.
+    uint8_t payload[18 + 11] = {
+        // Header
+        0xA8, 0x9F, 0x65, 0x72, // signature
+        0x00, 0x12, // header_length = 18
+        0x08, // version 8
+        0x00, // attrs
+        0x00, 0x00, 0x00, 0x0C, // actual_size = 12
+        0x40, // var_ratio (gives var table 12*0x40/256 = 3 → rounded up to 4)
+        0x00, // overrun
+        0x00, 0x00, // dcmp_id = 0
+        0x00, 0x00, // ctable_id
+        // Payload
+        0x03, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, // Literal6
+        0x4C, // const 0x4EBA
+        0x4E, // const 0x4E75
+        0x4D, // const 0x0008
+        0xFF, // end
+    };
+
+    size_t out_len = 0;
+    const char *err = NULL;
+    uint8_t *out = rsrc_dcmp_decompress(payload, sizeof(payload), &out_len, &err);
+    ASSERT_TRUE(out != NULL);
+    ASSERT_TRUE(err == NULL);
+    ASSERT_EQ_INT(12, (int)out_len);
+
+    uint8_t expected[12] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x4E, 0xBA, 0x4E, 0x75, 0x00, 0x08};
+    ASSERT_EQ_INT(0, memcmp(out, expected, 12));
+    free(out);
+}
+
+TEST(test_dcmp_remember_then_reuse) {
+    // Exercise the var-table dictionary: Remember2 stores a 2-byte literal,
+    // then ReuseData0 emits it again.  `actual_size` is padded to 20 so the
+    // var table is big enough (var_ratio 0x80 ⇒ 20·128/256 = 10 bytes —
+    // room for the index list plus a 2-byte string at the tail).  The
+    // remaining 14 bytes of the output come back as zero padding.
+    //   0x11 0xAA 0xBB                       -> Remember2: emit + store "AA BB"
+    //   0x4B                                  -> emit const 0x0000
+    //   0x23                                  -> ReuseData0 — fetch entry 0 = "AA BB"
+    //   0xFF                                  -> end
+    uint8_t payload[18 + 6] = {
+        0xA8, 0x9F, 0x65, 0x72, 0x00, 0x12, 0x08, 0x00, 0x00, 0x00, 0x00, 0x14, // actual_size = 20
+        0x80, // var_ratio = 0x80 → 20·128/256 = 10 bytes
+        0x00, 0x00, 0x00, 0x00, 0x00,
+        // Payload
+        0x11, 0xAA, 0xBB, // Remember2
+        0x4B, // const 0x0000
+        0x23, // ReuseData0
+        0xFF, // end
+    };
+    size_t out_len = 0;
+    const char *err = NULL;
+    uint8_t *out = rsrc_dcmp_decompress(payload, sizeof(payload), &out_len, &err);
+    ASSERT_TRUE(out != NULL);
+    ASSERT_EQ_INT(20, (int)out_len);
+    uint8_t expected[20] = {0xAA, 0xBB, 0x00, 0x00, 0xAA, 0xBB, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    ASSERT_EQ_INT(0, memcmp(out, expected, 20));
+    free(out);
+}
+
+TEST(test_dcmp_rejects_bad_magic) {
+    uint8_t bad[18] = {0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x12, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    const char *err = NULL;
+    uint8_t *out = rsrc_dcmp_decompress(bad, sizeof(bad), NULL, &err);
+    ASSERT_TRUE(out == NULL);
+    ASSERT_TRUE(err != NULL);
+}
+
+TEST(test_dcmp_rejects_wrong_dcmp_id) {
+    // Valid magic + header but dcmp_id = 2 (GreggyBits, not implemented).
+    uint8_t hdr[18] = {0xA8, 0x9F, 0x65, 0x72, 0x00, 0x12, 0x08, 0x00,
+                       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, // dcmp_id = 2
+                       0x00, 0x00};
+    const char *err = NULL;
+    uint8_t *out = rsrc_dcmp_decompress(hdr, sizeof(hdr), NULL, &err);
+    ASSERT_TRUE(out == NULL);
+    ASSERT_TRUE(err != NULL);
+}
+
+TEST(test_dcmp_zero_pads_short_streams) {
+    // actual_size = 10 but the stream emits 4 bytes before 0xFF — the
+    // remaining 6 bytes must come back as zeros so callers see a buffer
+    // of exactly actual_size.
+    uint8_t payload[] = {
+        0xA8, 0x9F, 0x65, 0x72, 0x00, 0x12, 0x08, 0x00, 0x00, 0x00, 0x00, 0x0A, // actual_size = 10
+        0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x11, 0x22, 0x33, 0x44, // Literal4
+        0xFF, // end
+    };
+    size_t out_len = 0;
+    uint8_t *out = rsrc_dcmp_decompress(payload, sizeof(payload), &out_len, NULL);
+    ASSERT_TRUE(out != NULL);
+    ASSERT_EQ_INT(10, (int)out_len);
+    uint8_t expected[10] = {0x11, 0x22, 0x33, 0x44, 0, 0, 0, 0, 0, 0};
+    ASSERT_EQ_INT(0, memcmp(out, expected, 10));
+    free(out);
+}
+
 int main(void) {
     RUN(test_parse_empty_fork);
     RUN(test_parse_two_types_multi_ids);
@@ -426,6 +551,12 @@ int main(void) {
     RUN(test_id_path_parse);
     RUN(test_type_path_parse);
     RUN(test_info_format);
+    RUN(test_dcmp_is_compressed);
+    RUN(test_dcmp_roundtrip_minimal);
+    RUN(test_dcmp_remember_then_reuse);
+    RUN(test_dcmp_rejects_bad_magic);
+    RUN(test_dcmp_rejects_wrong_dcmp_id);
+    RUN(test_dcmp_zero_pads_short_streams);
     fprintf(stderr, "All resfork tests passed.\n");
     return 0;
 }

--- a/tests/unit/suites/resfork/test.c
+++ b/tests/unit/suites/resfork/test.c
@@ -1,0 +1,431 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) pappadf
+
+// Unit tests for the resource-fork parser (src/core/storage/resource_fork.c).
+// Exercises the documented format edge cases: num_types-1 and count-1 off-by-
+// one fields, signed int16 IDs at the boundaries, type 4-CCs with a trailing
+// space and with high-bit MacRoman bytes, empty resources, single-resource
+// forks, missing-name (name_off == -1) records, and assorted corruption
+// scenarios that must produce a defined error rather than a crash.
+
+#include "resource_fork.h"
+#include "test_assert.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// ---- Big-endian writer helpers --------------------------------------------
+
+static void w_u16(uint8_t *p, uint16_t v) {
+    p[0] = (uint8_t)(v >> 8);
+    p[1] = (uint8_t)(v & 0xFF);
+}
+static void w_u32(uint8_t *p, uint32_t v) {
+    p[0] = (uint8_t)(v >> 24);
+    p[1] = (uint8_t)(v >> 16);
+    p[2] = (uint8_t)(v >> 8);
+    p[3] = (uint8_t)v;
+}
+static void w_i16(uint8_t *p, int16_t v) {
+    w_u16(p, (uint16_t)v);
+}
+
+// ---- Fork builder ----------------------------------------------------------
+//
+// Constructs a tiny but format-faithful resource fork in a freshly-malloc'd
+// buffer.  Each type takes 8 bytes in the type list and contributes 12
+// bytes per resource in the ref list.  Names are appended at the end of
+// the map area.
+
+typedef struct {
+    const uint8_t cc[4];
+    int16_t id;
+    int16_t name_off; // -1 = no name
+    uint8_t attrs;
+    size_t data_len;
+    const uint8_t *data; // borrowed
+} test_res_t;
+
+// Build a fork from `resources` (already grouped by type — order matters
+// because the on-disk format groups ref entries per type).  `n_types` and
+// `type_counts` describe the grouping.  Returns malloc'd buffer + len.
+static uint8_t *build_fork(const test_res_t *resources, size_t n_resources, const uint8_t (*type_ccs)[4],
+                           const size_t *type_counts, size_t n_types, const char *const *names, size_t *out_len) {
+    // Data area: 4 bytes length prefix + resource bytes per entry, no
+    // alignment padding (we read at any offset, the alignment hint in the
+    // format is a hint not a requirement).
+    size_t data_area = 0;
+    for (size_t r = 0; r < n_resources; r++)
+        data_area += 4 + resources[r].data_len;
+    size_t name_area = 0;
+    for (size_t i = 0; names && names[i]; i++)
+        name_area += 1 + strlen(names[i]); // Pascal pstring
+    size_t type_table_bytes = 2 + 8 * n_types;
+    size_t ref_table_bytes = 12 * n_resources;
+    size_t map_area = 30 + (type_table_bytes - 2) + ref_table_bytes + name_area;
+    // Layout: 16-byte header + data area + map area.
+    size_t fork_len = 16 + data_area + map_area;
+    uint8_t *buf = calloc(1, fork_len);
+    uint32_t data_off = 16;
+    uint32_t map_off = (uint32_t)(16 + data_area);
+    uint32_t data_len = (uint32_t)data_area;
+    uint32_t map_len = (uint32_t)map_area;
+    w_u32(buf + 0, data_off);
+    w_u32(buf + 4, map_off);
+    w_u32(buf + 8, data_len);
+    w_u32(buf + 12, map_len);
+
+    // Lay out data records and record absolute offsets within the data area.
+    uint32_t *res_data_off = calloc(n_resources, sizeof(uint32_t));
+    uint32_t cur = 0;
+    for (size_t r = 0; r < n_resources; r++) {
+        res_data_off[r] = cur;
+        w_u32(buf + data_off + cur, (uint32_t)resources[r].data_len);
+        memcpy(buf + data_off + cur + 4, resources[r].data, resources[r].data_len);
+        cur += 4 + (uint32_t)resources[r].data_len;
+    }
+
+    // Map area.  Header copy 0..15 + 4 reserved bytes (16..19) +
+    // reserved handle (20..21) + fork attrs (22..23) + offsets (24..27) +
+    // num types - 1 (28..29).  Type list begins at 28 in the map, so
+    // type_list_off (relative to map start) is 28.
+    uint8_t *map = buf + map_off;
+    uint16_t type_list_off = 28;
+    uint16_t name_list_off = (uint16_t)(type_list_off + 2 + 8 * n_types + 12 * n_resources);
+    w_u16(map + 22, 0); // fork attrs
+    w_u16(map + 24, type_list_off);
+    w_u16(map + 26, name_list_off);
+    if (n_types == 0)
+        w_u16(map + type_list_off, 0xFFFF); // num_types - 1 sentinel for empty fork
+    else
+        w_u16(map + type_list_off, (uint16_t)(n_types - 1));
+
+    // Type list entries start at type_list_off + 2; ref list entries follow
+    // the type list contiguously.
+    uint16_t type_entry_off = (uint16_t)(type_list_off + 2);
+    uint16_t ref_table_start = (uint16_t)(type_entry_off + 8 * n_types);
+    size_t resource_cursor = 0;
+    for (size_t t = 0; t < n_types; t++) {
+        uint8_t *te = map + type_entry_off + 8 * t;
+        memcpy(te, type_ccs[t], 4);
+        w_u16(te + 4, (uint16_t)(type_counts[t] - 1));
+        // ref-list offset is relative to type_list_off (not entry start).
+        uint16_t this_ref_off = (uint16_t)(ref_table_start + 12 * resource_cursor - type_list_off);
+        w_u16(te + 6, this_ref_off);
+        for (size_t r = 0; r < type_counts[t]; r++) {
+            uint8_t *re = map + ref_table_start + 12 * (resource_cursor + r);
+            w_i16(re + 0, resources[resource_cursor + r].id);
+            w_i16(re + 2, resources[resource_cursor + r].name_off);
+            re[4] = resources[resource_cursor + r].attrs;
+            uint32_t doff = res_data_off[resource_cursor + r];
+            re[5] = (uint8_t)((doff >> 16) & 0xFF);
+            re[6] = (uint8_t)((doff >> 8) & 0xFF);
+            re[7] = (uint8_t)(doff & 0xFF);
+            // 4 reserved bytes follow (already zeroed by calloc).
+        }
+        resource_cursor += type_counts[t];
+    }
+    // Append names as Pascal pstrings.
+    if (names) {
+        uint8_t *np = map + name_list_off;
+        for (size_t i = 0; names[i]; i++) {
+            size_t l = strlen(names[i]);
+            np[0] = (uint8_t)l;
+            memcpy(np + 1, names[i], l);
+            np += 1 + l;
+        }
+    }
+    free(res_data_off);
+    *out_len = fork_len;
+    return buf;
+}
+
+// ---- Tests -----------------------------------------------------------------
+
+TEST(test_parse_empty_fork) {
+    // Fork with zero types: num_types-1 stores 0xFFFF.
+    size_t fork_len;
+    uint8_t *buf = build_fork(NULL, 0, NULL, NULL, 0, NULL, &fork_len);
+    const char *err = NULL;
+    rfork_t *rf = rfork_parse(buf, fork_len, &err);
+    ASSERT_TRUE(rf != NULL);
+    ASSERT_EQ_INT(0, (int)rfork_num_types(rf));
+    rfork_free(rf);
+    free(buf);
+}
+
+TEST(test_parse_two_types_multi_ids) {
+    uint8_t cc[2][4] = {
+        {'C', 'O', 'D', 'E'},
+        {'v', 'e', 'r', 's'}
+    };
+    size_t counts[2] = {2, 1};
+    const uint8_t code1[] = {0xDE, 0xAD};
+    const uint8_t code2[] = {0xBE, 0xEF, 0xCA, 0xFE};
+    const uint8_t vers1[] = {0x01, 0x00, 0x80, 0x01, 0x00, 0x00};
+    const char *names[] = {"Main", "Init", NULL};
+    test_res_t res[] = {
+        {.cc = {'C', 'O', 'D', 'E'}, .id = 1, .name_off = 0,  .attrs = 0x04, .data_len = 2, .data = code1},
+        {.cc = {'C', 'O', 'D', 'E'}, .id = 2, .name_off = 5,  .attrs = 0x00, .data_len = 4, .data = code2},
+        {.cc = {'v', 'e', 'r', 's'}, .id = 1, .name_off = -1, .attrs = 0x00, .data_len = 6, .data = vers1},
+    };
+    size_t fork_len;
+    uint8_t *buf = build_fork(res, 3, cc, counts, 2, names, &fork_len);
+    const char *err = NULL;
+    rfork_t *rf = rfork_parse(buf, fork_len, &err);
+    ASSERT_TRUE(rf != NULL);
+    ASSERT_EQ_INT(2, (int)rfork_num_types(rf));
+
+    uint8_t qcc[4] = {'C', 'O', 'D', 'E'};
+    ASSERT_EQ_INT(2, (int)rfork_num_resources(rf, qcc));
+    ASSERT_EQ_INT(1, rfork_id_at(rf, qcc, 0));
+    ASSERT_EQ_INT(2, rfork_id_at(rf, qcc, 1));
+
+    const uint8_t *bytes = NULL;
+    size_t sz = 0;
+    const char *name = NULL;
+    uint8_t attrs = 0;
+    ASSERT_EQ_INT(0, rfork_lookup(rf, qcc, 1, &bytes, &sz, &name, &attrs));
+    ASSERT_EQ_INT(2, (int)sz);
+    ASSERT_EQ_INT(0x04, attrs);
+    ASSERT_EQ_INT(0, memcmp(bytes, code1, 2));
+    ASSERT_EQ_INT(0, strcmp(name, "Main"));
+
+    uint8_t vcc[4] = {'v', 'e', 'r', 's'};
+    ASSERT_EQ_INT(0, rfork_lookup(rf, vcc, 1, &bytes, &sz, &name, &attrs));
+    ASSERT_EQ_INT(6, (int)sz);
+    ASSERT_EQ_INT(0, strcmp(name, "")); // no name on this resource
+
+    rfork_free(rf);
+    free(buf);
+}
+
+TEST(test_id_boundaries) {
+    // IDs at int16 extremes: -32768, -1, 0, 32767.
+    uint8_t cc[1][4] = {
+        {'B', 'O', 'U', 'N'}
+    };
+    size_t counts[1] = {4};
+    const uint8_t payload[1] = {0x01};
+    test_res_t res[4] = {
+        {.cc = {'B', 'O', 'U', 'N'}, .id = -32768, .name_off = -1, .attrs = 0, .data_len = 1, .data = payload},
+        {.cc = {'B', 'O', 'U', 'N'}, .id = -1,     .name_off = -1, .attrs = 0, .data_len = 1, .data = payload},
+        {.cc = {'B', 'O', 'U', 'N'}, .id = 0,      .name_off = -1, .attrs = 0, .data_len = 1, .data = payload},
+        {.cc = {'B', 'O', 'U', 'N'}, .id = 32767,  .name_off = -1, .attrs = 0, .data_len = 1, .data = payload},
+    };
+    size_t fork_len;
+    uint8_t *buf = build_fork(res, 4, cc, counts, 1, NULL, &fork_len);
+    const char *err = NULL;
+    rfork_t *rf = rfork_parse(buf, fork_len, &err);
+    ASSERT_TRUE(rf != NULL);
+    uint8_t qcc[4] = {'B', 'O', 'U', 'N'};
+    ASSERT_EQ_INT(0, rfork_lookup(rf, qcc, -32768, NULL, NULL, NULL, NULL));
+    ASSERT_EQ_INT(0, rfork_lookup(rf, qcc, 32767, NULL, NULL, NULL, NULL));
+    ASSERT_EQ_INT(-ENOENT, rfork_lookup(rf, qcc, 1, NULL, NULL, NULL, NULL));
+    rfork_free(rf);
+    free(buf);
+}
+
+TEST(test_type_trailing_space) {
+    // The "STR " type's trailing space round-trips through path conversion.
+    uint8_t cc[1][4] = {
+        {'S', 'T', 'R', ' '}
+    };
+    size_t counts[1] = {1};
+    const uint8_t payload[] = {0x03, 'a', 'b', 'c'};
+    test_res_t res[1] = {
+        {.cc = {'S', 'T', 'R', ' '}, .id = 128, .name_off = -1, .data_len = 4, .data = payload}
+    };
+    size_t fork_len;
+    uint8_t *buf = build_fork(res, 1, cc, counts, 1, NULL, &fork_len);
+    rfork_t *rf = rfork_parse(buf, fork_len, NULL);
+    ASSERT_TRUE(rf != NULL);
+    const uint8_t *type_cc = rfork_type_at(rf, 0);
+    ASSERT_TRUE(type_cc != NULL);
+    ASSERT_EQ_INT(0, memcmp(type_cc, "STR ", 4));
+
+    char path[16];
+    rfork_type_to_path(type_cc, path, sizeof(path));
+    ASSERT_EQ_INT(0, strcmp(path, "STR "));
+    uint8_t round[4];
+    ASSERT_EQ_INT(0, rfork_type_from_path("STR ", round));
+    ASSERT_EQ_INT(0, memcmp(round, "STR ", 4));
+
+    rfork_free(rf);
+    free(buf);
+}
+
+TEST(test_type_high_bit_macroman) {
+    // Type 4-CC containing high-bit MacRoman bytes round-trips through
+    // UTF-8 path conversion.  In MacRoman: 0xA9 → © (U+00A9), 0xA8 → ®
+    // (U+00AE), 0xAA → ™ (U+2122), 0xAB → ´ (U+00B4).  All four map into
+    // BMP codepoints with 2- or 3-byte UTF-8 encodings; we round-trip
+    // them all the way through type_from_path back to raw MacRoman.
+    uint8_t cc[1][4] = {
+        {0xA9, 0xA8, 0xAA, 0xAB}
+    };
+    size_t counts[1] = {1};
+    const uint8_t payload[1] = {0xFF};
+    test_res_t res[1] = {
+        {.cc = {0xA9, 0xA8, 0xAA, 0xAB}, .id = 1, .name_off = -1, .data_len = 1, .data = payload}
+    };
+    size_t fork_len;
+    uint8_t *buf = build_fork(res, 1, cc, counts, 1, NULL, &fork_len);
+    rfork_t *rf = rfork_parse(buf, fork_len, NULL);
+    ASSERT_TRUE(rf != NULL);
+
+    char path[16];
+    rfork_type_to_path(cc[0], path, sizeof(path));
+    // © U+00A9 → C2 A9; ® U+00AE → C2 AE; ™ U+2122 → E2 84 A2; ´ U+00B4 → C2 B4.
+    ASSERT_EQ_INT((int)0xC2, (int)(uint8_t)path[0]);
+    ASSERT_EQ_INT((int)0xA9, (int)(uint8_t)path[1]);
+    ASSERT_EQ_INT((int)0xC2, (int)(uint8_t)path[2]);
+    ASSERT_EQ_INT((int)0xAE, (int)(uint8_t)path[3]);
+    ASSERT_EQ_INT((int)0xE2, (int)(uint8_t)path[4]);
+    ASSERT_EQ_INT((int)0x84, (int)(uint8_t)path[5]);
+    ASSERT_EQ_INT((int)0xA2, (int)(uint8_t)path[6]);
+    ASSERT_EQ_INT((int)0xC2, (int)(uint8_t)path[7]);
+    ASSERT_EQ_INT((int)0xB4, (int)(uint8_t)path[8]);
+
+    uint8_t round[4];
+    ASSERT_EQ_INT(0, rfork_type_from_path(path, round));
+    ASSERT_EQ_INT(0, memcmp(round, cc[0], 4));
+    rfork_free(rf);
+    free(buf);
+}
+
+TEST(test_empty_resource) {
+    uint8_t cc[1][4] = {
+        {'E', 'M', 'P', 'T'}
+    };
+    size_t counts[1] = {1};
+    test_res_t res[1] = {
+        {.cc = {'E', 'M', 'P', 'T'}, .id = 0, .name_off = -1, .data_len = 0, .data = NULL}
+    };
+    size_t fork_len;
+    uint8_t *buf = build_fork(res, 1, cc, counts, 1, NULL, &fork_len);
+    rfork_t *rf = rfork_parse(buf, fork_len, NULL);
+    ASSERT_TRUE(rf != NULL);
+    const uint8_t *bytes = (const uint8_t *)1;
+    size_t sz = 999;
+    ASSERT_EQ_INT(0, rfork_lookup(rf, cc[0], 0, &bytes, &sz, NULL, NULL));
+    ASSERT_EQ_INT(0, (int)sz);
+    rfork_free(rf);
+    free(buf);
+}
+
+TEST(test_single_resource_fork) {
+    uint8_t cc[1][4] = {
+        {'O', 'N', 'L', 'Y'}
+    };
+    size_t counts[1] = {1};
+    const uint8_t payload[3] = {1, 2, 3};
+    const char *names[] = {"Sole", NULL};
+    test_res_t res[1] = {
+        {.cc = {'O', 'N', 'L', 'Y'}, .id = 5, .name_off = 0, .data_len = 3, .data = payload}
+    };
+    size_t fork_len;
+    uint8_t *buf = build_fork(res, 1, cc, counts, 1, names, &fork_len);
+    rfork_t *rf = rfork_parse(buf, fork_len, NULL);
+    ASSERT_TRUE(rf != NULL);
+    const uint8_t *bytes = NULL;
+    size_t sz = 0;
+    const char *name = NULL;
+    ASSERT_EQ_INT(0, rfork_lookup(rf, cc[0], 5, &bytes, &sz, &name, NULL));
+    ASSERT_EQ_INT(3, (int)sz);
+    ASSERT_EQ_INT(0, strcmp(name, "Sole"));
+    rfork_free(rf);
+    free(buf);
+}
+
+TEST(test_truncated_header) {
+    uint8_t buf[8] = {0};
+    const char *err = NULL;
+    rfork_t *rf = rfork_parse(buf, sizeof(buf), &err);
+    ASSERT_TRUE(rf == NULL);
+    ASSERT_TRUE(err != NULL);
+}
+
+TEST(test_corrupt_offsets) {
+    // Header fields claim data and map regions past the end of the buffer.
+    uint8_t buf[64] = {0};
+    w_u32(buf + 0, 16); // data_off
+    w_u32(buf + 4, 4096); // map_off way past EOF
+    w_u32(buf + 8, 0);
+    w_u32(buf + 12, 30); // map_len
+    const char *err = NULL;
+    rfork_t *rf = rfork_parse(buf, sizeof(buf), &err);
+    ASSERT_TRUE(rf == NULL);
+    ASSERT_TRUE(err != NULL);
+}
+
+TEST(test_id_path_parse) {
+    int16_t v = 0;
+    ASSERT_EQ_INT(0, rfork_id_from_path("0", &v));
+    ASSERT_EQ_INT(0, v);
+    ASSERT_EQ_INT(0, rfork_id_from_path("-16", &v));
+    ASSERT_EQ_INT(-16, v);
+    ASSERT_EQ_INT(0, rfork_id_from_path("32767", &v));
+    ASSERT_EQ_INT(32767, v);
+    ASSERT_EQ_INT(0, rfork_id_from_path("-32768", &v));
+    ASSERT_EQ_INT(-32768, v);
+    // Out of range.
+    ASSERT_EQ_INT(-EINVAL, rfork_id_from_path("32768", &v));
+    ASSERT_EQ_INT(-EINVAL, rfork_id_from_path("-32769", &v));
+    // Trailing junk.
+    ASSERT_EQ_INT(-EINVAL, rfork_id_from_path("12x", &v));
+    ASSERT_EQ_INT(-EINVAL, rfork_id_from_path("", &v));
+}
+
+TEST(test_type_path_parse) {
+    uint8_t out[4];
+    ASSERT_EQ_INT(0, rfork_type_from_path("CODE", out));
+    ASSERT_EQ_INT(0, memcmp(out, "CODE", 4));
+    ASSERT_EQ_INT(0, rfork_type_from_path("STR ", out));
+    ASSERT_EQ_INT(0, memcmp(out, "STR ", 4));
+    // 3-char input must fail.
+    ASSERT_EQ_INT(-EINVAL, rfork_type_from_path("STR", out));
+    // 5-char input must fail.
+    ASSERT_EQ_INT(-EINVAL, rfork_type_from_path("CODES", out));
+    // Empty fails.
+    ASSERT_EQ_INT(-EINVAL, rfork_type_from_path("", out));
+}
+
+TEST(test_info_format) {
+    char buf[256];
+    int n = rfork_info_format("Hello", 0x04, 1576, buf, sizeof(buf));
+    ASSERT_TRUE(n > 0);
+    ASSERT_TRUE(strstr(buf, "\"name\":\"Hello\"") != NULL);
+    ASSERT_TRUE(strstr(buf, "\"preload\"") != NULL);
+    ASSERT_TRUE(strstr(buf, "\"size\":1576") != NULL);
+    // Empty name + no attrs.
+    n = rfork_info_format("", 0, 0, buf, sizeof(buf));
+    ASSERT_TRUE(n > 0);
+    ASSERT_TRUE(strstr(buf, "\"name\":\"\"") != NULL);
+    ASSERT_TRUE(strstr(buf, "\"attrs\":[]") != NULL);
+    // JSON escape: a name with a quote and backslash.
+    n = rfork_info_format("ab\"c\\d", 0, 0, buf, sizeof(buf));
+    ASSERT_TRUE(n > 0);
+    ASSERT_TRUE(strstr(buf, "\\\"") != NULL);
+    ASSERT_TRUE(strstr(buf, "\\\\") != NULL);
+}
+
+int main(void) {
+    RUN(test_parse_empty_fork);
+    RUN(test_parse_two_types_multi_ids);
+    RUN(test_id_boundaries);
+    RUN(test_type_trailing_space);
+    RUN(test_type_high_bit_macroman);
+    RUN(test_empty_resource);
+    RUN(test_single_resource_fork);
+    RUN(test_truncated_header);
+    RUN(test_corrupt_offsets);
+    RUN(test_id_path_parse);
+    RUN(test_type_path_parse);
+    RUN(test_info_format);
+    fprintf(stderr, "All resfork tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Lands the resource-fork layer of the binary-explode work as a standalone
capability, with no dependency on the `src/core/re/` orchestrator (which
stays on the feature branch for follow-up PRs).

Three logical pieces, one per commit:

1. **Parser + VFS path convention** — `src/core/storage/resource_fork.{c,h}`
   parses the 16-byte fork header + map + type list + ref list + name list
   into an `rfork_t`. `src/core/vfs/image_vfs.c` overlays a synthetic
   `<file>/rsrc/<TYPE>/<id>` tree on top of every Mac-forked file, with
   `<TYPE>` directories, `<id>` resource bytes, `<id>.info` JSON sidecars,
   and an `_raw` escape hatch for the whole fork. Includes an 8-entry LRU
   cache so repeated reads through the synthetic paths don't re-parse the
   fork each time. Tab completion (`src/core/shell/cmd_complete.c`) routes
   through VFS so completion works inside the synthetic tree.

2. **DonnBits (dcmp 0, v8 header)** — `src/core/storage/rsrc_dcmp.{c,h}`.
   Full opcode dispatch (LiteralN, RememberN, ReuseN, jump-table indirect)
   plus the 179-entry constant-word table verbatim from Apple's
   open-sourced sys71src `DeCompressDefProc.a`. Wired into `rfork_lookup`
   so callers see only uncompressed bytes.

3. **GreggyBits (dcmp 2, v9 header)** — second System 7+ decompressor.
   Pair-of-bytes scheme with optional bitmapped runs and the 256-word
   static table verbatim from Apple's `GreggyBitsDefProc.a`.

After this PR, anything that speaks VFS — shell, web2 file browser, future
`re/` orchestrator — can address Mac resources as regular file paths and
get fully-decoded bytes back.

## Test plan

- [x] `make` — host + WASM builds clean
- [x] `make unit-test` — 16 suites pass, including 20 resfork tests
  covering parser correctness, type/id path parsing, compressed-attr
  detection, dcmp 0 round-trip + opcode coverage, dcmp 2 static-table
  non-bitmapped + bitmapped paths
- [x] `make -C tests/integration test-vfs-rsrc` — walks
  `/rsrc/<TYPE>/<id>` and `.info` sidecars on a System 6 floppy; the
  recursive `storage.cp -r` extracts 181 files / 220KB across 19 dirs.
- [ ] Full CI integration suite (will run on PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)