### PR TITLE
status bar: show the accelerated-mode effective CPU speed

### DIFF
--- a/app/web2/src/bus/emulator.ts
+++ b/app/web2/src/bus/emulator.ts
@@ -11,6 +11,7 @@
 import {
   machine,
   setSchedulerMode,
+  setAcceleratedSpeed,
   type MachineStatus,
   type MmuKind,
   type SchedulerMode,
@@ -74,6 +75,7 @@ interface EmscriptenModuleConfig {
   onScreenResize?(w: number, h: number, parW?: number, parH?: number): void;
   onLogEmit?(line: string): void;
   onFloppyChange?(drive: number, present: boolean): void;
+  onSchedulerSpeed?(speedX256: number): void;
 }
 
 type CreateModule = (config: EmscriptenModuleConfig) => Promise<EmscriptenModule>;
@@ -144,6 +146,7 @@ export async function bootstrap(canvas: HTMLCanvasElement, wasmArgs: string[] = 
     onScreenResize: handleScreenResize,
     onLogEmit: routeLogEmit,
     onFloppyChange: onFloppyDriveChange,
+    onSchedulerSpeed: handleSchedulerSpeed,
   });
 
   bridgePtr = Module._get_js_bridge();
@@ -319,6 +322,13 @@ function handleRunStateChange(running: boolean): void {
   // when we know a machine is live.
   if (r) machine.status = 'running';
   else if (machine.status === 'running') machine.status = 'paused';
+}
+
+// Core-pushed accelerated-mode effective CPU speed (x256; 256 = 1x). Edge-
+// driven on the governor's rung transitions — the status bar shows it in
+// Accelerated mode. Divide by 256 for the multiplier.
+function handleSchedulerSpeed(speedX256: number): void {
+  setAcceleratedSpeed((speedX256 | 0) / 256);
 }
 
 function handleScreenResize(w: number, h: number, parW?: number, parH?: number): void {

--- a/app/web2/src/components/status-bar/StatusBar.svelte
+++ b/app/web2/src/components/status-bar/StatusBar.svelte
@@ -2,6 +2,7 @@
   import { machine, type MachineStatus } from '@/state/machine.svelte';
   import { activity } from '@/state/activity.svelte';
   import DriveActivity from './DriveActivity.svelte';
+  import Icon from '../common/Icon.svelte';
 
   // Spec §11: hidden before first machine start. Also surfaces during
   // pre-boot uploads so the user can see large-file progress in the
@@ -22,6 +23,16 @@
   function shortModel(model: string): string {
     return model.replace(/^Macintosh\s+/i, '');
   }
+
+  // Accelerated-mode CPU speed readout. The core pushes the applied multiplier
+  // (1x in every other mode), so gate on the mode too. The governor's ladder
+  // gives 1/1.5/2/3/4/6/8x — show up to one decimal, dropping a trailing .0.
+  const showSpeed = $derived(machine.scheduler === 'accel');
+  const speedLabel = $derived(
+    Number.isInteger(machine.acceleratedSpeed)
+      ? `${machine.acceleratedSpeed}×`
+      : `${machine.acceleratedSpeed.toFixed(1)}×`,
+  );
 </script>
 
 {#if visible}
@@ -36,6 +47,14 @@
       <div class="sb-item sb-state" title="Machine state">
         <span class="dot"></span><span class="label">{stateLabel[machine.status]}</span>
       </div>
+      {#if showSpeed}
+        <div
+          class="sb-item sb-speed"
+          title="CPU running at {speedLabel} the original Mac's speed (Accelerated mode); games, sound and animation stay real-time"
+        >
+          <Icon name="chip" size={13} /><span class="label">{speedLabel}</span>
+        </div>
+      {/if}
       <DriveActivity label="HD" title="Hard disk" activity={machine.driveActivity.hd} />
       <DriveActivity label="FD" title="Floppy disk" activity={machine.driveActivity.fd} />
       <DriveActivity label="CD" title="CD-ROM" activity={machine.driveActivity.cd} />
@@ -118,6 +137,13 @@
   }
   .gs-statusbar.stopped .sb-state .dot {
     background: #f14c4c;
+  }
+  .sb-speed {
+    gap: 4px;
+    font-variant-numeric: tabular-nums;
+  }
+  .sb-speed :global(.icon) {
+    opacity: 0.85;
   }
   .sb-upload {
     gap: 6px;

--- a/app/web2/src/state/index.ts
+++ b/app/web2/src/state/index.ts
@@ -2,6 +2,7 @@ export {
   machine,
   setZoom,
   setSchedulerMode,
+  setAcceleratedSpeed,
   startDriveActivityMock,
   stopDriveActivityMock,
   type MachineStatus,

--- a/app/web2/src/state/machine.svelte.ts
+++ b/app/web2/src/state/machine.svelte.ts
@@ -43,6 +43,11 @@ interface MachineState {
   screen: { width: number; height: number; parW: number; parH: number };
   driveActivity: { hd: DriveActivity; fd: DriveActivity; cd: DriveActivity };
   scheduler: SchedulerMode;
+  // Effective CPU speed multiplier the core is currently applying (1 = the
+  // original Mac's speed). Only meaningful — and only shown — in `accel` mode,
+  // where the adaptive governor moves it; pushed from the core on change
+  // (bus/emulator.ts handleSchedulerSpeed). 1 in every other mode.
+  acceleratedSpeed: number;
   zoom: number;
 }
 
@@ -56,6 +61,7 @@ export const machine: MachineState = $state({
   screen: { width: 512, height: 342, parW: 1, parH: 1 },
   driveActivity: { hd: 'idle', fd: 'idle', cd: 'idle' },
   scheduler: 'live',
+  acceleratedSpeed: 1,
   zoom: 200,
 });
 
@@ -70,6 +76,17 @@ export function setZoom(value: number): void {
 // bus/emulator.ts (applySchedulerMode), which calls this on success.
 export function setSchedulerMode(mode: SchedulerMode): void {
   machine.scheduler = mode;
+  // Any mode switch resets the core's governor to the authentic floor
+  // (scheduler_set_mode → scheduler_governor_reset), so the applied speed is
+  // 1x until the governor earns headroom again. Mirror that immediately; the
+  // core's push then tracks the climb. (Not a guess — it matches the
+  // documented governor-reset behaviour, like the optimistic mode mirror.)
+  machine.acceleratedSpeed = 1;
+}
+
+// Core-pushed effective CPU speed multiplier (bus/emulator.ts handleSchedulerSpeed).
+export function setAcceleratedSpeed(multiplier: number): void {
+  machine.acceleratedSpeed = multiplier;
 }
 
 // ---- Drive activity mock ----

--- a/src/core/scheduler/scheduler.c
+++ b/src/core/scheduler/scheduler.c
@@ -1094,6 +1094,18 @@ void scheduler_set_max_speed(struct scheduler *restrict s, double multiplier) {
     scheduler_update_cpi_eff(s);
 }
 
+// The speed multiplier actually applied to the CPU right now, x256 fixed point
+// (256 = 1x = authentic). This is 1x in paced/unthrottled and, in accelerated
+// mode, the live multiplier (pinned or the governor's current rung). It is
+// what a UI should display as "how much faster than the original this CPU is
+// running" — a slowly-varying, core-driven signal (the governor steps it on a
+// ≥2 s dwell), suited to a push-on-change notification rather than polling.
+uint32_t scheduler_effective_speed_x256(struct scheduler *restrict s) {
+    if (!s || s->mode != schedule_accelerated)
+        return SPEED_X256_ONE;
+    return scheduler_current_speed_x256(s);
+}
+
 // Set the CPU clock frequency in Hz
 void scheduler_set_frequency(struct scheduler *restrict s, uint32_t frequency_hz) {
     if (!s)

--- a/src/core/scheduler/scheduler.h
+++ b/src/core/scheduler/scheduler.h
@@ -136,6 +136,11 @@ void scheduler_set_speed(struct scheduler *restrict s, double multiplier);
 // clamped to it at use. Persisted with the checkpoint prefix.
 void scheduler_set_max_speed(struct scheduler *restrict s, double multiplier);
 
+// The speed multiplier actually applied to the CPU right now, x256 fixed point
+// (256 = 1x). 1x in paced/unthrottled; in accelerated mode the live pinned or
+// governed multiplier. Divide by 256.0 for the display value.
+uint32_t scheduler_effective_speed_x256(struct scheduler *restrict s);
+
 // Set the CPU clock frequency in Hz (e.g. 7833600 for Plus, 15667200 for SE/30)
 void scheduler_set_frequency(struct scheduler *restrict s, uint32_t frequency_hz);
 

--- a/src/platform/wasm/em_main.c
+++ b/src/platform/wasm/em_main.c
@@ -799,6 +799,22 @@ void em_main_tick(void) {
             // clang-format on
         }
     }
+
+    // Push the accelerated-mode effective CPU speed (x256; 256 = 1x) to JS on
+    // change, same diff-and-async pattern as the run-state push. The value is
+    // 1x outside accelerated mode and the governor steps it only on a ≥2 s
+    // dwell, so this fires rarely — the status bar reads it edge-driven rather
+    // than polling. JS divides by 256 for the multiplier.
+    int speed_x256 = sched ? (int)scheduler_effective_speed_x256(sched) : 256;
+    static int last_reported_speed = -1;
+    if (speed_x256 != last_reported_speed) {
+        last_reported_speed = speed_x256;
+        // clang-format off
+        MAIN_THREAD_ASYNC_EM_ASM(
+            { if (typeof Module.onSchedulerSpeed === 'function') Module.onSchedulerSpeed($0); },
+            speed_x256);
+        // clang-format on
+    }
 }
 
 // Exposed tick wrapper for Emscripten main loop

--- a/tests/e2e/web2-specs/scheduler-accelerated.spec.ts
+++ b/tests/e2e/web2-specs/scheduler-accelerated.spec.ts
@@ -165,9 +165,20 @@ test('Accelerated toolbar mode: faster CPU, real-time timebase', async ({
   expect(accel.cyclesPerSec).toBeGreaterThan(live.cyclesPerSec * 0.7);
   expect(accel.cyclesPerSec).toBeLessThan(live.cyclesPerSec * 1.3);
 
+  // --- Status-bar readout ----------------------------------------------------
+  // The core pushes the governed multiplier (onSchedulerSpeed); the status bar
+  // shows it only in Accelerated mode. It must now read the climbed speed
+  // (> 1x — matching the throughput rise above).
+  const speed = page.locator('.gs-statusbar .sb-speed .label');
+  await expect(speed).toBeVisible({ timeout: 10_000 });
+  const shown = parseFloat((await speed.innerText()).replace('×', ''));
+  expect(shown).toBeGreaterThan(1);
+
   // --- Back to Real-Time ------------------------------------------------------
   await page.getByRole('button', { name: 'real-time', exact: true }).click();
   await expect
     .poll(async () => probeString(page, 'scheduler.mode'), { timeout: 30_000 })
     .toBe('paced');
+  // Leaving Accelerated hides the readout.
+  await expect(speed).toBeHidden({ timeout: 10_000 });
 });


### PR DESCRIPTION
Surfaces how fast the CPU is actually running in Accelerated mode — where the adaptive governor picks the speed on its own, and nothing previously showed it.

## Metric

The **effective speed multiplier** the core is applying (1× = the original Mac), rendered as a chip glyph + `N×` in the status bar, **only in Accelerated mode** (it's always 1× elsewhere). Chosen over raw MIPS because:

- It's the mode's contract made visible ("faster CPU"), and calibratable against the 1×–8× range the user knows.
- It's honest: it reflects the governor's *decision*, so it stays meaningful even when a guest idle loop retires few instructions — a MIPS readout would swing on guest workload for reasons unrelated to the mode working.

The governor's ladder yields 1 / 1.5 / 2 / 3 / 4 / 6 / 8×; the label shows up to one decimal, dropping a trailing `.0`.

## Delivery: push, matching the run-state idiom

Mirrors `onRunStateChange` / `onFloppyChange` exactly: `em_main_tick` diffs `scheduler_effective_speed_x256()` against a static and fires `MAIN_THREAD_ASYNC_EM_ASM(Module.onSchedulerSpeed)` **only on change**. The value is quantized and governor-dwell-gated (≥2 s between steps) and constant outside Accelerated, so this is edge-rare — no polling, no throttle, zero traffic once settled. The JS handler writes `machine.acceleratedSpeed`; a mode switch resets it to 1× locally (mirroring `scheduler_set_mode`'s governor reset), so the readout is correct the instant you enter the mode, before the first core push lands.

Poll was the alternative (a 1 Hz `gsEval('scheduler.speed')` needs no core change), but push is consistent with the datapoints it sits beside and cheaper at rest — see the design discussion. New core accessor `scheduler_effective_speed_x256()` returns 1× in paced/turbo and the live pinned/governed multiplier in accelerated.

## Tests

The existing `scheduler-accelerated.spec.ts` now also asserts the status bar shows the climbed multiplier (> 1×) once the governor has ramped, and hides it on return to Real-Time — end-to-end coverage of the whole worklet-free push path.

Verified locally: wasm + headless build, web2 typecheck + prettier + 339 vitest, 20/20 scheduler unit, and the accelerated e2e with the new assertions (29 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)