### PR TITLE
storage/vfs: Disk Copy 6.x (NDIF) read/mount + storage.export_raw

### DIFF
--- a/src/core/storage/adc.c
+++ b/src/core/storage/adc.c
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) pappadf
+
+// adc.c
+// Apple Data Compression (ADC) decompressor — see adc.h.
+//
+// The stream is a sequence of tokens.  The top two bits of each tag byte
+// select the token type:
+//   1xxxxxxx  literal run  : len = (tag & 0x7F) + 1, then `len` literal bytes
+//   01xxxxxx  long match   : len = (tag & 0x3F) + 4, offset = BE16(next two)
+//   00xxxxxx  short match  : len = ((tag>>2) & 0x0F) + 3, offset = ((tag&3)<<8)|next
+// For matches the copy source is (out_pos - offset - 1) and the copy is done
+// one byte at a time so overlapping runs (RLE) work.
+
+#include "adc.h"
+
+long adc_decompress(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_cap) {
+    size_t ip = 0;
+    size_t op = 0;
+
+    while (ip < in_len && op < out_cap) {
+        uint8_t tag = in[ip];
+
+        if (tag & 0x80) {
+            // Literal run.
+            size_t len = (size_t)(tag & 0x7F) + 1;
+            ip++;
+            if (len > in_len - ip)
+                len = in_len - ip; // truncated stream: copy what's left
+            if (len > out_cap - op)
+                len = out_cap - op;
+            for (size_t k = 0; k < len; k++)
+                out[op++] = in[ip++];
+        } else if (tag & 0x40) {
+            // Long back-reference (3-byte token).
+            size_t len = (size_t)(tag & 0x3F) + 4;
+            if (in_len - ip < 3)
+                break; // truncated token
+            size_t off = ((size_t)in[ip + 1] << 8) | (size_t)in[ip + 2];
+            ip += 3;
+            if (off + 1 > op)
+                return -1; // reference before start of output
+            size_t src = op - off - 1;
+            for (size_t k = 0; k < len && op < out_cap; k++)
+                out[op++] = out[src++];
+        } else {
+            // Short back-reference (2-byte token).
+            size_t len = (size_t)((tag >> 2) & 0x0F) + 3;
+            if (in_len - ip < 2)
+                break; // truncated token
+            size_t off = ((size_t)(tag & 0x03) << 8) | (size_t)in[ip + 1];
+            ip += 2;
+            if (off + 1 > op)
+                return -1;
+            size_t src = op - off - 1;
+            for (size_t k = 0; k < len && op < out_cap; k++)
+                out[op++] = out[src++];
+        }
+    }
+    return (long)op;
+}

--- a/src/core/storage/adc.h
+++ b/src/core/storage/adc.h
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) pappadf
+
+// adc.h
+// Apple Data Compression (ADC) decompressor.  ADC is the byte-aligned LZ77
+// variant Disk Copy 6.x uses for NDIF (0x83) chunks and that UDIF later
+// reused (chunk type 0x80000004).  Reverse-engineered; matches dmg2img/adc.c
+// and Aaru.  Decode-only (creating ADC streams is out of scope).
+
+#ifndef GS_ADC_H
+#define GS_ADC_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+// Decompress an ADC stream.  Reads up to `in_len` bytes from `in`, writes up
+// to `out_cap` bytes to `out`, stopping when the input is exhausted or the
+// output buffer is full.  Returns the number of output bytes written, or -1
+// on a malformed stream (a back-reference pointing before the start of the
+// decoded output).
+long adc_decompress(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_cap);
+
+#endif // GS_ADC_H

--- a/src/core/storage/image_ndif.c
+++ b/src/core/storage/image_ndif.c
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) pappadf
+
+// image_ndif.c
+// NDIF 'bcem' block-map parser + chunk decoder — see image_ndif.h.
+
+#include "image_ndif.h"
+
+#include "adc.h"
+#include "resource_fork.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define NDIF_SECTOR_SIZE 512u
+// 'bcem' resource, ID 128 (Aaru: NDIF_RESOURCE / NDIF_RESOURCEID).
+#define BCEM_RESOURCE_ID 128
+// Header size preceding the 12-byte chunk-descriptor array.
+#define BCEM_HEADER_SIZE 0x80
+#define BCEM_ENTRY_SIZE  12
+
+// Header field offsets (big-endian), verified against real images.
+#define BCEM_OFF_NAME       0x04 // Str63 (length byte + up to 63 chars)
+#define BCEM_OFF_SECTORS    0x44
+#define BCEM_OFF_DATAOFFSET 0x4C
+#define BCEM_OFF_CRC        0x50
+#define BCEM_OFF_CHUNKS     0x7C
+
+static const uint8_t BCEM_TYPE[4] = {'b', 'c', 'e', 'm'};
+
+static uint32_t rd32(const uint8_t *p) {
+    return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) | ((uint32_t)p[2] << 8) | (uint32_t)p[3];
+}
+
+// Locate the 'bcem' resource bytes in a parsed fork.  Prefers ID 128, then
+// falls back to the first 'bcem' present.  On success returns 0 and sets
+// *bytes (pointing into the caller's `rfork` buffer, which must outlive use)
+// and *size; also returns the parsed rfork_t via *rf_out (caller frees).
+static int locate_bcem(const uint8_t *rfork, size_t rfork_len, const uint8_t **bytes, size_t *size, rfork_t **rf_out) {
+    const char *errmsg = NULL;
+    rfork_t *rf = rfork_parse(rfork, rfork_len, &errmsg);
+    if (!rf)
+        return -EINVAL;
+    const uint8_t *b = NULL;
+    size_t sz = 0;
+    if (rfork_lookup(rf, BCEM_TYPE, BCEM_RESOURCE_ID, &b, &sz, NULL, NULL) < 0) {
+        if (rfork_num_resources(rf, BCEM_TYPE) == 0) {
+            rfork_free(rf);
+            return -ENOENT;
+        }
+        int16_t id = rfork_id_at(rf, BCEM_TYPE, 0);
+        if (rfork_lookup(rf, BCEM_TYPE, id, &b, &sz, NULL, NULL) < 0) {
+            rfork_free(rf);
+            return -ENOENT;
+        }
+    }
+    *bytes = b;
+    *size = sz;
+    *rf_out = rf;
+    return 0;
+}
+
+bool ndif_detect(const uint8_t *rfork, size_t rfork_len) {
+    if (!rfork || rfork_len < 16)
+        return false;
+    const uint8_t *b = NULL;
+    size_t sz = 0;
+    rfork_t *rf = NULL;
+    if (locate_bcem(rfork, rfork_len, &b, &sz, &rf) != 0)
+        return false;
+    bool ok = (sz >= BCEM_HEADER_SIZE);
+    rfork_free(rf);
+    return ok;
+}
+
+int ndif_parse(const uint8_t *rfork, size_t rfork_len, ndif_map_t **out) {
+    if (!rfork || !out)
+        return -EINVAL;
+    *out = NULL;
+
+    const uint8_t *b = NULL;
+    size_t sz = 0;
+    rfork_t *rf = NULL;
+    int rc = locate_bcem(rfork, rfork_len, &b, &sz, &rf);
+    if (rc)
+        return rc;
+    if (sz < BCEM_HEADER_SIZE) {
+        rfork_free(rf);
+        return -EINVAL;
+    }
+
+    uint32_t sectors = rd32(b + BCEM_OFF_SECTORS);
+    uint32_t data_offset = rd32(b + BCEM_OFF_DATAOFFSET);
+    uint32_t crc = rd32(b + BCEM_OFF_CRC);
+    uint32_t n_entries = rd32(b + BCEM_OFF_CHUNKS);
+
+    // Bounds: the descriptor array must fit within the resource.
+    if (n_entries == 0 || (uint64_t)n_entries * BCEM_ENTRY_SIZE > (uint64_t)(sz - BCEM_HEADER_SIZE)) {
+        rfork_free(rf);
+        return -EINVAL;
+    }
+
+    ndif_map_t *m = calloc(1, sizeof(*m));
+    ndif_chunk_t *chunks = calloc(n_entries, sizeof(ndif_chunk_t));
+    if (!m || !chunks) {
+        free(m);
+        free(chunks);
+        rfork_free(rf);
+        return -ENOMEM;
+    }
+
+    m->sectors = sectors;
+    m->crc = crc;
+    uint8_t nlen = b[BCEM_OFF_NAME];
+    if (nlen > 63)
+        nlen = 63;
+    memcpy(m->volume_name, b + BCEM_OFF_NAME + 1, nlen);
+    m->volume_name[nlen] = '\0';
+
+    // Read raw descriptors first; the per-chunk sector count derives from the
+    // next descriptor's starting sector (or the image total for the last one).
+    const uint8_t *arr = b + BCEM_HEADER_SIZE;
+    size_t nc = 0;
+    for (uint32_t i = 0; i < n_entries; i++) {
+        const uint8_t *e = arr + (size_t)i * BCEM_ENTRY_SIZE;
+        uint32_t word = rd32(e);
+        uint8_t type = (uint8_t)(word & 0xFF);
+        if (type == NDIF_CHUNK_END)
+            break;
+        uint32_t sector = word >> 8;
+        uint32_t next_sector = sectors;
+        if (i + 1 < n_entries) {
+            uint32_t nword = rd32(arr + (size_t)(i + 1) * BCEM_ENTRY_SIZE);
+            next_sector = nword >> 8;
+        }
+        chunks[nc].sector = sector;
+        chunks[nc].count = (next_sector > sector) ? (next_sector - sector) : 0;
+        chunks[nc].type = type;
+        chunks[nc].offset = rd32(e + 4) + data_offset;
+        chunks[nc].length = rd32(e + 8);
+        nc++;
+    }
+
+    m->chunks = chunks;
+    m->n_chunks = nc;
+    rfork_free(rf);
+    *out = m;
+    return 0;
+}
+
+void ndif_map_free(ndif_map_t *m) {
+    if (!m)
+        return;
+    free(m->chunks);
+    free(m);
+}
+
+int ndif_decode_chunk(const ndif_chunk_t *chunk, const uint8_t *src, size_t src_len, uint8_t *dst, size_t dst_len) {
+    if (!chunk || !dst)
+        return -EINVAL;
+    size_t need = (size_t)chunk->count * NDIF_SECTOR_SIZE;
+    if (dst_len < need)
+        return -EINVAL;
+
+    switch (chunk->type) {
+    case NDIF_CHUNK_ZERO:
+        memset(dst, 0, need);
+        return 0;
+    case NDIF_CHUNK_COPY:
+        if (!src || src_len < need)
+            return -EINVAL;
+        memcpy(dst, src, need);
+        return 0;
+    case NDIF_CHUNK_ADC: {
+        if (!src)
+            return -EINVAL;
+        long got = adc_decompress(src, src_len, dst, need);
+        if (got < 0)
+            return -EINVAL;
+        // A well-formed chunk decodes to exactly `need` bytes; zero-pad any
+        // short tail defensively so callers always get a full sector run.
+        if ((size_t)got < need)
+            memset(dst + got, 0, need - (size_t)got);
+        return 0;
+    }
+    default:
+        return -EINVAL; // KenCode / RLE / LZH / StuffIt not implemented
+    }
+}

