### PR TITLE
scheduler: stage 2 — adaptive governor, Real-Time/Accelerated/Fast-Forward relabel, accelerated e2e

### DIFF
--- a/app/web2/src/components/display/DisplayToolbar.svelte
+++ b/app/web2/src/components/display/DisplayToolbar.svelte
@@ -131,22 +131,22 @@
         class="sch-btn"
         class:active={machine.scheduler === 'live'}
         disabled={!isLive}
-        title="Live — pace the machine to real time"
-        onclick={() => onSchedulerClick('live')}>live</button
+        title="Real-Time — runs at the original Mac's speed"
+        onclick={() => onSchedulerClick('live')}>real-time</button
       >
       <button
         class="sch-btn"
         class:active={machine.scheduler === 'accel'}
         disabled={!isLive}
-        title="Accel — faster CPU while games, sound and animations keep the correct speed (like a CPU accelerator card)"
-        onclick={() => onSchedulerClick('accel')}>accel</button
+        title="Accelerated — runs faster while keeping games, sound, and animations at the correct speed, like adding a CPU accelerator card"
+        onclick={() => onSchedulerClick('accel')}>accelerated</button
       >
       <button
         class="sch-btn"
         class:active={machine.scheduler === 'turbo'}
         disabled={!isLive}
-        title="Turbo — run everything as fast as the host allows (time itself speeds up)"
-        onclick={() => onSchedulerClick('turbo')}>turbo</button
+        title="Fast-Forward — runs everything as fast as possible to skip ahead; games and sound run fast too"
+        onclick={() => onSchedulerClick('turbo')}>fast-forward</button
       >
     </div>
   </div>

--- a/app/web2/src/state/machine.svelte.ts
+++ b/app/web2/src/state/machine.svelte.ts
@@ -10,9 +10,12 @@ export type DriveActivity = 'idle' | 'read' | 'write';
 // Three pacing modes, mirroring the core's schedule_paced/schedule_accelerated/
 // schedule_unthrottled (proposal-scheduler-two-modes.md and
 // proposal-scheduler-accelerated-mode.md): 'live' = wall-clock paced, 'accel' =
-// real-time timebase with a faster CPU (accelerator-card model), 'turbo' = as
-// fast as the host allows. The guest timeline is identical in live/turbo; accel
-// trades that determinism for CPU throughput while VBL/sound stay real-time.
+// real-time timebase with a faster CPU (accelerator-card model; the adaptive
+// governor picks the speed), 'turbo' = as fast as the host allows. The guest
+// timeline is identical in live/turbo; accel trades that determinism for CPU
+// throughput while VBL/sound stay real-time. The toolbar labels these
+// Real-Time / Accelerated / Fast-Forward (proposal §5.1); the internal ids
+// below predate the relabel and stay stable.
 export type SchedulerMode = 'live' | 'accel' | 'turbo';
 
 // Typed MMU kind, sourced from `machine.profile(id).capabilities.mmu.kind`

--- a/docs/core/scheduler/scheduler.md
+++ b/docs/core/scheduler/scheduler.md
@@ -161,9 +161,50 @@ formula. With the authentic integer CPI (paced/turbo) the remainder is identical
 zero and every code path is bit-identical to the pre-fractional arithmetic — pinned
 budgets do not move.
 
-`scheduler.speed` (1.0 .. 8.0, 1/256th steps) picks the multiplier; the *setting*
-persists in the checkpoint prefix while the derived `cpi_eff_x256` and the remainder
-are transient and re-derived/cleared on restore and on every mode/CPI/speed change.
+`scheduler.speed` picks the multiplier: **0 = auto** (the adaptive governor, the
+default) or 1.0 .. 8.0 to pin a fixed multiplier. The *setting* (and the
+`scheduler.max_speed` cap) persist in the checkpoint prefix while the derived
+`cpi_eff_x256`, the remainder, and all governor state are transient and
+re-derived/cleared on restore and on every mode/CPI/speed change.
+
+### 2.3 The adaptive governor (speed = auto)
+
+With `scheduler.speed = 0`, a closed-loop governor (stage 2 of the proposal, §4)
+picks the highest speed the host can sustain *without missing the real-time
+deadline* — overrunning it stalls the paced accumulator, which surfaces as audio
+underruns and stutter. Per paced main-loop tick that executed frame-units, it:
+
+1. **Measures** utilization `u = host seconds to emulate one frame-unit /
+   MAC_VBL_PERIOD` (the same measurement the pacing EWMA already makes), smoothed
+   with a fast-up/slow-down EWMA so pressure registers quickly.
+2. **AIMD on a quantized ladder** (1×, 1.5×, 2×, 3×, 4×, 6×, 8×): one rung **down**
+   immediately when the smoothed utilization crosses 0.90 or the (optional) audio
+   ring drains below half its target depth; one rung **up** only after ≥2 s of
+   residence at the current rung, outside a 1 s post-back-off holdoff, and only if
+   the utilization *projected at the next rung* stays under the 0.80 target.
+3. **Bounds**: floor = the authentic CPI (rung 0 — accelerated never runs slower
+   than real hardware; an overloaded host degrades to exactly `paced` behavior);
+   ceiling = `scheduler.max_speed` (default 8×, persisted).
+
+The dwell/holdoff slew limit and the coarse quantization are **correctness
+requirements**, not tuning niceties (proposal §4.4): the guest calibrates
+instruction-counted delays (`TimeDBRA` etc.) against the VIA at boot, so the
+machine must dwell at stable speeds rather than glide. The utilization EWMA is
+rescaled on every step (utilization is proportional to instructions per frame),
+keeping the estimator meaningful across steps.
+
+**Audio feedback** (§11.3): `platform_audio_ring_fill()` reports the host ring's
+fill fraction against its target depth, or `< 0` where the signal doesn't exist —
+headless, or audio idle. On wasm the worklet posts periodic fill reports which are
+cached and piggybacked back to the emulator thread on the (already main-thread-
+proxied) push call — no extra round trips. The governor treats the signal as
+strictly optional.
+
+**Headless**: the governor's input is the paced main loop's host-timing signal,
+which the budget-driven headless path never produces — so accelerated-auto stays
+at the authentic floor there. Headless acceleration uses a pinned
+`scheduler.speed`, which is also the §4.4-safe configuration (a constant speed is
+self-consistent with the guest's boot-time calibration).
 
 ---
 
@@ -664,7 +705,7 @@ No `host_time()` value ever feeds guest execution on the headless path.
 ([em_main.c](../src/platform/wasm/em_main.c)). It maps the elapsed host time onto a
 whole number of frame-units and runs that many via `scheduler_run_frame()`:
 
-- **`schedule_paced`** (default; "Live" in the web2 toolbar): a wall-clock
+- **`schedule_paced`** (default; "Real-Time" in the web2 toolbar): a wall-clock
   accumulator. Elapsed host time accumulates in `vbl_acc_error`; each whole
   `MAC_VBL_PERIOD` earns one frame-unit, capped at `PACED_MAX_CATCHUP` (4) per tick.
   At a ~60 Hz host this is 1 frame-unit per tick in steady state (one repeat/skip
@@ -675,13 +716,16 @@ whole number of frame-units and runs that many via `scheduler_run_frame()`:
   feedback that could pile ~60 frame-units into one tick. Under a sustained-slow host
   the accumulator saturates and the emulator simply lags real time by a bounded
   amount.
-- **`schedule_accelerated`** ("Accel"): shares the paced wall-clock accumulator
-  verbatim — same `vbl_acc_error` math, same `PACED_MAX_CATCHUP` cap — so its
-  timebase (VBL cadence, and everything cycle-derived) is real-time exactly like
-  paced. It differs from paced only in the effective CPI *inside* each frame-unit
-  (§2.2): more instructions per frame, correct clock. This is the "faster machine,
-  correct time" mode a CPU-bound title (e.g. Marathon's software renderer) wants.
-- **`schedule_unthrottled`** ("Turbo"): as many frame-units as fit in
+- **`schedule_accelerated`** ("Accelerated"): shares the paced wall-clock
+  accumulator verbatim — same `vbl_acc_error` math, same `PACED_MAX_CATCHUP` cap —
+  so its timebase (VBL cadence, and everything cycle-derived) is real-time exactly
+  like paced. It differs from paced only in the effective CPI *inside* each
+  frame-unit (§2.2): more instructions per frame, correct clock. This is the
+  "faster machine, correct time" mode a CPU-bound title (e.g. Marathon's software
+  renderer) wants. By default the adaptive governor (§2.3) picks the speed from
+  the measured per-frame host cost, evaluated right here in the main loop's
+  timing-update tail.
+- **`schedule_unthrottled`** ("Fast-Forward"): as many frame-units as fit in
   `TURBO_HOST_HEADROOM` (50%) of the smoothed host loop period, leaving the rest for
   the browser. Emulated time outruns real time on a fast host. The first tick after
   init / checkpoint restore / mode switch has no `host_secs_per_vbl` estimate yet
@@ -828,7 +872,9 @@ The scheduler is an object-model citizen (`scheduler.*` paths in the typed shell
 | `scheduler.stop`            | Stop execution immediately.                                |
 | `scheduler.mode`            | Pacing mode: `"paced"` \| `"accelerated"` \| `"turbo"` (writable; legacy aliases `real`/`hw` → paced, `max` → turbo, `accel` → accelerated). |
 | `scheduler.cpi`             | Per-machine CPI constant; writable as a debug override (1..255). |
-| `scheduler.speed`           | Accelerated-mode CPU speed multiplier (1.0 .. 8.0, 1/256th steps); persisted, but only takes effect in mode `accelerated`. |
+| `scheduler.speed`           | Accelerated-mode multiplier in force (live). Write `0` for auto (adaptive governor) or 1.0 .. 8.0 to pin; persisted, but only takes effect in mode `accelerated`. |
+| `scheduler.speed_auto`      | RO: true while the adaptive governor is choosing the speed (`speed = 0`). |
+| `scheduler.max_speed`       | Cap on the accelerated multiplier (1.0 .. 8.0, default 8): the governor's ceiling, and pinned speeds clamp to it. Persisted. |
 | `scheduler.running`         | True while executing (useful for scripts).                 |
 | `scheduler.cycles` / `.instr_count` | Cycle / instruction counters.                      |
 | `events`                    | Dump the pending event queue with Δcycles and Δµs.         |

--- a/docs/core/scheduler/timing.md
+++ b/docs/core/scheduler/timing.md
@@ -44,7 +44,9 @@ The sprint arithmetic actually runs on an **effective CPI** in x256 fixed point
 (`cpi_eff_x256`). In paced/unthrottled it is exactly `cpi << 8` and every
 computation below is bit-identical to the plain integer form. The `accelerated`
 mode (proposal-scheduler-accelerated-mode.md) lowers it — never raises it — by
-the `scheduler.speed` multiplier (1x..8x), so a frame-unit's fixed cycle budget
+the `scheduler.speed` multiplier (a pinned 1x..8x, or by default the adaptive
+governor's pick on a quantized ladder up to `scheduler.max_speed` — see
+docs/core/scheduler/scheduler.md §2.3), so a frame-unit's fixed cycle budget
 converts to proportionally more instructions while the cycle timebase (and thus
 every cycle-derived peripheral clock) stays real-time. The sub-cycle remainder
 of each sprint (`cycle_frac_x256`) carries in scheduler state, so `cpu_cycles`

--- a/src/core/scheduler/scheduler.c
+++ b/src/core/scheduler/scheduler.c
@@ -59,9 +59,29 @@ LOG_USE_CATEGORY_NAME("scheduler");
 // hardware); the 8x cap keeps instruction-timed guest code (TimeDBRA-derived
 // busy-waits) from drifting absurdly far on fast hosts
 // (proposal-scheduler-accelerated-mode.md §4.3/§4.4).
-#define SPEED_X256_ONE     256
-#define SPEED_X256_MAX     (8 * 256)
-#define SPEED_X256_DEFAULT (4 * 256)
+#define SPEED_X256_ONE 256
+#define SPEED_X256_MAX (8 * 256)
+// scheduler.speed == 0 means "auto": the adaptive governor picks the speed.
+#define SPEED_X256_AUTO 0
+
+// Adaptive governor (accelerated mode with scheduler.speed = auto). AIMD on a
+// quantized speed ladder: additive rung-up only after dwelling at the current
+// speed (the §4.4 slew limit — instruction-counted guest delays calibrated at
+// one speed must not be replayed at a glided-away one), multiplicative
+// rung-down (each rung is ~x1.5) as soon as sustained utilization threatens
+// the real-time deadline. Utilization = host seconds spent emulating one
+// frame-unit / MAC_VBL_PERIOD; overrunning it stalls the paced accumulator,
+// which surfaces as audio underruns and stutter — hence the headroom target.
+#define GOV_UTIL_TARGET  0.80 // climb only if the *projected* post-climb utilization stays below this
+#define GOV_UTIL_CEILING 0.90 // sustained above → back off one rung
+#define GOV_DWELL_SECS   2.0 // minimum residence at a rung before climbing
+#define GOV_HOLDOFF_SECS 1.0 // after a back-off, no climb attempts for this long
+#define GOV_AUDIO_LOW    0.5 // audio ring below half its target depth = pressure (optional signal)
+
+// Quantized speed steps (x256): 1x, 1.5x, 2x, 3x, 4x, 6x, 8x. Rung 0 is the
+// authentic floor — the mode never runs the guest slower than real hardware.
+static const uint32_t gov_ladder_x256[] = {256, 384, 512, 768, 1024, 1536, 2048};
+#define GOV_NUM_RUNGS ((int)(sizeof(gov_ladder_x256) / sizeof(gov_ladder_x256[0])))
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 
@@ -109,11 +129,17 @@ struct scheduler {
     // in every pacing mode (one guest timeline)
     uint32_t cpi;
 
-    // Accelerated-mode speed multiplier, x256 fixed point (256 = 1x). Lives
-    // in the plain-data checkpoint prefix on purpose: the user's speed
-    // *setting* persists; the derived cpi_eff_x256 below is transient and
-    // re-derived on restore. Inert unless mode == schedule_accelerated.
+    // Accelerated-mode pinned speed multiplier, x256 fixed point (256 = 1x),
+    // or SPEED_X256_AUTO (0) to let the adaptive governor pick. Lives in the
+    // plain-data checkpoint prefix on purpose: the user's speed *setting*
+    // persists; the governor's live speed below is transient. Inert unless
+    // mode == schedule_accelerated.
     uint32_t speed_x256;
+
+    // User cap on the accelerated-mode multiplier (governor ceiling; a pinned
+    // speed is clamped to it too), x256 fixed point. Persisted with the
+    // prefix; default 8x.
+    uint32_t max_speed_x256;
 
     // Event type registry for checkpointing
     event_type_t event_types[MAX_EVENT_TYPES];
@@ -121,13 +147,21 @@ struct scheduler {
 
     // Effective CPI, x256 fixed point: cpi << 8 in paced/unthrottled, lowered
     // (never raised) in accelerated mode. Derived by scheduler_update_cpi_eff
-    // from (mode, cpi, speed_x256); deliberately after event_types so it is
-    // never checkpointed — restore re-derives it.
+    // from (mode, cpi, speed setting, governor rung); deliberately after
+    // event_types so it is never checkpointed — restore re-derives it.
     uint32_t cpi_eff_x256;
     // Sub-cycle remainder of sprint cycle accounting, 0..255 (x256 fractional
     // cycles). Carried across sprints so cycles advanced stay exact integers
     // and nothing is dropped; reset on mode/CPI/speed changes and on restore.
     uint32_t cycle_frac_x256;
+
+    // Adaptive-governor state — live controller state, never checkpointed
+    // (like the host-timing estimators above the prefix boundary): a restored
+    // or mode-switched machine re-learns its speed from fresh measurements.
+    int gov_rung; // current index into gov_ladder_x256 (0 = authentic 1x)
+    double gov_util_ewma; // smoothed utilization (host secs per frame / VBL period)
+    double gov_dwell_secs; // host seconds spent at the current rung
+    double gov_holdoff_secs; // remaining post-back-off climb holdoff
 
     // Sprint execution counters (previously file-scope globals)
     uint64_t total_instructions; // accumulated instructions from completed sprints
@@ -183,24 +217,114 @@ static inline uint32_t avg_cycles_per_instr(struct scheduler *s) {
     return s->cpi;
 }
 
-// Re-derive the effective CPI (x256) from mode, authentic CPI and speed
-// setting, and clear the sub-cycle remainder so no fractional carry leaks
-// across a mode/CPI/speed change. The effective CPI equals the authentic CPI
-// everywhere except accelerated mode, where it is lowered — never raised — so
-// more instructions fit in the same (real-time) cycle budget. Holding the
-// cycle rate and tuning CPI is what keeps every cycle-derived peripheral
-// clock (VIA φ2, sound scan, SCC fallback) real-time for free (proposal §3).
+// The speed multiplier (x256) accelerated mode runs at right now: the pinned
+// setting if one is set, else the governor's current rung — clamped to the
+// user cap either way.
+static uint32_t scheduler_current_speed_x256(struct scheduler *s) {
+    GS_ASSERT(s != NULL);
+    GS_ASSERT(s->gov_rung >= 0 && s->gov_rung < GOV_NUM_RUNGS);
+    uint32_t sp = (s->speed_x256 != SPEED_X256_AUTO) ? s->speed_x256 : gov_ladder_x256[s->gov_rung];
+    if (sp > s->max_speed_x256)
+        sp = s->max_speed_x256;
+    if (sp < SPEED_X256_ONE)
+        sp = SPEED_X256_ONE;
+    return sp;
+}
+
+// Re-derive the effective CPI (x256) from mode, authentic CPI and the current
+// speed (pinned or governed), and clear the sub-cycle remainder so no
+// fractional carry leaks across a mode/CPI/speed change. The effective CPI
+// equals the authentic CPI everywhere except accelerated mode, where it is
+// lowered — never raised — so more instructions fit in the same (real-time)
+// cycle budget. Holding the cycle rate and tuning CPI is what keeps every
+// cycle-derived peripheral clock (VIA φ2, sound scan, SCC fallback) real-time
+// for free (proposal §3).
 static void scheduler_update_cpi_eff(struct scheduler *s) {
     GS_ASSERT(s != NULL);
     GS_ASSERT(s->cpi > 0);
     uint32_t eff = s->cpi << 8;
-    if (s->mode == schedule_accelerated && s->speed_x256 > SPEED_X256_ONE) {
-        eff = (uint32_t)(((uint64_t)s->cpi << 16) / s->speed_x256);
-        if (eff == 0)
-            eff = 1; // never a zero divisor (cpi 1 at the 8x cap is still 32)
+    if (s->mode == schedule_accelerated) {
+        uint32_t sp = scheduler_current_speed_x256(s);
+        if (sp > SPEED_X256_ONE) {
+            eff = (uint32_t)(((uint64_t)s->cpi << 16) / sp);
+            if (eff == 0)
+                eff = 1; // never a zero divisor (cpi 1 at the 8x cap is still 32)
+        }
     }
     s->cpi_eff_x256 = eff;
     s->cycle_frac_x256 = 0;
+}
+
+// Reset the adaptive governor to the authentic floor with fresh estimators.
+// Called wherever its measurements go stale: mode switches, pin/unpin, cap
+// changes, init and checkpoint restore — the controller re-learns the host's
+// headroom from scratch rather than acting on stale utilization.
+static void scheduler_governor_reset(struct scheduler *s) {
+    GS_ASSERT(s != NULL);
+    s->gov_rung = 0;
+    s->gov_util_ewma = 0.0;
+    s->gov_dwell_secs = 0.0;
+    s->gov_holdoff_secs = 0.0;
+}
+
+// One adaptive-governor evaluation (accelerated mode, speed = auto). Fed from
+// the paced main loop with the measured host cost of one frame-unit and the
+// elapsed host time since the previous tick. AIMD on the quantized ladder:
+//   - back off one rung immediately when sustained utilization crosses the
+//     ceiling or the (optional) audio ring drains below half target — the
+//     multiplicative decrease that keeps a spike from becoming a spiral;
+//   - climb one rung only after GOV_DWELL_SECS of residence, outside the
+//     post-back-off holdoff, and only if the utilization *projected* at the
+//     next rung stays under the target — the slew limit §4.4 requires so
+//     instruction-counted guest delays see a stable speed, plus headroom.
+// The utilization EWMA is rescaled on every step (utilization is proportional
+// to instructions per frame), so the estimator stays meaningful across steps.
+static void scheduler_governor_tick(struct scheduler *s, double host_secs_this_vbl, double elapsed_secs) {
+    GS_ASSERT(s != NULL);
+    GS_ASSERT(s->mode == schedule_accelerated && s->speed_x256 == SPEED_X256_AUTO);
+
+    // Utilization of the real-time frame budget, smoothed. Pressure registers
+    // fast (protect the deadline); optimism accumulates slowly.
+    double u = host_secs_this_vbl / MAC_VBL_PERIOD;
+    double alpha = (u > s->gov_util_ewma) ? 0.35 : 0.10;
+    s->gov_util_ewma += alpha * (u - s->gov_util_ewma);
+
+    s->gov_dwell_secs += elapsed_secs;
+    if (s->gov_holdoff_secs > 0.0)
+        s->gov_holdoff_secs -= elapsed_secs;
+
+    // Optional audio feedback (§11.3): the platform reports the host ring's
+    // fill fraction against its target depth, or <0 where the signal doesn't
+    // exist (headless, audio idle). A draining ring means the deadline is
+    // already being missed where it hurts first.
+    double fill = platform_audio_ring_fill();
+    bool audio_pressure = (fill >= 0.0 && fill < GOV_AUDIO_LOW);
+
+    // Highest rung the user cap allows
+    int max_rung = 0;
+    while (max_rung + 1 < GOV_NUM_RUNGS && gov_ladder_x256[max_rung + 1] <= s->max_speed_x256)
+        max_rung++;
+
+    int new_rung = s->gov_rung;
+    if ((s->gov_util_ewma > GOV_UTIL_CEILING || audio_pressure) && new_rung > 0) {
+        new_rung--; // back off fast
+        s->gov_holdoff_secs = GOV_HOLDOFF_SECS;
+    } else if (new_rung < max_rung && s->gov_holdoff_secs <= 0.0 && s->gov_dwell_secs >= GOV_DWELL_SECS) {
+        // Climb only with headroom at the *next* rung, not just the current one
+        double projected = s->gov_util_ewma * (double)gov_ladder_x256[new_rung + 1] / gov_ladder_x256[new_rung];
+        if (projected < GOV_UTIL_TARGET)
+            new_rung++;
+    }
+    if (new_rung > max_rung)
+        new_rung = max_rung; // cap lowered mid-run
+
+    if (new_rung != s->gov_rung) {
+        // Rescale the estimator to the new speed and require a fresh dwell
+        s->gov_util_ewma *= (double)gov_ladder_x256[new_rung] / gov_ladder_x256[s->gov_rung];
+        s->gov_rung = new_rung;
+        s->gov_dwell_secs = 0.0;
+        scheduler_update_cpi_eff(s);
+    }
 }
 
 // Validate all critical scheduler invariants at key transition points
@@ -508,7 +632,8 @@ struct scheduler *scheduler_init(struct cpu *cpu, checkpoint_t *checkpoint) {
     s->host_secs_per_loop = 1.0 / 60.0;
     s->frequency = (uint32_t)MAC_CPU_FREQUENCY;
     s->cpi = CYCLES_PER_INSTR_DEFAULT;
-    s->speed_x256 = SPEED_X256_DEFAULT;
+    s->speed_x256 = SPEED_X256_AUTO;
+    s->max_speed_x256 = SPEED_X256_MAX;
     s->num_event_types = 0;
     memset(s->event_types, 0, sizeof(s->event_types));
 
@@ -541,10 +666,13 @@ struct scheduler *scheduler_init(struct cpu *cpu, checkpoint_t *checkpoint) {
         GS_ASSERT(s->mode == schedule_paced || s->mode == schedule_unthrottled || s->mode == schedule_accelerated);
         GS_ASSERT(s->cpu_cycles < (1ULL << 60));
 
-        // Checkpoints are build-ID-gated so the field is always present, but
-        // a corrupt speed must not poison the effective-CPI derivation.
-        if (s->speed_x256 < SPEED_X256_ONE || s->speed_x256 > SPEED_X256_MAX)
-            s->speed_x256 = SPEED_X256_DEFAULT;
+        // Checkpoints are build-ID-gated so the fields are always present,
+        // but corrupt values must not poison the effective-CPI derivation.
+        // speed: 0 (auto) or a pinned multiplier in [1x, 8x].
+        if (s->speed_x256 != SPEED_X256_AUTO && (s->speed_x256 < SPEED_X256_ONE || s->speed_x256 > SPEED_X256_MAX))
+            s->speed_x256 = SPEED_X256_AUTO;
+        if (s->max_speed_x256 < SPEED_X256_ONE || s->max_speed_x256 > SPEED_X256_MAX)
+            s->max_speed_x256 = SPEED_X256_MAX;
 
         // Save event data for deferred restoration (names must be resolved after device registration).
         system_read_checkpoint_data(checkpoint, &s->tmp_num_events, sizeof(s->tmp_num_events));
@@ -570,8 +698,10 @@ struct scheduler *scheduler_init(struct cpu *cpu, checkpoint_t *checkpoint) {
         s->tmp_events = NULL;
     }
 
-    // Derive the transient effective CPI (fresh boot and restore alike — it is
-    // never checkpointed) before anything can size a sprint or read cycles.
+    // Derive the transient governor + effective-CPI state (fresh boot and
+    // restore alike — neither is checkpointed) before anything can size a
+    // sprint or read cycles.
+    scheduler_governor_reset(s);
     scheduler_update_cpi_eff(s);
 
     scheduler_new_event_type(s, "scheduler", s, "run_stop", run_stop_event);
@@ -916,14 +1046,40 @@ void scheduler_set_mode(struct scheduler *restrict s, enum schedule_mode mode) {
     s->host_secs_per_loop = 1.0 / 60.0;
     // Entering or leaving accelerated symmetrically re-derives the effective
     // CPI and clears the sub-cycle remainder, so no accelerated-mode speed
-    // leaks into paced/unthrottled (or vice versa).
+    // leaks into paced/unthrottled (or vice versa). The governor restarts
+    // from the authentic floor with fresh estimators.
+    scheduler_governor_reset(s);
     scheduler_update_cpi_eff(s);
 }
 
-// Set the accelerated-mode speed multiplier (clamped to [1x, 8x]). Stored
-// x256; retained across mode switches/checkpoints but inert outside
+// Set the accelerated-mode speed multiplier: 0 = auto (the adaptive governor
+// picks, bounded by max_speed), any other value pins a fixed multiplier
+// (clamped to [1x, 8x] — the §4.4 correctness-safe configuration, and the
+// only way to accelerate headless runs, which have no host-timing signal for
+// the governor). Retained across mode switches/checkpoints but inert outside
 // schedule_accelerated.
 void scheduler_set_speed(struct scheduler *restrict s, double multiplier) {
+    if (!s)
+        return;
+    if (isnan(multiplier))
+        return;
+    if (multiplier == 0.0) {
+        s->speed_x256 = SPEED_X256_AUTO;
+    } else {
+        double clamped = multiplier;
+        if (clamped < (double)SPEED_X256_ONE / 256.0)
+            clamped = (double)SPEED_X256_ONE / 256.0;
+        if (clamped > (double)SPEED_X256_MAX / 256.0)
+            clamped = (double)SPEED_X256_MAX / 256.0;
+        s->speed_x256 = (uint32_t)(clamped * 256.0 + 0.5);
+    }
+    scheduler_governor_reset(s);
+    scheduler_update_cpi_eff(s);
+}
+
+// Set the user cap on the accelerated-mode multiplier (governor ceiling; a
+// pinned speed is clamped to it at use). Clamped to [1x, 8x]; persisted.
+void scheduler_set_max_speed(struct scheduler *restrict s, double multiplier) {
     if (!s)
         return;
     if (isnan(multiplier))
@@ -933,7 +1089,8 @@ void scheduler_set_speed(struct scheduler *restrict s, double multiplier) {
         clamped = (double)SPEED_X256_ONE / 256.0;
     if (clamped > (double)SPEED_X256_MAX / 256.0)
         clamped = (double)SPEED_X256_MAX / 256.0;
-    s->speed_x256 = (uint32_t)(clamped * 256.0 + 0.5);
+    s->max_speed_x256 = (uint32_t)(clamped * 256.0 + 0.5);
+    scheduler_governor_reset(s);
     scheduler_update_cpi_eff(s);
 }
 
@@ -1259,6 +1416,13 @@ void scheduler_main_loop(config_t *restrict config, double now_msecs) {
         s->host_secs_per_vbl = delta / denom;
     else
         s->host_secs_per_vbl = s->host_secs_per_vbl * 0.9 + (delta * 0.1) / denom;
+
+    // Adaptive governor: accelerated mode with speed = auto learns the host's
+    // headroom from the measured per-frame emulation cost. Evaluated only on
+    // ticks that actually ran frame-units (no new cost sample otherwise) —
+    // and never on the headless path, which doesn't come through this loop.
+    if (s->mode == schedule_accelerated && s->speed_x256 == SPEED_X256_AUTO && executed_vbls > 0)
+        scheduler_governor_tick(s, delta / denom, current_period);
 }
 
 // ============================================================================
@@ -1330,17 +1494,41 @@ static value_t sched_attr_cpi_set(struct object *self, const member_t *m, value_
     return val_none();
 }
 
-// Accelerated-mode speed multiplier (1.0 = authentic .. 8.0). The setting is
-// retained (and checkpointed) in every mode but only applies in 'accelerated'.
+// Accelerated-mode speed multiplier. Reads back the multiplier currently in
+// force for accelerated mode — the pinned value, or the adaptive governor's
+// live speed when the setting is auto (so it moves on its own; "RO while
+// adaptive" in the proposal's terms). Writing 0 selects auto; 1.0..8.0 pins.
+// The setting is retained (and checkpointed) in every mode but only applies
+// in 'accelerated'; the governor's live speed is transient.
 static value_t sched_attr_speed(struct object *self, const member_t *m) {
     (void)m;
-    return val_float((double)sched_self_from(self)->speed_x256 / 256.0);
+    return val_float((double)scheduler_current_speed_x256(sched_self_from(self)) / 256.0);
 }
 static value_t sched_attr_speed_set(struct object *self, const member_t *m, value_t in) {
     (void)m;
-    if (isnan(in.f) || in.f < 1.0 || in.f > 8.0)
-        return val_err("scheduler.speed: %g out of range (1.0 .. 8.0)", in.f);
+    if (isnan(in.f) || (in.f != 0.0 && (in.f < 1.0 || in.f > 8.0)))
+        return val_err("scheduler.speed: %g out of range (0 = auto, or 1.0 .. 8.0)", in.f);
     scheduler_set_speed(sched_self_from(self), in.f);
+    return val_none();
+}
+
+// Whether the adaptive governor is choosing the speed (scheduler.speed = 0)
+static value_t sched_attr_speed_auto(struct object *self, const member_t *m) {
+    (void)m;
+    return val_bool(sched_self_from(self)->speed_x256 == SPEED_X256_AUTO);
+}
+
+// User cap on the accelerated-mode multiplier (governor ceiling; also clamps
+// a pinned speed). Persisted.
+static value_t sched_attr_max_speed(struct object *self, const member_t *m) {
+    (void)m;
+    return val_float((double)sched_self_from(self)->max_speed_x256 / 256.0);
+}
+static value_t sched_attr_max_speed_set(struct object *self, const member_t *m, value_t in) {
+    (void)m;
+    if (isnan(in.f) || in.f < 1.0 || in.f > 8.0)
+        return val_err("scheduler.max_speed: %g out of range (1.0 .. 8.0)", in.f);
+    scheduler_set_max_speed(sched_self_from(self), in.f);
     return val_none();
 }
 
@@ -1429,9 +1617,20 @@ static const member_t scheduler_members[] = {
      .attr = {.type = V_UINT, .get = sched_attr_cpi, .set = sched_attr_cpi_set}},
     {.kind = M_ATTR,
      .name = "speed",
-     .doc = "Accelerated-mode CPU speed multiplier (1.0 .. 8.0, 1/256th steps). Only takes effect while "
-            "mode is 'accelerated'; timebase (VBL/VIA/sound) stays real-time regardless", .flags = 0,
+     .doc = "Accelerated-mode CPU speed multiplier in force (live). Write 0 for auto (adaptive governor, "
+            "capped by max_speed) or 1.0..8.0 to pin a fixed multiplier. Only takes effect while mode is "
+            "'accelerated'; timebase (VBL/VIA/sound) stays real-time regardless", .flags = 0,
      .attr = {.type = V_FLOAT, .get = sched_attr_speed, .set = sched_attr_speed_set}},
+    {.kind = M_ATTR,
+     .name = "speed_auto",
+     .doc = "True while the adaptive governor is choosing the accelerated-mode speed (scheduler.speed = 0)",
+     .flags = VAL_RO,
+     .attr = {.type = V_BOOL, .get = sched_attr_speed_auto, .set = NULL}},
+    {.kind = M_ATTR,
+     .name = "max_speed",
+     .doc = "Cap on the accelerated-mode multiplier (1.0..8.0): the adaptive governor's ceiling, and pinned "
+            "speeds are clamped to it. Persisted", .flags = 0,
+     .attr = {.type = V_FLOAT, .get = sched_attr_max_speed, .set = sched_attr_max_speed_set}},
     {.kind = M_ATTR,
      .name = "cycles",
      .doc = "Total CPU cycles executed so far",

--- a/src/core/scheduler/scheduler.h
+++ b/src/core/scheduler/scheduler.h
@@ -122,11 +122,19 @@ bool scheduler_is_running(struct scheduler *restrict s);
 // Set scheduler pacing mode (paced/unthrottled/accelerated)
 void scheduler_set_mode(struct scheduler *restrict s, enum schedule_mode mode);
 
-// Set the accelerated-mode CPU speed multiplier (clamped to [1.0, 8.0]; stored
-// as x256 fixed point). Retained across mode switches and checkpoints, but
-// only takes effect while the mode is schedule_accelerated — paced and
-// unthrottled always run the authentic CPI.
+// Set the accelerated-mode CPU speed multiplier: 0 = auto (the adaptive
+// governor picks moment to moment, bounded by max_speed), any other value
+// pins a fixed multiplier (clamped to [1.0, 8.0]; stored as x256 fixed
+// point). Retained across mode switches and checkpoints, but only takes
+// effect while the mode is schedule_accelerated — paced and unthrottled
+// always run the authentic CPI. The governor needs the paced main loop's
+// host-timing signal, so headless accelerated runs use a pinned speed.
 void scheduler_set_speed(struct scheduler *restrict s, double multiplier);
+
+// Set the user cap on the accelerated-mode multiplier (clamped to
+// [1.0, 8.0]): the adaptive governor's ceiling, and pinned speeds are
+// clamped to it at use. Persisted with the checkpoint prefix.
+void scheduler_set_max_speed(struct scheduler *restrict s, double multiplier);
 
 // Set the CPU clock frequency in Hz (e.g. 7833600 for Plus, 15667200 for SE/30)
 void scheduler_set_frequency(struct scheduler *restrict s, uint32_t frequency_hz);

--- a/src/platform/headless/platform.h
+++ b/src/platform/headless/platform.h
@@ -183,6 +183,12 @@ static inline void platform_audio_set_rate(uint32_t src_rate_hz) {
     (void)src_rate_hz;
 }
 
+// No host audio ring headless — the governor's audio signal is simply absent
+// (and the governor itself never runs on the budget-driven headless path).
+static inline double platform_audio_ring_fill(void) {
+    return -1.0;
+}
+
 // Video stub (no-op in headless)
 static inline void platform_refresh_screen(struct platform *p, unsigned char *buf) {
     (void)p;

--- a/src/platform/wasm/em_audio.c
+++ b/src/platform/wasm/em_audio.c
@@ -121,6 +121,12 @@ EM_JS(void, gs_audio_init_js, (), {
         "    var w=this.wIdx, r=this.rIdx, mask=this.mask;",
         "    var avail=(w-r)&mask;",
         "    this.quietQ++;",
+        // Fill-level report every 32 quanta (~85 ms at 48 kHz): the node side
+        // caches it and the emulator's adaptive governor reads it as back-
+        // pressure (a draining ring = the real-time deadline being missed).
+        "    if(((this.statQ=(this.statQ||0)+1)&31)===0){",
+        "      this.port.postMessage({fill:avail/(this.targetFrames||1)});",
+        "    }",
         // Start gate: stay silent until the ring reaches the target depth, OR
         // until the stream has evidently ended short of it (data pending but
         // no push for 12 quanta ~32 ms) — so sounds shorter than the cushion
@@ -209,6 +215,15 @@ EM_JS(void, gs_audio_init_js, (), {
                     targetLatency: ga.targetLatency
                 }
             });
+            // Cache the worklet's periodic fill reports for the governor's
+            // ring-pressure query (returned by gs_audio_push_js).
+            ga.node.port.onmessage = function(e) {
+                var d = e.data;
+                if (d && typeof d.fill === 'number') {
+                    ga.fill = d.fill;
+                    ga.fillAt = performance.now();
+                }
+            };
             ga.node.connect(ga.ctx.destination);
             console.log('[audio] worklet open rate=' + p.rate + 'Hz ch=' + p.ch +
                         ' targetLatency=' + (ga.targetLatency * 1000).toFixed(1) + 'ms');
@@ -274,20 +289,24 @@ EM_JS(void, gs_audio_set_rate_js, (int rate), {
         ga.node.port.postMessage({rate: rate});
 });
 
-// Push interleaved int16 frames to the worklet via MessagePort
-EM_JS(void, gs_audio_push_js, (uint32_t ptr, int nframes, int volume), {
+// Push interleaved int16 frames to the worklet via MessagePort. Returns the
+// worklet's last-reported ring fill against target depth in per-mille (0 =
+// empty, 1000 = at target), or -1 when no fresh report exists — piggybacked
+// on the push so the emulator thread gets the governor's audio-pressure
+// signal with no extra main-thread round trips.
+EM_JS(int, gs_audio_push_js, (uint32_t ptr, int nframes, int volume), {
     var ga = Module.gsAudio;
     if (!ga || !ga.ctx || !ga.node || nframes <= 0)
-        return;
+        return -1;
     gs_audio_resume_js();
 
     var heap = (typeof HEAPU8 !== 'undefined') ? HEAPU8 : Module.HEAPU8;
     if (!heap)
-        return;
+        return -1;
     var bytes = nframes * ga.channels * 2;
     var end = Math.min(ptr + bytes, heap.length);
     if (ptr >= end || ((end - ptr) & 1))
-        return;
+        return -1;
 
     // Copy samples from WASM heap (must copy — heap can grow/move); the
     // slice's fresh ArrayBuffer is viewed as Int16Array in the worklet.
@@ -308,6 +327,11 @@ EM_JS(void, gs_audio_push_js, (uint32_t ptr, int nframes, int volume), {
         {buf: raw.buffer, vol: (volume | 0) & 7, sil: silent},
         [raw.buffer]
     );
+
+    // Fresh (<500 ms) worklet fill report, if any
+    if (ga.fillAt !== undefined && (performance.now() - ga.fillAt) < 500)
+        return Math.max(0, Math.min(2000, Math.round(ga.fill * 1000)));
+    return -1;
 });
 // clang-format on
 
@@ -351,11 +375,23 @@ static void gs_audio_set_rate(int rate) {
     }
 }
 
+// Last worklet-reported ring fill (fraction of target depth) and when it was
+// captured, in host seconds. Written on the emulator thread (the only pusher)
+// and read by the scheduler's governor on the same thread.
+static double g_ring_fill = -1.0;
+static double g_ring_fill_time = -1.0;
+
 static void gs_audio_push(uint32_t ptr, int nframes, int volume) {
+    int fill_pm;
     if (emscripten_is_main_browser_thread()) {
-        gs_audio_push_js(ptr, nframes, volume);
+        fill_pm = gs_audio_push_js(ptr, nframes, volume);
     } else {
-        emscripten_sync_run_in_main_runtime_thread(EM_FUNC_SIG_VIII, gs_audio_push_js, ptr, nframes, volume);
+        fill_pm =
+            (int)emscripten_sync_run_in_main_runtime_thread(EM_FUNC_SIG_IIII, gs_audio_push_js, ptr, nframes, volume);
+    }
+    if (fill_pm >= 0) {
+        g_ring_fill = (double)fill_pm / 1000.0;
+        g_ring_fill_time = host_time();
     }
 }
 
@@ -392,4 +428,14 @@ void platform_audio_push(const int16_t *frames, int nframes, int vol_0_7) {
 // Change the source sample rate mid-stream
 void platform_audio_set_rate(uint32_t src_rate_hz) {
     gs_audio_set_rate((int)src_rate_hz);
+}
+
+// Ring fill fraction against target depth for the accelerated-mode governor.
+// Fresh only while the producer is actively pushing (each push refreshes the
+// cache from the worklet's periodic reports); goes stale — and reads as
+// "no signal" — within half a second of the stream idling.
+double platform_audio_ring_fill(void) {
+    if (g_ring_fill < 0.0 || g_ring_fill_time < 0.0 || host_time() - g_ring_fill_time > 0.5)
+        return -1.0;
+    return g_ring_fill;
 }

--- a/src/platform/wasm/platform.h
+++ b/src/platform/wasm/platform.h
@@ -191,6 +191,13 @@ void platform_audio_push(const int16_t *frames, int nframes, int vol_0_7);
 // Change the source sample rate mid-stream (stream restart host-side)
 void platform_audio_set_rate(uint32_t src_rate_hz);
 
+// Host audio ring fill fraction against its target depth (0.0 = empty,
+// 1.0 = at target), or < 0 when no fresh signal exists (stream closed, audio
+// idle, worklet not yet reporting). Optional feedback for the accelerated-
+// mode governor: a draining ring means the real-time deadline is already
+// being missed where it hurts first.
+double platform_audio_ring_fill(void);
+
 // === Timing Functions ===
 
 #define PLATFORM_TICKS_PER_SEC 1000

--- a/tests/e2e/web2-specs/iicx-video-modes.spec.ts
+++ b/tests/e2e/web2-specs/iicx-video-modes.spec.ts
@@ -203,7 +203,7 @@ test('IIcx video modes: post-shader canvas matches per-mode baselines', async ({
 
     // Turbo (unthrottled) batching, then the three bounded run stages with
     // the boot-drive-wait skip pokes (same mechanics as the integration test).
-    await page.getByRole('button', { name: 'turbo', exact: true }).click();
+    await page.getByRole('button', { name: 'fast-forward', exact: true }).click();
     await page.locator('button.ptab[data-tab="terminal"]').click();
     await expect(page.locator('.xterm')).toBeVisible({ timeout: 15_000 });
     // The machine auto-runs after boot; halt it so the bounded run stages

--- a/tests/e2e/web2-specs/scheduler-accelerated.spec.ts
+++ b/tests/e2e/web2-specs/scheduler-accelerated.spec.ts
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) pappadf
+
+// web2 e2e: the Accelerated scheduler button (proposal-scheduler-accelerated-
+// mode.md §9, last bullet) — the third toolbar mode switches the core to
+// `accelerated`, instruction throughput rises above Real-Time (the adaptive
+// governor climbing under the real RAF loop), and the *timebase* stays locked
+// to real wall-clock while it does.
+//
+// The two rates that pin the mode's contract, both read through the shipped
+// Terminal panel (web2 has no window.gsEval):
+//   - scheduler.cycles per wall second: cycles ARE the guest timebase (VBL,
+//     VIA φ2 and sound all divide them down), so this must sit at the
+//     machine's clock rate in Real-Time AND in Accelerated — and it is what
+//     separates Accelerated from Fast-Forward, where time itself runs fast.
+//   - machine.cpu.instr_count per wall second: in Real-Time this is
+//     cycles/CPI; Accelerated raises it while cycles/s stays put.
+//
+// The machine is an SE/30 with no media, free-running at the ROM's insert-
+// disk prompt under the real RAF loop — a busy-wait, so instructions retire
+// at full rate without booting an OS. All bounds are generous: terminal
+// round-trips add ±hundreds of ms to the wall-clock windows, and CI hosts
+// pace RAF with their own jitter.
+
+import { test, expect, type Page } from '@playwright/test';
+import * as path from 'node:path';
+import { gotoWeb2 } from '../helpers/web2-fs';
+
+const DATA = path.resolve(__dirname, '../../data');
+const SE30_ROM = path.join(DATA, 'roms', 'SE30.rom');
+
+// SE/30: 15.6672 MHz, authentic CPI 4.
+const SE30_HZ = 15_667_200;
+
+// Type one shell line into the Terminal panel's xterm. A trailing settle
+// lets the async worker round-trip land before the next interaction.
+async function terminalRun(page: Page, line: string): Promise<void> {
+  const term = page.locator('.xterm');
+  await term.click();
+  await page.keyboard.type(line);
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(250);
+}
+
+// Probe the cycle and instruction counters with a fresh key per probe so
+// stale terminal echoes can't satisfy the match (same pattern as
+// iicx-video-modes.spec.ts).
+let probeSeq = 0;
+async function probeCounters(
+  page: Page,
+): Promise<{ cycles: number; instr: number }> {
+  for (let attempt = 0; attempt < 30; attempt++) {
+    const key = `rate${++probeSeq}`;
+    await terminalRun(
+      page,
+      `echo ${key}=\${scheduler.cycles},\${machine.cpu.instr_count}`,
+    );
+    await page.waitForTimeout(400);
+    const text = await page.locator('.xterm-rows').innerText();
+    const m = text.match(new RegExp(`${key}=(\\d+),(\\d+)`));
+    if (m) return { cycles: Number(m[1]), instr: Number(m[2]) };
+  }
+  throw new Error('terminal counter probe never answered');
+}
+
+// Read a string expression through the terminal (mode readbacks). The value
+// pattern is strict word characters so the echoed *input* line (which still
+// shows the unexpanded ${...}) can never satisfy the match — only the
+// response can.
+async function probeString(page: Page, expr: string): Promise<string> {
+  for (let attempt = 0; attempt < 30; attempt++) {
+    const key = `str${++probeSeq}`;
+    await terminalRun(page, `echo ${key}=[${'$'}{${expr}}]`);
+    await page.waitForTimeout(400);
+    const text = await page.locator('.xterm-rows').innerText();
+    const m = text.match(new RegExp(`${key}=\\[([A-Za-z0-9_.-]+)\\]`));
+    if (m) return m[1];
+  }
+  throw new Error('terminal string probe never answered');
+}
+
+// Wall-clock rate measurement across `seconds` of free-running emulation.
+// The window is timed around the probes themselves so terminal latency lands
+// inside the measured interval rather than skewing it.
+async function measureRates(
+  page: Page,
+  seconds: number,
+): Promise<{ cyclesPerSec: number; instrPerSec: number }> {
+  const a = await probeCounters(page);
+  const ta = Date.now();
+  await page.waitForTimeout(seconds * 1000);
+  const b = await probeCounters(page);
+  const dt = (Date.now() - ta) / 1000;
+  return {
+    cyclesPerSec: (b.cycles - a.cycles) / dt,
+    instrPerSec: (b.instr - a.instr) / dt,
+  };
+}
+
+test('Accelerated toolbar mode: faster CPU, real-time timebase', async ({
+  page,
+}) => {
+  test.setTimeout(10 * 60 * 1000);
+  await gotoWeb2(page);
+
+  // SE/30 ROM via the Welcome "Upload ROM..." button; built-in video, so no
+  // vROM staging and no video-mode plumbing.
+  const [romChooser] = await Promise.all([
+    page.waitForEvent('filechooser'),
+    page.getByRole('button', { name: 'Upload ROM...' }).click(),
+  ]);
+  await romChooser.setFiles(SE30_ROM);
+
+  // New Machine: SE/30, 8 MB, no media — free-runs at the flashing-? insert
+  // prompt, a busy-wait that retires instructions at full rate.
+  await page.getByRole('button', { name: 'New Machine...' }).click();
+  const model = page.locator('#cfg-model');
+  await expect(model.locator('option[value="se30"]')).toHaveCount(1, {
+    timeout: 30_000,
+  });
+  await model.selectOption('se30');
+  await page.locator('#cfg-ram').selectOption('8 MB');
+  await page.getByRole('button', { name: 'Start Machine' }).click();
+  await expect(
+    page.locator('.toast .msg').filter({ hasText: 'Machine started' }),
+  ).toBeVisible({
+    timeout: 60_000,
+  });
+
+  // Terminal up (the typed path to the object model).
+  await page.locator('button.ptab[data-tab="terminal"]').click();
+  await expect(page.locator('.xterm')).toBeVisible({ timeout: 15_000 });
+
+  // --- Real-Time baseline ---------------------------------------------------
+  // Default mode is live/paced; the cycle rate must sit at the SE/30's clock
+  // and instructions at cycles/CPI (authentic 4).
+  expect(await probeString(page, 'scheduler.mode')).toBe('paced');
+  const live = await measureRates(page, 6);
+  expect(live.cyclesPerSec).toBeGreaterThan(SE30_HZ * 0.5);
+  expect(live.cyclesPerSec).toBeLessThan(SE30_HZ * 1.5);
+  expect(live.cyclesPerSec / live.instrPerSec).toBeGreaterThan(3.6); // ~CPI 4
+  expect(live.cyclesPerSec / live.instrPerSec).toBeLessThan(4.4);
+
+  // --- Switch to Accelerated -------------------------------------------------
+  await page.getByRole('button', { name: 'accelerated', exact: true }).click();
+  await expect
+    .poll(async () => probeString(page, 'scheduler.mode'), { timeout: 30_000 })
+    .toBe('accelerated');
+  expect(await probeString(page, 'scheduler.speed_auto')).toBe('true');
+
+  // The adaptive governor climbs one quantized rung per ~2 s dwell as long as
+  // the host shows headroom; wait until throughput clears 1.4x the Real-Time
+  // baseline (first rung is 1.5x, so this is one climb with margin).
+  await expect
+    .poll(async () => (await measureRates(page, 3)).instrPerSec, {
+      timeout: 120_000,
+    })
+    .toBeGreaterThan(live.instrPerSec * 1.4);
+
+  // --- The §9 property, measured in one window -------------------------------
+  // CPU-bound throughput up, timebase unchanged: instructions per real second
+  // beat Real-Time while cycles per real second stay at the machine's clock.
+  const accel = await measureRates(page, 6);
+  expect(accel.instrPerSec).toBeGreaterThan(live.instrPerSec * 1.4);
+  expect(accel.cyclesPerSec).toBeGreaterThan(live.cyclesPerSec * 0.7);
+  expect(accel.cyclesPerSec).toBeLessThan(live.cyclesPerSec * 1.3);
+
+  // --- Back to Real-Time ------------------------------------------------------
+  await page.getByRole('button', { name: 'real-time', exact: true }).click();
+  await expect
+    .poll(async () => probeString(page, 'scheduler.mode'), { timeout: 30_000 })
+    .toBe('paced');
+});

--- a/tests/unit/suites/scheduler/platform.h
+++ b/tests/unit/suites/scheduler/platform.h
@@ -55,4 +55,8 @@ static inline uint64_t platform_ticks(void) {
 // Controllable fake host clock, implemented in test.c
 double host_time(void);
 
+// Controllable fake audio-ring fill signal (governor tests), implemented in
+// test.c; < 0 = no signal, matching the real platform contract.
+double platform_audio_ring_fill(void);
+
 #endif // PLATFORM_H

--- a/tests/unit/suites/scheduler/test.c
+++ b/tests/unit/suites/scheduler/test.c
@@ -38,6 +38,20 @@
 //   - the speed setter clamps to [1x, 8x]
 //   - pacing: accelerated shares the paced wall-clock accumulator (rate
 //     converges to VBL_HZ, bursts capped)
+//
+// Adaptive governor (stage 2 — scheduler.speed = 0/auto; the stub CPU's
+// per-instruction host cost closes the control loop, since faster speeds
+// retire more instructions per frame and thus consume more fake host time):
+//   - steady fast host: climbs the quantized ladder one rung at a time,
+//     monotonically, respecting the dwell slew limit, and settles at the cap
+//   - steady slow host: never leaves the authentic floor (degrades to paced)
+//   - load spike: multiplicative back-off within a couple of ticks, settling
+//     at the highest rung whose utilization clears the ceiling
+//   - audio-ring pressure (optional signal) forces a back-off even at low
+//     measured utilization; signal absence (< 0) is ignored
+//   - max_speed caps both the governor and pinned speeds
+//   - pin/unpin: writing a speed pins (governor off), 0 returns to auto and
+//     restarts from the authentic floor
 
 #include "object.h"
 #include "scheduler.h"
@@ -61,6 +75,14 @@ static double g_secs_per_instr; // simulated emulation cost (0 = free)
 
 double host_time(void) {
     return g_now;
+}
+
+// --- Fake audio-ring signal (governor feedback) ----------------------------
+
+static double g_audio_fill = -1.0; // < 0 = no signal (the default contract)
+
+double platform_audio_ring_fill(void) {
+    return g_audio_fill;
 }
 
 // --- Stubs ------------------------------------------------------------------
@@ -209,6 +231,7 @@ static void ping_event(void *source, uint64_t data) {
 static scheduler_t *fresh_scheduler(bool with_ping) {
     g_now = 0.0;
     g_secs_per_instr = 0.0;
+    g_audio_fill = -1.0;
     g_vbls = 0;
     g_pings = 0;
     scheduler_t *s = scheduler_init(TEST_CPU, NULL);
@@ -602,6 +625,199 @@ TEST(test_accelerated_paced_pacing) {
     teardown(s);
 }
 
+// --- Adaptive governor (stage 2) ---------------------------------------------
+
+// Authentic instructions per frame-unit, measured (12 CPI at 7.8336 MHz).
+static uint64_t authentic_per_frame(void) {
+    scheduler_t *s = fresh_scheduler(false);
+    uint64_t i0 = cpu_instr_count();
+    scheduler_run_frame(s, TEST_CFG);
+    uint64_t pf = cpu_instr_count() - i0;
+    teardown(s);
+    return pf;
+}
+
+// Drive `ticks` 60 Hz main-loop ticks against the governor, tracking the
+// per-frame instruction count (the observable for the current speed rung).
+// Asserts every change is a single monotonic step when `expect_monotonic`,
+// and records the smallest host-time gap between consecutive changes.
+typedef struct {
+    uint64_t final_pf; // per-frame instructions after the last clean sample
+    int changes; // number of distinct per-frame-count transitions
+    double min_gap; // smallest host-seconds gap between transitions
+    uint64_t max_pf; // largest per-frame count ever observed
+} gov_trace_t;
+
+static gov_trace_t gov_drive(scheduler_t *s, double *now, int ticks, bool expect_monotonic) {
+    gov_trace_t t = {0, 0, 1e9, 0};
+    uint64_t prev_instr = cpu_instr_count();
+    uint64_t prev_vbls = g_vbls;
+    double last_change = *now;
+    for (int i = 0; i < ticks; i++) {
+        *now += 1.0 / 60.0;
+        tick_at(*now);
+        uint64_t vd = g_vbls - prev_vbls;
+        uint64_t id = cpu_instr_count() - prev_instr;
+        prev_vbls = g_vbls;
+        prev_instr = cpu_instr_count();
+        if (vd != 1)
+            continue; // only clean single-frame ticks give a per-frame sample
+        if (id > t.max_pf)
+            t.max_pf = id;
+        if (t.final_pf != 0 && id != t.final_pf) {
+            double gap = *now - last_change;
+            if (gap < t.min_gap)
+                t.min_gap = gap;
+            if (expect_monotonic)
+                ASSERT_TRUE(id > t.final_pf);
+            t.changes++;
+            last_change = *now;
+        } else if (t.final_pf == 0) {
+            last_change = *now;
+        }
+        t.final_pf = id;
+    }
+    return t;
+}
+
+// Steady fast host: the governor climbs the ladder one rung at a time —
+// monotonically, each step after at least the dwell time — and settles at
+// the 8x cap without ever overshooting it.
+TEST(test_governor_climbs_to_cap) {
+    uint64_t pf1 = authentic_per_frame();
+
+    scheduler_t *s = fresh_scheduler(false);
+    scheduler_set_mode(s, schedule_accelerated); // speed defaults to auto
+    // 1x utilization ~0.05: plenty of headroom all the way to 8x (~0.40)
+    g_secs_per_instr = 0.05 * VBL_PERIOD / (double)pf1;
+
+    double now = 0.0;
+    gov_trace_t t = gov_drive(s, &now, 25 * 60, true);
+
+    ASSERT_TRUE(t.changes == 6); // rung 0 -> 6, one step at a time
+    ASSERT_TRUE(t.min_gap > 1.8); // dwell slew limit respected (2 s nominal)
+    double ratio = (double)t.final_pf / (double)pf1;
+    ASSERT_TRUE(ratio > 7.9 && ratio < 8.1); // settled at the cap
+    ASSERT_TRUE((double)t.max_pf / (double)pf1 < 8.1); // never above it
+    teardown(s);
+}
+
+// Steady slow host: utilization at 1x already breaches the ceiling, so the
+// governor never leaves the authentic floor — accelerated degrades to paced.
+TEST(test_governor_slow_host_stays_authentic) {
+    uint64_t pf1 = authentic_per_frame();
+
+    scheduler_t *s = fresh_scheduler(false);
+    scheduler_set_mode(s, schedule_accelerated);
+    g_secs_per_instr = 0.95 * VBL_PERIOD / (double)pf1; // 1x utilization ~0.95
+
+    double now = 0.0;
+    gov_trace_t t = gov_drive(s, &now, 10 * 60, true);
+
+    ASSERT_TRUE(t.changes == 0); // never climbed
+    ASSERT_TRUE(t.final_pf == pf1); // authentic instructions per frame
+    teardown(s);
+}
+
+// Load spike: after climbing on a fast host, a 4x cost spike drives
+// utilization far past the ceiling; the governor backs off within a couple
+// of ticks per rung — no dwell on the way down — and settles at the highest
+// rung whose utilization clears the ceiling (3x here: 0.06 * 4 * 3 = 0.72).
+TEST(test_governor_spike_backoff) {
+    uint64_t pf1 = authentic_per_frame();
+
+    scheduler_t *s = fresh_scheduler(false);
+    scheduler_set_mode(s, schedule_accelerated);
+    g_secs_per_instr = 0.06 * VBL_PERIOD / (double)pf1;
+
+    double now = 0.0;
+    gov_trace_t t = gov_drive(s, &now, 25 * 60, true);
+    ASSERT_TRUE((double)t.final_pf / (double)pf1 > 7.9); // reached the cap
+
+    g_secs_per_instr *= 4.0; // spike: 8x now costs ~1.92 of the budget
+    gov_trace_t back = gov_drive(s, &now, 12 * 60, false);
+    double settled = (double)back.final_pf / (double)pf1;
+    ASSERT_TRUE(settled > 2.9 && settled < 3.1); // backed off to 3x
+    ASSERT_TRUE(back.changes >= 3); // stepped down through the rungs
+    teardown(s);
+}
+
+// Audio-ring pressure: a draining host ring forces a back-off even when the
+// measured utilization is comfortable; a recovered ring lets it climb again.
+TEST(test_governor_audio_pressure) {
+    uint64_t pf1 = authentic_per_frame();
+
+    scheduler_t *s = fresh_scheduler(false);
+    scheduler_set_mode(s, schedule_accelerated);
+    g_secs_per_instr = 0.05 * VBL_PERIOD / (double)pf1;
+
+    double now = 0.0;
+    gov_trace_t t = gov_drive(s, &now, 7 * 60, true);
+    ASSERT_TRUE(t.final_pf > pf1); // climbed at least one rung
+
+    uint64_t before = t.final_pf;
+    g_audio_fill = 0.2; // ring draining: pressure regardless of utilization
+    gov_trace_t drop = gov_drive(s, &now, 3 * 60, false);
+    ASSERT_TRUE(drop.final_pf < before); // backed off
+
+    g_audio_fill = 1.0; // ring healthy again: climbing resumes
+    gov_trace_t re = gov_drive(s, &now, 10 * 60, false);
+    ASSERT_TRUE(re.final_pf > drop.final_pf);
+    teardown(s);
+}
+
+// max_speed caps the governor's ceiling — and clamps pinned speeds too.
+TEST(test_governor_max_speed_cap) {
+    uint64_t pf1 = authentic_per_frame();
+
+    scheduler_t *s = fresh_scheduler(false);
+    scheduler_set_mode(s, schedule_accelerated);
+    scheduler_set_max_speed(s, 3.0);
+    g_secs_per_instr = 0.05 * VBL_PERIOD / (double)pf1;
+
+    double now = 0.0;
+    gov_trace_t t = gov_drive(s, &now, 15 * 60, true);
+    double ratio = (double)t.final_pf / (double)pf1;
+    ASSERT_TRUE(ratio > 2.9 && ratio < 3.1); // settled exactly at the 3x cap
+    ASSERT_TRUE((double)t.max_pf / (double)pf1 < 3.1); // never above it
+
+    // A pinned speed is clamped to the cap as well
+    scheduler_set_speed(s, 8.0);
+    uint64_t i0 = cpu_instr_count();
+    scheduler_run_frame(s, TEST_CFG);
+    double pinned = (double)(cpu_instr_count() - i0) / (double)pf1;
+    ASSERT_TRUE(pinned > 2.9 && pinned < 3.1);
+    teardown(s);
+}
+
+// Pin/unpin: auto starts from the authentic floor; a written speed pins the
+// multiplier immediately; writing 0 returns to auto at the floor again.
+TEST(test_governor_pin_unpin) {
+    uint64_t pf1 = authentic_per_frame();
+
+    scheduler_t *s = fresh_scheduler(false);
+    scheduler_set_mode(s, schedule_accelerated);
+
+    // Auto, no main-loop ticks yet: the governor sits at the authentic floor
+    uint64_t i0 = cpu_instr_count();
+    scheduler_run_frame(s, TEST_CFG);
+    ASSERT_TRUE(cpu_instr_count() - i0 == pf1);
+
+    // Pin 4x: takes effect immediately, no governor involved
+    scheduler_set_speed(s, 4.0);
+    i0 = cpu_instr_count();
+    scheduler_run_frame(s, TEST_CFG);
+    double pinned = (double)(cpu_instr_count() - i0) / (double)pf1;
+    ASSERT_TRUE(pinned > 3.9 && pinned < 4.1);
+
+    // Unpin (0 = auto): back to the floor until the governor earns headroom
+    scheduler_set_speed(s, 0.0);
+    i0 = cpu_instr_count();
+    scheduler_run_frame(s, TEST_CFG);
+    ASSERT_TRUE(cpu_instr_count() - i0 == pf1);
+    teardown(s);
+}
+
 int main(void) {
     RUN(test_paced_rate_60hz);
     RUN(test_paced_rate_5994hz);
@@ -617,6 +833,12 @@ int main(void) {
     RUN(test_accelerated_mode_switch_hygiene);
     RUN(test_accelerated_speed_clamp);
     RUN(test_accelerated_paced_pacing);
+    RUN(test_governor_climbs_to_cap);
+    RUN(test_governor_slow_host_stays_authentic);
+    RUN(test_governor_spike_backoff);
+    RUN(test_governor_audio_pressure);
+    RUN(test_governor_max_speed_cap);
+    RUN(test_governor_pin_unpin);
     fprintf(stderr, "[OK  ] scheduler suite passed\n");
     return 0;
 }


### PR DESCRIPTION
Completes `local/gs-docs/proposals/proposal-scheduler-accelerated-mode.md` — everything deferred from stage 1 (#58).

## Adaptive governor (§4)

`scheduler.speed = 0` (**the new default**) hands the accelerated-mode speed to a closed-loop controller fed by the paced main loop's measured per-frame host cost (the same site that maintains `host_secs_per_vbl` — a controller on existing plumbing, per §4.1):

- **AIMD on a quantized ladder** (1×, 1.5×, 2×, 3×, 4×, 6×, 8×): one rung **down** immediately when smoothed utilization crosses 0.90 *or* the audio ring drains below half target; one rung **up** only after 2 s dwell, outside a 1 s post-back-off holdoff, and only when utilization *projected at the next rung* stays under the 0.80 headroom target (§4.2).
- **Slew/quantization as correctness** (§4.4): the guest calibrates instruction-counted delays (`TimeDBRA`) at boot, so the machine dwells at stable speeds rather than gliding. The utilization EWMA is rescaled on every step (utilization ∝ instructions/frame), keeping the estimator meaningful.
- **Bounds** (§4.3): floor = authentic CPI — an overloaded host degrades to exactly `paced`; ceiling = the new **`scheduler.max_speed`** (1–8, default 8, persisted in the checkpoint prefix). Governor state is transient — a restore or mode switch re-learns from fresh measurements.
- Writing a nonzero `scheduler.speed` still **pins** a fixed multiplier (the §4.4-safe configuration, and the only accelerated path headless, which never produces the governor's host-timing signal). `scheduler.speed` reads back the multiplier *in force* — the proposal's "effective multiplier, RO while adaptive". New RO `scheduler.speed_auto` flags governor control.

## Audio-ring feedback (§11.3)

The worklet posts its fill level (vs target depth) every 32 quanta; the node side caches it, and the **already main-thread-proxied push call returns it** to the emulator thread — zero additional round trips. Core reads `platform_audio_ring_fill()`: fraction, or `< 0` when stale (>0.5 s — stream idle) or absent (headless inline stub). The governor treats the signal as strictly optional, exactly as §11.3 requires.

## §5.1 relabel (open question 1 → adopted)

Toolbar buttons are now **real-time / accelerated / fast-forward** with the proposal's tooltips. Internal mode ids (`live`/`accel`/`turbo`) and the core enum names are unchanged. The one e2e locator that clicked `turbo` by name now clicks `fast-forward` (verified by running a video-modes subset locally).

## New e2e (§9 last bullet)

`scheduler-accelerated.spec.ts`: free-runs an SE/30 at the ROM insert-disk prompt (busy-wait — full instruction rate without booting an OS), clicks Accelerated, and asserts the mode's contract through the Terminal panel:
- instructions per wall second climb past 1.4× the Real-Time baseline (the governor's first rung is 1.5×), and
- **cycles per wall second — the guest timebase — stay at the machine clock** in both modes (this is precisely what separates Accelerated from Fast-Forward),
then round-trips back to Real-Time. Bounds are generous for CI RAF/terminal jitter.

## Tests

- Scheduler unit suite: +6 closed-loop governor tests — the stub CPU's per-instruction host cost closes the control loop, so the tests exercise real feedback: monotonic one-rung climbs with the dwell gap measured, slow-host floor clamp, spike back-off settling at the analytically predicted rung, audio-pressure back-off and recovery, `max_speed` capping both governor and pinned speeds, pin/unpin semantics. 20/20.
- 94/94 integration, 29/29 unit suites, wasm + headless builds, web2 typecheck + 339 vitest, new e2e passes locally in 32 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)