--- a/src/core/storage/image_ndif.h
+++ b/src/core/storage/image_ndif.h
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) pappadf
+
+// image_ndif.h
+// Parser for the Disk Copy 6.x / NDIF (New Disk Image Format) block map.
+//
+// An NDIF image is a dual-fork Mac file: the data fork holds the payload
+// chunks and the resource fork holds a 'bcem' resource (ID 128) describing
+// how to reassemble them.  This module parses that 'bcem' block map and
+// decodes individual chunks (zero-fill / raw / ADC).  It does NOT know how
+// the two forks are obtained — the caller supplies the resource-fork bytes
+// (from the containing HFS volume's resource fork, an AppleDouble sidecar,
+// etc.) and reads the data-fork slices.
+//
+// On-disk layout (big-endian), verified against real Disk Copy 6.3.3 images
+// and cross-checked with Aaru's Aaru.Images/NDIF Structs.cs / Constants.cs.
+// NB: this is the classic NDIF 'bcem' — a 128-byte header + 12-byte chunk
+// descriptors with 8-bit type codes — NOT UDIF's 40-byte 'mish' entries.
+
+#ifndef GS_IMAGE_NDIF_H
+#define GS_IMAGE_NDIF_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// NDIF chunk type codes (low byte of the descriptor's first word).
+#define NDIF_CHUNK_ZERO    0x00 // zero-fill; no data-fork bytes
+#define NDIF_CHUNK_COPY    0x02 // raw / uncompressed copy
+#define NDIF_CHUNK_KENCODE 0x80 // KenCode (unsupported)
+#define NDIF_CHUNK_RLE     0x81 // RLE (unsupported)
+#define NDIF_CHUNK_LZH     0x82 // LZH (unsupported)
+#define NDIF_CHUNK_ADC     0x83 // Apple Data Compression
+#define NDIF_CHUNK_STUFFIT 0xF0 // StuffIt (unsupported)
+#define NDIF_CHUNK_END     0xFF // terminator
+
+// One decoded chunk descriptor.
+typedef struct {
+    uint32_t sector; // starting logical sector (512-byte units)
+    uint32_t count; // number of logical sectors this chunk covers
+    uint8_t type; // NDIF_CHUNK_*
+    uint32_t offset; // byte offset of stored data in the data fork (incl. data_offset)
+    uint32_t length; // stored byte length in the data fork (0 for zero-fill)
+} ndif_chunk_t;
+
+// Parsed block map.  Free with ndif_map_free().
+typedef struct {
+    uint32_t sectors; // total logical sectors of the decoded image
+    uint32_t crc; // "CRC28" (== CRC-32) of the decoded image, informational
+    char volume_name[64]; // image name from the 'bcem' header (MacRoman bytes)
+    size_t n_chunks; // usable chunks (END terminator dropped)
+    ndif_chunk_t *chunks; // n_chunks entries
+} ndif_map_t;
+
+// True if `rfork`/`rfork_len` is a resource fork carrying an NDIF 'bcem'
+// block map (used for format detection).
+bool ndif_detect(const uint8_t *rfork, size_t rfork_len);
+
+// Parse the 'bcem' block map from a resource fork.  Returns 0 and sets *out
+// (caller frees via ndif_map_free) on success, or a negative errno.
+int ndif_parse(const uint8_t *rfork, size_t rfork_len, ndif_map_t **out);
+
+void ndif_map_free(ndif_map_t *m);
+
+// Decode one chunk: `src`/`src_len` are the stored data-fork bytes for the
+// chunk, `dst`/`dst_len` the output (must be >= chunk->count*512).  Handles
+// ZERO, COPY, and ADC; returns -EINVAL for unsupported types or a decode
+// error.  Returns 0 on success.
+int ndif_decode_chunk(const ndif_chunk_t *chunk, const uint8_t *src, size_t src_len, uint8_t *dst, size_t dst_len);
+
+#endif // GS_IMAGE_NDIF_H

--- a/src/core/storage/storage_class.c
+++ b/src/core/storage/storage_class.c
@@ -295,6 +295,25 @@ static value_t storage_method_cp(struct object *self, const member_t *m, int arg
     return val_bool(true);
 }
 
+// `storage.export_raw(src, dst)` — write a disk image referenced by a VFS
+// path (a host raw/DC42 image, or an image nested inside a mounted image such
+// as an NDIF `.img` in a Toast CD) as a flat, decoded RAW image on the host.
+// Unlike `cp` — which copies a file's data fork verbatim (for an NDIF `.img`
+// that is the still-compressed data fork) — this decodes the image and emits
+// its logical block device, ready to re-mount or `dd`.  Refuses to overwrite.
+static value_t storage_method_export_raw(struct object *self, const member_t *m, int argc, const value_t *argv) {
+    (void)self;
+    (void)m;
+    (void)argc;
+    const char *src = argv[0].s;
+    const char *dst = argv[1].s;
+    char err[256] = {0};
+    int rc = vfs_export_raw_image(src, dst, err, sizeof(err));
+    if (rc < 0)
+        return val_err("%s", err[0] ? err : "storage.export_raw: failed");
+    return val_bool(true);
+}
+
 // `storage.find_media(dir, [dst])` — search a directory for a recognised
 // floppy image; if `dst` is given, the image is copied there.
 static value_t storage_method_find_media(struct object *self, const member_t *m, int argc, const value_t *argv) {
@@ -654,6 +673,10 @@ static const arg_decl_t storage_cp_args[] = {
     {.name = "dst", .kind = V_STRING, .doc = "Destination path"},
     {.name = "flag", .kind = V_STRING, .validation_flags = OBJ_ARG_OPTIONAL, .doc = "Optional -r / -R for recursive"},
 };
+static const arg_decl_t storage_export_raw_args[] = {
+    {.name = "src", .kind = V_STRING, .doc = "Source image path (host, or nested inside a mounted image)"},
+    {.name = "dst", .kind = V_STRING, .doc = "Destination host path for the decoded raw image"           },
+};
 static const arg_decl_t storage_find_media_args[] = {
     {.name = "dir", .kind = V_STRING, .doc = "Directory to scan"},
     {.name = "dst", .kind = V_STRING, .validation_flags = OBJ_ARG_OPTIONAL, .doc = "Optional path to copy match into"},
@@ -703,6 +726,10 @@ static const member_t storage_members[] = {
      .name = "cp",
      .doc = "Copy a host or VFS path to another VFS path",
      .method = {.args = storage_cp_args, .nargs = 3, .result = V_BOOL, .fn = storage_method_cp}                  },
+    {.kind = M_METHOD,
+     .name = "export_raw",
+     .doc = "Decode a disk image (incl. NDIF nested in a mounted image) to a flat raw image on the host",
+     .method = {.args = storage_export_raw_args, .nargs = 2, .result = V_BOOL, .fn = storage_method_export_raw}  },
     {.kind = M_METHOD,
      .name = "find_media",
      .doc = "Find a recognised floppy/disk image in a directory",

--- a/src/core/vfs/image_vfs.c
+++ b/src/core/vfs/image_vfs.c
@@ -16,6 +16,7 @@
 #include "image.h"
 #include "image_apm.h"
 #include "image_hfs.h"
+#include "image_ndif.h"
 #include "image_ufs.h"
 #include "resource_fork.h"
 
@@ -28,6 +29,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <unistd.h>
 
 // ---- Mount table ----------------------------------------------------------
 
@@ -1361,6 +1363,220 @@ static int img_readonly2(void *ctx, const char *a, const char *b) {
     (void)a;
     (void)b;
     return -EROFS;
+}
+
+// ---- Nested-image materialisation ----------------------------------------
+//
+// The auto-mount path (image_vfs_acquire_mount) opens a *host* file.  To let
+// the VFS descend into a disk image that itself lives inside another mounted
+// image (e.g. a Disk Copy 6.x / NDIF .img inside a Toast CD), we decode that
+// inner file to a host scratch file and mount that scratch normally.  NDIF
+// images are decoded here (bcem block map + ADC); any other nested file is
+// copied verbatim so a nested raw / Disk Copy 4.2 image mounts too.
+
+#define NESTED_SCRATCH_DIR "/tmp/gs-image-ro/nested"
+
+static int mkdir_p_nested(const char *path) {
+    char tmp[PATH_MAX];
+    int n = snprintf(tmp, sizeof(tmp), "%s", path);
+    if (n < 0 || (size_t)n >= sizeof(tmp))
+        return -1;
+    for (char *p = tmp + 1; *p; p++) {
+        if (*p == '/') {
+            *p = '\0';
+            if (mkdir(tmp, 0777) != 0 && errno != EEXIST)
+                return -1;
+            *p = '/';
+        }
+    }
+    if (mkdir(tmp, 0777) != 0 && errno != EEXIST)
+        return -1;
+    return 0;
+}
+
+static uint32_t fnv1a_update(const void *data, size_t n, uint32_t h) {
+    const uint8_t *p = (const uint8_t *)data;
+    for (size_t i = 0; i < n; i++) {
+        h ^= p[i];
+        h *= 0x01000193u;
+    }
+    return h;
+}
+
+// Read an entire in-image file (given its in-image subpath) into a malloc'd
+// buffer.  Returns 0 and sets *out_buf/*out_len (empty file → NULL/0), or a
+// negative errno.  Caller frees *out_buf.
+static int read_in_image_file(image_mount_t *m, const char *subpath, uint8_t **out_buf, size_t *out_len) {
+    *out_buf = NULL;
+    *out_len = 0;
+    vfs_stat_t st;
+    int rc = img_stat(m, subpath, &st);
+    if (rc)
+        return rc;
+    if (!(st.mode & VFS_MODE_FILE))
+        return -EINVAL;
+    size_t sz = (size_t)st.size;
+    if (sz == 0)
+        return 0;
+    uint8_t *buf = malloc(sz);
+    if (!buf)
+        return -ENOMEM;
+    vfs_file_t *f = NULL;
+    rc = img_open(m, subpath, &f);
+    if (rc) {
+        free(buf);
+        return rc;
+    }
+    size_t off = 0;
+    while (off < sz) {
+        size_t got = 0;
+        int r = img_read(f, off, buf + off, sz - off, &got);
+        if (r || got == 0) {
+            img_close(f);
+            free(buf);
+            return r ? r : -EIO;
+        }
+        off += got;
+    }
+    img_close(f);
+    *out_buf = buf;
+    *out_len = sz;
+    return 0;
+}
+
+// Decode an NDIF file (data fork `df` open on the inner file, block map
+// `map`) into the already-sized scratch file `out`.  Returns true on success.
+static bool write_ndif_to_scratch(image_mount_t *m, const char *file_subpath, ndif_map_t *map, FILE *out) {
+    if (ftruncate(fileno(out), (off_t)map->sectors * 512) != 0)
+        return false;
+    vfs_file_t *df = NULL;
+    if (img_open(m, file_subpath, &df) != 0)
+        return false;
+    bool ok = true;
+    for (size_t i = 0; i < map->n_chunks && ok; i++) {
+        ndif_chunk_t *c = &map->chunks[i];
+        if (c->type == NDIF_CHUNK_ZERO || c->count == 0)
+            continue; // ftruncate already zero-filled the gap
+        size_t need = (size_t)c->count * 512;
+        uint8_t *dbuf = malloc(need);
+        uint8_t *cbuf = c->length ? malloc(c->length) : NULL;
+        if (!dbuf || (c->length && !cbuf)) {
+            free(dbuf);
+            free(cbuf);
+            ok = false;
+            break;
+        }
+        size_t clen = 0;
+        if (c->length) {
+            size_t off = 0;
+            while (off < c->length) {
+                size_t got = 0;
+                if (img_read(df, c->offset + off, cbuf + off, c->length - off, &got) != 0 || got == 0) {
+                    ok = false;
+                    break;
+                }
+                off += got;
+            }
+            clen = off;
+        }
+        if (ok && ndif_decode_chunk(c, cbuf, clen, dbuf, need) == 0) {
+            if (fseek(out, (long)c->sector * 512, SEEK_SET) != 0 || fwrite(dbuf, 1, need, out) != need)
+                ok = false;
+        } else {
+            ok = false;
+        }
+        free(dbuf);
+        free(cbuf);
+    }
+    img_close(df);
+    return ok;
+}
+
+// Copy the data fork of an inner (non-NDIF) file verbatim to the scratch
+// file — handles a nested raw or Disk Copy 4.2 image.
+static bool copy_fork_to_scratch(image_mount_t *m, const char *file_subpath, uint64_t size, FILE *out) {
+    vfs_file_t *df = NULL;
+    if (img_open(m, file_subpath, &df) != 0)
+        return false;
+    bool ok = true;
+    uint8_t buf[65536];
+    uint64_t off = 0;
+    while (off < size) {
+        size_t want = (size - off > sizeof(buf)) ? sizeof(buf) : (size_t)(size - off);
+        size_t got = 0;
+        if (img_read(df, off, buf, want, &got) != 0 || got == 0) {
+            ok = false;
+            break;
+        }
+        if (fwrite(buf, 1, got, out) != got) {
+            ok = false;
+            break;
+        }
+        off += got;
+    }
+    img_close(df);
+    return ok;
+}
+
+char *image_vfs_materialize_nested(image_mount_t *m, const char *file_subpath) {
+    if (!m || !file_subpath)
+        return NULL;
+    vfs_stat_t st;
+    if (img_stat(m, file_subpath, &st) != 0 || !(st.mode & VFS_MODE_FILE))
+        return NULL;
+
+    // Deterministic scratch name from the outer file identity + subpath +
+    // mtime, so repeated descents reuse the same decoded file (and its cached
+    // mount) and a changed outer file re-decodes.
+    uint32_t h = 0x811c9dc5u;
+    if (m->host_path)
+        h = fnv1a_update(m->host_path, strlen(m->host_path), h);
+    h = fnv1a_update("\x1f", 1, h);
+    h = fnv1a_update(file_subpath, strlen(file_subpath), h);
+    uint32_t h2 = fnv1a_update(&m->mtime, sizeof(m->mtime), h);
+    char scratch[PATH_MAX];
+    if (snprintf(scratch, sizeof(scratch), "%s/%08x%08x.img", NESTED_SCRATCH_DIR, h, h2) >= (int)sizeof(scratch))
+        return NULL;
+
+    struct stat sb;
+    if (stat(scratch, &sb) == 0 && sb.st_size > 0)
+        return strdup(scratch); // already materialised
+
+    if (mkdir_p_nested(NESTED_SCRATCH_DIR) != 0)
+        return NULL;
+
+    // Read the inner file's resource fork (for NDIF detection).  Best-effort:
+    // a non-NDIF nested image simply has no bcem and is copied verbatim.
+    char rsrc_path[VFS_PATH_MAX];
+    uint8_t *rbuf = NULL;
+    size_t rlen = 0;
+    if (snprintf(rsrc_path, sizeof(rsrc_path), "%s/rsrc/_raw", file_subpath) < (int)sizeof(rsrc_path))
+        read_in_image_file(m, rsrc_path, &rbuf, &rlen);
+
+    FILE *out = fopen(scratch, "wb");
+    if (!out) {
+        free(rbuf);
+        return NULL;
+    }
+
+    bool ok = false;
+    if (rbuf && ndif_detect(rbuf, rlen)) {
+        ndif_map_t *map = NULL;
+        if (ndif_parse(rbuf, rlen, &map) == 0) {
+            ok = write_ndif_to_scratch(m, file_subpath, map, out);
+            ndif_map_free(map);
+        }
+    } else {
+        ok = copy_fork_to_scratch(m, file_subpath, st.size, out);
+    }
+
+    fclose(out);
+    free(rbuf);
+    if (!ok) {
+        remove(scratch);
+        return NULL;
+    }
+    return strdup(scratch);
 }
 
 static const vfs_backend_t image_backend = {

--- a/src/core/vfs/image_vfs.h
+++ b/src/core/vfs/image_vfs.h
@@ -44,6 +44,16 @@ int image_vfs_acquire_mount(const char *host_path, image_mount_t **out_mount);
 // dropped, -ENOENT if no match.
 int image_vfs_unmount(const char *host_path);
 
+// Materialise a disk image that lives *inside* an already-mounted image
+// (`m`) to a host scratch file, so it can be mounted via
+// image_vfs_acquire_mount().  `in_image_file_path` is the inner file's
+// in-image path (e.g. "/partition2/Foo/Bar.img").  Disk Copy 6.x / NDIF
+// images are decoded (bcem + ADC); other files are copied verbatim (nested
+// raw / Disk Copy 4.2).  Returns a malloc'd host path (caller frees) or NULL
+// if the file could not be decoded/extracted.  The scratch name is
+// deterministic, so repeated calls reuse the same file.
+char *image_vfs_materialize_nested(image_mount_t *m, const char *in_image_file_path);
+
 // Iteration over the current cache, for `image list`.  `cb` is called
 // once per live mount; return non-zero to stop early.
 typedef void (*image_vfs_list_cb)(const char *host_path, const char *format_name, uint32_t n_partitions,

--- a/src/core/vfs/vfs.c
+++ b/src/core/vfs/vfs.c
@@ -11,6 +11,7 @@
 
 #include "vfs.h"
 
+#include "image.h"
 #include "image_vfs.h"
 
 #include <errno.h>
@@ -409,6 +410,69 @@ int vfs_rename(const char *src, const char *dst) {
     if (!src_be->rename)
         return -EROFS;
     return src_be->rename(src_ctx, src_tail, dst_tail);
+}
+
+static void set_err(char *err, size_t cap, const char *msg) {
+    if (err && cap)
+        snprintf(err, cap, "%s", msg);
+}
+
+int vfs_export_raw_image(const char *src, const char *dst, char *err, size_t err_cap) {
+    if (!src || !dst) {
+        set_err(err, err_cap, "export_raw: missing src/dst");
+        return -EINVAL;
+    }
+
+    char resolved[VFS_PATH_MAX];
+    const vfs_backend_t *be = NULL;
+    void *ctx = NULL;
+    const char *tail = NULL;
+    // Strict resolve (not descend): a bare image path stays a "file" so a
+    // nested `.img` resolves to (image backend, outer mount, in-image tail)
+    // rather than descending into its partition list.
+    int rc = vfs_resolve(src, resolved, sizeof(resolved), &be, &ctx, &tail);
+    if (rc) {
+        set_err(err, err_cap, "export_raw: cannot resolve source path");
+        return rc;
+    }
+
+    // The host image path we ultimately open read-only and flatten to raw.
+    // For a nested image we first decode it to a scratch file.
+    const char *host_image_path = resolved;
+    char *scratch = NULL;
+
+    if (be == vfs_image_backend() && ctx) {
+        // Source lives inside a mounted image; `tail` is its in-image path.
+        vfs_stat_t st;
+        if (be->stat(ctx, tail, &st) != 0 || !(st.mode & VFS_MODE_FILE)) {
+            set_err(err, err_cap, "export_raw: source is not a file inside the image");
+            return -ENOENT;
+        }
+        scratch = image_vfs_materialize_nested((image_mount_t *)ctx, tail);
+        if (!scratch) {
+            set_err(err, err_cap, "export_raw: could not decode/extract the nested image");
+            return -EIO;
+        }
+        host_image_path = scratch;
+    }
+
+    // Open the (decoded) image read-only and flatten its logical media to a
+    // new raw file.  image_export_to refuses to overwrite and creates parent
+    // directories.
+    image_t *img = image_open_readonly(host_image_path);
+    if (!img) {
+        free(scratch);
+        set_err(err, err_cap, "export_raw: source is not a recognised disk image");
+        return -EIO;
+    }
+    int erc = image_export_to(img, dst);
+    image_close(img);
+    free(scratch);
+    if (erc != 0) {
+        set_err(err, err_cap, "export_raw: write failed (destination exists or not writable)");
+        return -EIO;
+    }
+    return 0;
 }
 
 const char *vfs_get_cwd(void) {

--- a/src/core/vfs/vfs.c
+++ b/src/core/vfs/vfs.c
@@ -15,6 +15,7 @@
 
 #include <errno.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 
@@ -145,6 +146,72 @@ static image_mount_t *walk_for_descent(const char *resolved, size_t *out_prefix_
     return NULL;
 }
 
+// True if any '/'-separated component of the in-image path `tail` (which
+// starts with '/') is a synthetic fork keyword ("rsrc" or "finf").  Such
+// paths address the *outer* file's forks, not a nested image, so nested
+// descent must skip them.
+static bool tail_has_fork_component(const char *tail) {
+    const char *p = tail;
+    while (*p) {
+        while (*p == '/')
+            p++;
+        const char *start = p;
+        while (*p && *p != '/')
+            p++;
+        size_t len = (size_t)(p - start);
+        if ((len == 4 && strncmp(start, "rsrc", 4) == 0) || (len == 4 && strncmp(start, "finf", 4) == 0))
+            return true;
+    }
+    return false;
+}
+
+// True if the FIRST component of `rem` (which starts with '/') is a synthetic
+// fork keyword — i.e. `rem` addresses the just-matched file's own fork rather
+// than descending into it as a nested image.  Deeper "rsrc"/"finf" belong to
+// files *inside* a nested image and must not disqualify the descent.
+static bool first_component_is_fork(const char *rem) {
+    const char *p = rem;
+    while (*p == '/')
+        p++;
+    const char *start = p;
+    while (*p && *p != '/')
+        p++;
+    size_t len = (size_t)(p - start);
+    return len == 4 && (strncmp(start, "rsrc", 4) == 0 || strncmp(start, "finf", 4) == 0);
+}
+
+// Given an outer image mount `m` and its in-image tail (starting with '/'),
+// find whether the tail descends through a nested image FILE.  On success
+// returns true, sets *split to the byte length within `tail` of that file's
+// subpath, and *rem to `tail + split` (the remaining in-image path of the
+// nested image, starting with '/').  Fork-suffix tails are left to the image
+// backend and do not count as nested descent.
+static bool find_nested_split(image_mount_t *m, const char *tail, size_t *split, const char **rem) {
+    const vfs_backend_t *ib = vfs_image_backend();
+    size_t len = strlen(tail);
+    for (size_t j = 1; j < len; j++) {
+        if (tail[j] != '/')
+            continue;
+        char tmp[VFS_PATH_MAX];
+        if (j >= sizeof(tmp))
+            return false;
+        memcpy(tmp, tail, j);
+        tmp[j] = '\0';
+        vfs_stat_t st;
+        if (ib->stat(m, tmp, &st) != 0)
+            continue; // not resolvable at this prefix; keep walking
+        if (st.mode & VFS_MODE_FILE) {
+            const char *r = tail + j; // remaining path, starts with '/'
+            if (first_component_is_fork(r))
+                return false; // this file's own fork access, not a nested image
+            *split = j;
+            *rem = r;
+            return true;
+        }
+    }
+    return false;
+}
+
 // Shared body for vfs_resolve / vfs_resolve_descend.  `descend_bare`
 // controls the "ls/cd bare image path" rule.
 static int resolve_impl(const char *input, char *resolved, size_t resolved_len, const vfs_backend_t **be, void **ctx,
@@ -173,6 +240,54 @@ static int resolve_impl(const char *input, char *resolved, size_t resolved_len, 
                 prefix_len = strlen(resolved);
             } else if (pr == -EBUSY) {
                 return -EBUSY;
+            }
+        }
+    }
+
+    // Nested-image descent: the in-image tail may itself point through a
+    // disk image FILE (e.g. an NDIF .img inside a Toast CD).  For each such
+    // level, materialise the inner image to a host scratch file, mount it,
+    // and continue with the remaining in-image tail (a substring of
+    // `resolved`, so no reallocation is needed).  Bounded to avoid loops.
+    for (int depth = 0; mount && depth < 8; depth++) {
+        const char *ntail = resolved + prefix_len;
+        size_t split = 0;
+        const char *rem = NULL;
+        if (!find_nested_split(mount, ntail, &split, &rem))
+            break;
+        char sub[VFS_PATH_MAX];
+        if (split >= sizeof(sub))
+            break;
+        memcpy(sub, ntail, split);
+        sub[split] = '\0';
+        char *scratch = image_vfs_materialize_nested(mount, sub);
+        if (!scratch)
+            return -EIO; // inner image present but undecodable
+        image_mount_t *nested = NULL;
+        int pr = image_vfs_acquire_mount(scratch, &nested);
+        free(scratch);
+        if (pr != 0)
+            return (pr == -ENOTDIR || pr == -ENOENT) ? -ENOTDIR : pr;
+        mount = nested;
+        prefix_len = (size_t)(rem - resolved);
+    }
+
+    // Bare nested image (ls/cd on the inner .img itself): descend so the
+    // partition list is shown, mirroring the top-level bare-image rule.
+    if (mount && descend_bare) {
+        const char *ntail = resolved + prefix_len;
+        if (ntail[0] == '/' && ntail[1] && !tail_has_fork_component(ntail)) {
+            vfs_stat_t st;
+            if (vfs_image_backend()->stat(mount, ntail, &st) == 0 && (st.mode & VFS_MODE_FILE)) {
+                char *scratch = image_vfs_materialize_nested(mount, ntail);
+                if (scratch) {
+                    image_mount_t *nested = NULL;
+                    if (image_vfs_acquire_mount(scratch, &nested) == 0) {
+                        mount = nested;
+                        prefix_len = strlen(resolved);
+                    }
+                    free(scratch);
+                }
             }
         }
     }

--- a/src/core/vfs/vfs.h
+++ b/src/core/vfs/vfs.h
@@ -104,6 +104,16 @@ int vfs_mkdir(const char *path);
 int vfs_unlink(const char *path);
 int vfs_rename(const char *src, const char *dst);
 
+// Export a disk image referenced by a VFS path as a flat **raw** image on
+// the host.  `src` may be a plain host image (raw / Disk Copy 4.2) or a disk
+// image nested inside a mounted image (e.g. an NDIF `.img` inside a Toast CD);
+// in the latter case it is decoded first (NDIF bcem/ADC → raw).  The result
+// is the decoded logical block device — single-fork, portable, directly
+// re-mountable.  Refuses to overwrite an existing `dst`.  Returns 0 on
+// success or a negated errno; on failure `err`/`err_cap` (optional) receives
+// a human-readable message.
+int vfs_export_raw_image(const char *src, const char *dst, char *err, size_t err_cap);
+
 // current_dir accessor + setter (backed by the shell's existing static).
 // Today the cwd is a host path string; an image-rooted cwd would need
 // extending this with the resolver's auto-mount state.

--- a/tests/integration/image-export-raw/config.mk
+++ b/tests/integration/image-export-raw/config.mk
@@ -1,0 +1,9 @@
+# Integration test: storage.export_raw flattens a disk image to a raw file.
+# The NDIF bcem/ADC decode path is covered by the `ndif` unit suite; this
+# exercises the export plumbing (VFS resolve -> image_open -> flatten to raw)
+# and round-trips the result back through the VFS to prove it re-mounts.
+
+TEST_NAME := storage.export_raw
+TEST_DESC := Export a disk image to a flat raw file and re-mount it via the VFS
+
+TEST_ROM := roms/SE30.rom

--- a/tests/integration/image-export-raw/test.script
+++ b/tests/integration/image-export-raw/test.script
@@ -1,0 +1,22 @@
+# Integration test: storage.export_raw decodes a disk image to a flat, raw,
+# single-fork image on the host.  Uses a raw bare-HFS floppy; the NDIF
+# bcem/ADC decode path is covered by the `ndif` unit suite.  The runner cd's
+# into this directory, so image paths are relative and WORK_DIR is absolute.
+
+# Export the source floppy to a flat raw image.
+assert ${storage.export_raw("../../data/systems/System_6_0_8.dsk", "${WORK_DIR}/exported.img")} "export_raw returned false"
+
+# The exported file exists on the host and is the decoded logical size
+# (raw 800 KB floppy = 819200 bytes).
+assert ${storage.path_exists("${WORK_DIR}/exported.img")} "exported image missing on host"
+assert ${storage.path_size("${WORK_DIR}/exported.img") == 819200} "exported image wrong size"
+
+# Round-trip: the exported raw image re-mounts as a bare HFS volume and its
+# root directory lists entries (same opendir/readdir path as the source).
+storage.probe ${WORK_DIR}/exported.img
+assert ${vfs.list("${WORK_DIR}/exported.img/partition1")} "exported raw image did not re-mount as HFS"
+
+# Sanity: the source still lists too (no state clobbered by the export).
+assert ${vfs.list("../../data/systems/System_6_0_8.dsk/partition1")} "source listing empty after export"
+
+quit

--- a/tests/unit/suites/ndif/Makefile
+++ b/tests/unit/suites/ndif/Makefile
@@ -1,0 +1,9 @@
+TEST_NAME := ndif
+TEST_SRCS := test.c
+TEST_HARNESS := isolated
+EXTRA_SRCS := ../../../../src/core/storage/adc.c \
+              ../../../../src/core/storage/image_ndif.c \
+              ../../../../src/core/storage/resource_fork.c \
+              ../../../../src/core/storage/macroman.c \
+              ../../../../src/core/storage/rsrc_dcmp.c
+include ../../common.mk

--- a/tests/unit/suites/ndif/test.c
+++ b/tests/unit/suites/ndif/test.c
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) pappadf
+
+// Unit tests for the Disk Copy 6.x / NDIF decoder: the ADC decompressor
+// (src/core/storage/adc.c) and the 'bcem' block-map parser + chunk decoder
+// (src/core/storage/image_ndif.c).  The 'bcem' layout is built by hand here
+// so the tests are self-contained (no external image fixtures); the byte
+// layout matches real Disk Copy 6.3.3 images and Aaru's NDIF Structs.cs.
+
+#include "adc.h"
+#include "image_ndif.h"
+#include "resource_fork.h"
+#include "test_assert.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void w_u16(uint8_t *p, uint16_t v) {
+    p[0] = (uint8_t)(v >> 8);
+    p[1] = (uint8_t)v;
+}
+static void w_u32(uint8_t *p, uint32_t v) {
+    p[0] = (uint8_t)(v >> 24);
+    p[1] = (uint8_t)(v >> 16);
+    p[2] = (uint8_t)(v >> 8);
+    p[3] = (uint8_t)v;
+}
+
+// ---- ADC decompressor ------------------------------------------------------
+
+TEST(adc_literal_run) {
+    // 0x82 = 0x80 | 2 -> literal run of length 3, then 3 literal bytes.
+    uint8_t in[] = {0x82, 'A', 'B', 'C'};
+    uint8_t out[8] = {0};
+    long n = adc_decompress(in, sizeof(in), out, sizeof(out));
+    ASSERT_EQ_INT(3, (int)n);
+    ASSERT_EQ_INT(0, memcmp(out, "ABC", 3));
+}
+
+TEST(adc_short_match_rle) {
+    // literal 'A', then a short match len=3 off=0 -> repeats the last byte
+    // (overlapping copy = RLE) producing "AAAA".
+    uint8_t in[] = {0x80, 'A', 0x00, 0x00};
+    uint8_t out[8] = {0};
+    long n = adc_decompress(in, sizeof(in), out, sizeof(out));
+    ASSERT_EQ_INT(4, (int)n);
+    ASSERT_EQ_INT(0, memcmp(out, "AAAA", 4));
+}
+
+TEST(adc_long_match) {
+    // literal "ABCD", then a long match len=4 off=3 copies from the start ->
+    // "ABCDABCD".
+    uint8_t in[] = {0x83, 'A', 'B', 'C', 'D', 0x40, 0x00, 0x03};
+    uint8_t out[16] = {0};
+    long n = adc_decompress(in, sizeof(in), out, sizeof(out));
+    ASSERT_EQ_INT(8, (int)n);
+    ASSERT_EQ_INT(0, memcmp(out, "ABCDABCD", 8));
+}
+
+TEST(adc_backref_before_start_is_error) {
+    // A short match as the very first token references before the output
+    // start -> must fail rather than read out of bounds.
+    uint8_t in[] = {0x00, 0x00};
+    uint8_t out[8] = {0};
+    long n = adc_decompress(in, sizeof(in), out, sizeof(out));
+    ASSERT_EQ_INT(-1, (int)n);
+}
+
+TEST(adc_respects_out_cap) {
+    // A long RLE run clamped by a small output buffer stops at out_cap.
+    uint8_t in[] = {0x80, 'Z', 0x7F, 0x00, 0x00}; // literal Z + long match len 67
+    uint8_t out[5] = {0};
+    long n = adc_decompress(in, sizeof(in), out, sizeof(out));
+    ASSERT_EQ_INT(5, (int)n);
+    ASSERT_EQ_INT(0, memcmp(out, "ZZZZZ", 5));
+}
+
+// Build an ADC stream that decodes to `n` copies of byte `v` into `out`
+// (assumed large enough).  Returns the encoded length.
+static size_t adc_fill(uint8_t *out, uint8_t v, size_t n) {
+    size_t o = 0, produced = 0;
+    out[o++] = 0x80; // literal run length 1
+    out[o++] = v;
+    produced = 1;
+    while (produced < n) {
+        size_t remain = n - produced;
+        if (remain >= 4) {
+            size_t len = remain > 67 ? 67 : remain;
+            out[o++] = (uint8_t)(0x40 | (len - 4)); // long match, off=0
+            out[o++] = 0;
+            out[o++] = 0;
+            produced += len;
+        } else {
+            size_t len = remain; // 1..3 -> short match (min len 3) or literal
+            if (len >= 3) {
+                out[o++] = (uint8_t)(((len - 3) << 2) | 0);
+                out[o++] = 0;
+            } else {
+                out[o++] = (uint8_t)(0x80 | (len - 1));
+                for (size_t k = 0; k < len; k++)
+                    out[o++] = v;
+            }
+            produced += len;
+        }
+    }
+    return o;
+}
+
+// ---- 'bcem' block-map builders --------------------------------------------
+
+// Build a 'bcem' body: 128-byte header + `n` 12-byte descriptors.
+static uint8_t *build_bcem(uint32_t sectors, uint32_t crc, const char *name, const uint32_t *words,
+                           const uint32_t *offs, const uint32_t *lens, uint32_t n, size_t *out_len) {
+    size_t len = 128 + (size_t)n * 12;
+    uint8_t *b = calloc(1, len);
+    w_u16(b + 0x00, 11); // version
+    w_u16(b + 0x02, 0); // driver (HFS)
+    size_t nl = strlen(name);
+    if (nl > 63)
+        nl = 63;
+    b[0x04] = (uint8_t)nl;
+    memcpy(b + 0x05, name, nl);
+    w_u32(b + 0x44, sectors);
+    w_u32(b + 0x48, 128); // maxSectorsPerChunk
+    w_u32(b + 0x4C, 0); // dataOffset
+    w_u32(b + 0x50, crc);
+    w_u32(b + 0x7C, n); // chunk count
+    for (uint32_t i = 0; i < n; i++) {
+        uint8_t *e = b + 128 + (size_t)i * 12;
+        w_u32(e + 0, words[i]);
+        w_u32(e + 4, offs[i]);
+        w_u32(e + 8, lens[i]);
+    }
+    *out_len = len;
+    return b;
+}
+
+// Wrap a 'bcem' body in a minimal resource fork (single resource, id 128).
+static uint8_t *build_bcem_fork(const uint8_t *bcem, size_t bcem_len, size_t *out_len) {
+    size_t data_area = 4 + bcem_len;
+    size_t map_area = 50; // 28-byte preamble + 2 + 8 (one type) + 12 (one ref)
+    size_t fork_len = 16 + data_area + map_area;
+    uint8_t *buf = calloc(1, fork_len);
+    uint32_t data_off = 16;
+    uint32_t map_off = (uint32_t)(16 + data_area);
+    w_u32(buf + 0, data_off);
+    w_u32(buf + 4, map_off);
+    w_u32(buf + 8, (uint32_t)data_area);
+    w_u32(buf + 12, (uint32_t)map_area);
+    // Data record: 4-byte length prefix + body.
+    w_u32(buf + data_off, (uint32_t)bcem_len);
+    memcpy(buf + data_off + 4, bcem, bcem_len);
+    // Map area.
+    uint8_t *map = buf + map_off;
+    uint16_t tlo = 28; // type-list offset
+    uint16_t ref_start = (uint16_t)(tlo + 2 + 8);
+    uint16_t nlo = (uint16_t)(ref_start + 12);
+    w_u16(map + 24, tlo);
+    w_u16(map + 26, nlo);
+    w_u16(map + tlo, 0); // num types - 1 = 0
+    uint8_t *te = map + tlo + 2;
+    te[0] = 'b';
+    te[1] = 'c';
+    te[2] = 'e';
+    te[3] = 'm';
+    w_u16(te + 4, 0); // count - 1 = 0
+    w_u16(te + 6, (uint16_t)(ref_start - tlo));
+    uint8_t *re = map + ref_start;
+    w_u16(re, 128); // resource id
+    re[2] = 0xFF; // name offset -1 high byte
+    re[3] = 0xFF;
+    re[4] = 0; // attrs
+    re[5] = re[6] = re[7] = 0; // data offset 0
+    *out_len = fork_len;
+    return buf;
+}
+
+// ---- 'bcem' parse + chunk decode ------------------------------------------
+
+TEST(ndif_detect_and_parse) {
+    // Two chunks: sector 0 = COPY (1 sector), sector 1 = ZERO (1 sector),
+    // plus the END terminator at sector 2.  sectors = 2.
+    uint32_t words[] = {(0u << 8) | NDIF_CHUNK_COPY, (1u << 8) | NDIF_CHUNK_ZERO, (2u << 8) | NDIF_CHUNK_END};
+    uint32_t offs[] = {0, 512, 0};
+    uint32_t lens[] = {512, 0, 0};
+    size_t blen = 0;
+    uint8_t *bcem = build_bcem(2, 0x1234abcd, "Test Vol", words, offs, lens, 3, &blen);
+    size_t flen = 0;
+    uint8_t *fork = build_bcem_fork(bcem, blen, &flen);
+
+    ASSERT_TRUE(ndif_detect(fork, flen));
+
+    ndif_map_t *m = NULL;
+    ASSERT_EQ_INT(0, ndif_parse(fork, flen, &m));
+    ASSERT_TRUE(m != NULL);
+    ASSERT_EQ_INT(2, (int)m->sectors);
+    ASSERT_EQ_INT((int)0x1234abcd, (int)m->crc);
+    ASSERT_EQ_INT(0, strcmp(m->volume_name, "Test Vol"));
+    ASSERT_EQ_INT(2, (int)m->n_chunks); // END dropped
+    ASSERT_EQ_INT(0, (int)m->chunks[0].sector);
+    ASSERT_EQ_INT(1, (int)m->chunks[0].count);
+    ASSERT_EQ_INT(NDIF_CHUNK_COPY, m->chunks[0].type);
+    ASSERT_EQ_INT(1, (int)m->chunks[1].sector);
+    ASSERT_EQ_INT(1, (int)m->chunks[1].count);
+    ASSERT_EQ_INT(NDIF_CHUNK_ZERO, m->chunks[1].type);
+
+    ndif_map_free(m);
+    free(bcem);
+    free(fork);
+}
+
+TEST(ndif_detect_false_on_plain_fork) {
+    // A fork with no 'bcem' resource is not NDIF.
+    uint8_t junk[64];
+    memset(junk, 0, sizeof(junk));
+    ASSERT_TRUE(!ndif_detect(junk, sizeof(junk)));
+}
+
+TEST(ndif_decode_copy_zero_adc) {
+    // Chunk 0: ADC of 512 bytes of 0xCD.  Chunk 1: COPY of 512 bytes of 0x11.
+    // Chunk 2: ZERO.  Chunk 3: END.  sectors = 3.
+    uint8_t adc_stream[1024];
+    size_t adc_len = adc_fill(adc_stream, 0xCD, 512);
+
+    uint32_t words[] = {(0u << 8) | NDIF_CHUNK_ADC, (1u << 8) | NDIF_CHUNK_COPY, (2u << 8) | NDIF_CHUNK_ZERO,
+                        (3u << 8) | NDIF_CHUNK_END};
+    uint32_t offs[] = {0, (uint32_t)adc_len, (uint32_t)adc_len + 512, 0};
+    uint32_t lens[] = {(uint32_t)adc_len, 512, 0, 0};
+    size_t blen = 0;
+    uint8_t *bcem = build_bcem(3, 0, "X", words, offs, lens, 4, &blen);
+    size_t flen = 0;
+    uint8_t *fork = build_bcem_fork(bcem, blen, &flen);
+
+    ndif_map_t *m = NULL;
+    ASSERT_EQ_INT(0, ndif_parse(fork, flen, &m));
+    ASSERT_EQ_INT(3, (int)m->n_chunks);
+
+    uint8_t sect[512];
+
+    // ADC chunk -> 512 x 0xCD.
+    ASSERT_EQ_INT(0, ndif_decode_chunk(&m->chunks[0], adc_stream, adc_len, sect, sizeof(sect)));
+    for (int i = 0; i < 512; i++)
+        ASSERT_EQ_INT(0xCD, sect[i]);
+
+    // COPY chunk -> verbatim.
+    uint8_t raw[512];
+    memset(raw, 0x11, sizeof(raw));
+    ASSERT_EQ_INT(0, ndif_decode_chunk(&m->chunks[1], raw, sizeof(raw), sect, sizeof(sect)));
+    for (int i = 0; i < 512; i++)
+        ASSERT_EQ_INT(0x11, sect[i]);
+
+    // ZERO chunk -> zeros (no source bytes).
+    memset(sect, 0xAA, sizeof(sect));
+    ASSERT_EQ_INT(0, ndif_decode_chunk(&m->chunks[2], NULL, 0, sect, sizeof(sect)));
+    for (int i = 0; i < 512; i++)
+        ASSERT_EQ_INT(0, sect[i]);
+
+    ndif_map_free(m);
+    free(bcem);
+    free(fork);
+}
+
+TEST(ndif_decode_rejects_unsupported_type) {
+    ndif_chunk_t c = {.sector = 0, .count = 1, .type = NDIF_CHUNK_KENCODE, .offset = 0, .length = 4};
+    uint8_t src[4] = {0};
+    uint8_t dst[512];
+    ASSERT_EQ_INT(-EINVAL, ndif_decode_chunk(&c, src, sizeof(src), dst, sizeof(dst)));
+}
+
+int main(void) {
+    RUN(adc_literal_run);
+    RUN(adc_short_match_rle);
+    RUN(adc_long_match);
+    RUN(adc_backref_before_start_is_error);
+    RUN(adc_respects_out_cap);
+    RUN(ndif_detect_and_parse);
+    RUN(ndif_detect_false_on_plain_fork);
+    RUN(ndif_decode_copy_zero_adc);
+    RUN(ndif_decode_rejects_unsupported_type);
+    fprintf(stderr, "All ndif tests passed.\n");
+    return 0;
+}

--- a/tests/unit/suites/vfs/image_vfs_stubs.c
+++ b/tests/unit/suites/vfs/image_vfs_stubs.c
@@ -4,6 +4,7 @@
 // vfs_resolve falls through to host resolution unchanged.  Production
 // code provides the real implementations in src/core/vfs/image_vfs.c.
 
+#include "image.h"
 #include "image_vfs.h"
 
 #include <errno.h>
@@ -20,6 +21,23 @@ char *image_vfs_materialize_nested(image_mount_t *m, const char *in_image_file_p
     (void)m;
     (void)in_image_file_path;
     return NULL; // no nested descent in the stubbed VFS unit test
+}
+
+// Image-layer symbols referenced by vfs_export_raw_image().  The stubbed VFS
+// unit test never exercises the export path, so these just satisfy the linker.
+image_t *image_open_readonly(const char *base_path) {
+    (void)base_path;
+    return NULL;
+}
+
+int image_export_to(image_t *image, const char *dest_path) {
+    (void)image;
+    (void)dest_path;
+    return -1;
+}
+
+void image_close(image_t *image) {
+    (void)image;
 }
 
 int image_vfs_unmount(const char *host_path) {

--- a/tests/unit/suites/vfs/image_vfs_stubs.c
+++ b/tests/unit/suites/vfs/image_vfs_stubs.c
@@ -7,12 +7,19 @@
 #include "image_vfs.h"
 
 #include <errno.h>
+#include <stddef.h>
 
 int image_vfs_acquire_mount(const char *host_path, image_mount_t **out_mount) {
     (void)host_path;
     if (out_mount)
         *out_mount = NULL;
     return -ENOTDIR;
+}
+
+char *image_vfs_materialize_nested(image_mount_t *m, const char *in_image_file_path) {
+    (void)m;
+    (void)in_image_file_path;
+    return NULL; // no nested descent in the stubbed VFS unit test
 }
 
 int image_vfs_unmount(const char *host_path) {


### PR DESCRIPTION
## What & why

Granny Smith recognised only **Disk Copy 4.2** and raw disk images. **NDIF**
images — the format Disk Copy 6.x wrote throughout the Mac OS 8/9 era (`.img`,
creator `ddsk`) — fell through to being treated as raw bytes and failed to
mount, so `vfs.ls` into one returned `[]`. This PR adds NDIF read/mount support
and a raw-export command.

Motivating case: the **8•24 GC driver floppies** (and `Apple Macintosh 24AC.img`)
live as NDIF images *inside* `Misc_Mac_Drivers.toast`, and none of them could be
browsed.

## What's in it

**1. NDIF read/mount (`0757655`)**
- `src/core/storage/adc.{c,h}` — Apple Data Compression (ADC) decompressor (~50-line LZ77 variant).
- `src/core/storage/image_ndif.{c,h}` — parser for the classic NDIF `bcem` block map (128-byte `ChunkHeader` + 12-byte descriptors, 8-bit type codes packed as `(sector<<8)|type` — **not** UDIF's 40-byte `mish`) + chunk decode (zero-fill / raw / ADC). Layout verified against real Disk Copy 6.3.3 images and cross-checked with Aaru's `Aaru.Images/NDIF`.
- `src/core/vfs/image_vfs.c` — `image_vfs_materialize_nested()`: decodes an inner NDIF file to a host scratch raw image (`ftruncate` zero-fills the sparse gaps), then mounts it via the normal read-only path — so the existing APM/HFS/VFS stack is untouched.
- `src/core/vfs/vfs.c` — resolver **nested-image descent**: an in-image path that passes through an image *file* (e.g. an NDIF `.img` inside a Toast CD) materialises + mounts the inner image and keeps resolving into it.

**2. `storage.export_raw` (`947b7d5`)**
- New `storage.export_raw(src, dst)` object-model method. `storage.cp` of an NDIF `.img` copies its (still-compressed, fork-dependent) data fork; `export_raw` decodes the image and writes a flat, single-fork **raw** block image — portable, re-mountable, `dd`/`hdiutil`-friendly. Backed by `vfs_export_raw_image()` (resolve → decode/materialise → `image_open_readonly` + `image_export_to`, which already refuses to overwrite).

## Design notes

- **Why materialise-to-raw** rather than an on-demand storage hook: an NDIF block map can't be expressed as the storage engine's single constant `base_data_offset` (the trick DC42 uses). Decoding to a scratch raw file needs zero `storage.c` changes and is exactly what `hdiutil convert` / `ndif2raw` do. An on-demand `base_read` path is a documented future optimisation.
- **Reuse:** the existing resource-fork parser (`rfork_parse`/`rfork_lookup`) extracts `bcem`; the `.delta` overlay gives read-only NDIF a writable overlay for free; APM/HFS/catalog traversal is unchanged.
- **Doc trap corrected:** two community write-ups describe `bcem` as a UDIF `mish` table (204-byte header, 40-byte entries, 32-bit type codes) — that's UDIF, wrong for classic NDIF. This uses the Aaru + byte-verified layout.

## Litmus test — passes

Mounts and reads both 8•24 GC driver floppies (System 6 + 7) straight out of the toast:

```
vfs.ls  ".../8•24 GC for System 7.x.img/partition1"        → 8•24 GC   Desktop
storage.cp ".../8•24 GC/rsrc/vers/1" out                   → "7.0.1, © Apple Computer, Inc. 1989-1992"
storage.export_raw ".../8•24 GC for System 7.x.img" gc.img → 819200-byte raw HFS, re-mounts cleanly
```

## Testing

- New unit suite `tests/unit/suites/ndif` (ADC vectors + synthetic `bcem` parse/decode) — full unit suite **24/24**.
- New integration test `tests/integration/image-export-raw` (round-trips a bare-HFS floppy out and re-mounts it).
- Storage/VFS integration regressions (`image-hfs-traverse`, `image-partmap`, `image-ufs-traverse`, `vfs-rsrc`, `storage-guards`, `object-storage`) stay green. Non-nested listings unchanged.

## Scope / deferred

Covers NDIF nested inside a mounted image and zero/raw/**ADC** chunks (≈ all real floppy/CD images). Not in this PR: standalone host-file NDIF (needs AppleDouble/MacBinary fork acquisition), KenCode/RLE/LZH chunk codecs (return a defined error), and on-demand (non-materialising) decode for very large images. NDIF "CRC28" verification is skipped — it is **not** standard CRC-32 (Aaru/dmg2img skip it too); decode correctness is proven by the volume mounting and listing real files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
