### PR TITLE
nubus: stage 2 — SOCKET topology, per-slot staged config, multi-card boot

### DIFF
--- a/app/web2/src/components/display/WelcomeConfigSlide.svelte
+++ b/app/web2/src/components/display/WelcomeConfigSlide.svelte
@@ -49,6 +49,9 @@
     // Per-card video slot shape (proposal §4.4) — the single source for both
     // the VROM requirement (per-card requires_vrom; see needsVrom) and the
     // video-mode list (each card's monitors × depths; see videoModes).
+    // Stage 2 of the computed-card-compatibility proposal emits EVERY
+    // declared socket here (all offering the same computed card list); the
+    // dialog configures the first entry only (see configSlot).
     video_slots?: Array<{
       slot: string;
       fixed: boolean;
@@ -124,12 +127,17 @@
     for (const v of allVroms) (out[v.cardId] ??= []).push(v);
     return out;
   });
-  // The current model's video-slot cards, flattened (machines have one slot).
-  let slotCards = $derived((currentProfile?.video_slots ?? []).flatMap((s) => s.cards ?? []));
+  // The slot this dialog configures: the FIRST video_slots entry.  Machines
+  // now declare every socket (stage 2 of the computed-card-compatibility
+  // proposal), all offering the same computed card list — the single picker
+  // drives the first one via the machine.nubus.video_card first-socket
+  // alias; a per-socket UI is future work.  On builtin-first machines
+  // (SE/30, IIci, IIsi) the first entry is the fixed built-in video, which
+  // keeps their no-picker/vROM-row behavior exactly as before.
+  let configSlot = $derived((currentProfile?.video_slots ?? [])[0]);
+  let slotCards = $derived(configSlot?.cards ?? []);
   // The slot's default card id (the C-side default pick).
-  let defaultCardId = $derived(
-    (currentProfile?.video_slots ?? []).find((s) => s.default_card)?.default_card ?? '',
-  );
+  let defaultCardId = $derived(configSlot?.default_card ?? '');
   // A card is offerable iff it needs no vROM (builtin) or its vROM is present.
   let availableCards = $derived(
     slotCards.filter((c) => !c.requires_vrom || (vromsByCardId[c.id]?.length ?? 0) > 0),

--- a/docs/guide/ARCHITECTURE.md
+++ b/docs/guide/ARCHITECTURE.md
@@ -460,15 +460,23 @@ the VROM prompt, and the slot labels all follow from data. Because capabilities
 are *derived* from the facts, they can never drift from behavior.
 
 **Computed card compatibility (no per-machine card lists).** A machine's slot
-table declares *topology* only (which slots exist, which hold a soldered-down
-builtin pseudo-card, the shipped default); each card kind declares its
-*attachment* (`card_attach_t` — a genuine NuBus card vs. builtin motherboard
-circuitry). Which cards a configurable slot offers is **computed** by matching
-the two (`nubus_card_fits_socket`), used identically by the `machine.profile`
-encoder and `nubus_init`'s boot-time pick validation. Adding a NuBus card is
-one registry line plus one `VROM_CATALOG` row — it is then offered on every
-machine with a socket, with no per-machine edits (see
-`proposal-nubus-computed-card-compatibility.md`).
+table declares *topology* only (which slots exist, which are user-populatable
+`SOCKET`s, which hold a soldered-down builtin pseudo-card, the shipped
+default); each card kind declares its *attachment* (`card_attach_t` — a
+genuine NuBus card vs. builtin motherboard circuitry). Which cards a socket
+offers is **computed** by matching the two (`nubus_card_fits_socket`), used
+identically by the `machine.profile` encoder and `nubus_init`'s boot-time
+pick validation. Adding a NuBus card is one registry line plus one
+`VROM_CATALOG` row — it is then offered on every machine with a socket, with
+no per-machine edits (see `proposal-nubus-computed-card-compatibility.md`).
+
+Each socket resolves its configuration independently at boot, so machines
+boot multi-card (e.g. two displays). Picks are staged per slot in the object
+model — `machine.nubus.slot[N].card_id` / `.video_mode`, consumed by the
+next `machine.boot` — while `machine.nubus.video_card` / `video_mode` remain
+as wildcard aliases meaning "the first socket" (what the config dialog and
+the headless `video_card=` arg use). `machine.screen` shows the *primary*
+display: the first populated video slot in declared order.
 
 The CPU is split into template-instantiated decoders (`cpu_68000.c`,
 `cpu_68030.c`) sharing helpers via `cpu_internal.h`. The memory subsystem uses a

--- a/src/core/peripherals/nubus/cards/jmfb.c
+++ b/src/core/peripherals/nubus/cards/jmfb.c
@@ -684,6 +684,11 @@ static int card_init(nubus_card_t *card, config_t *cfg, checkpoint_t *cp) {
         // the slot, but the rest of the machine still boots.
         LOG(0, "Apple-341-0868.vrom not found; declaration ROM is zero-filled");
     }
+    // Publish the declaration ROM on the card struct (drives the
+    // slot[N].card.declrom object-model node, same as the 24AC / 8•24 GC);
+    // nubus_delete owns and frees card->declrom after card_teardown.
+    card->declrom = p->vrom;
+    card->declrom_size = p->vrom_size;
 
     // If a pending video-mode id was set (via `machine.video_mode =
     // "13in_rgb_8bpp"`), resolve it now — it overrides the pending
@@ -870,7 +875,7 @@ static void card_teardown(nubus_card_t *card, config_t *cfg) {
     if (!p)
         return;
     free(p->vram);
-    free(p->vrom);
+    // p->vrom is published as card->declrom; nubus_delete owns and frees it.
     free(p->vrom_path);
     free(p);
     card->priv = NULL;

--- a/src/core/peripherals/nubus/nubus.c
+++ b/src/core/peripherals/nubus/nubus.c
@@ -9,6 +9,9 @@
 
 #include "nubus.h"
 #include "card.h"
+#include "display_card_24ac.h" // staged video-mode routing (stage_mode_for_kind)
+#include "display_card_824gc.h"
+#include "jmfb.h"
 #include "log.h"
 #include "machine_profile.h" // machine_substrate_t (slot-IRQ routing)
 #include "system_config.h"
@@ -26,6 +29,7 @@ LOG_USE_CATEGORY_NAME("nubus");
 // nubus.h so card drivers can't reach into it without the public API.
 struct nubus_bus {
     config_t *cfg;
+    const nubus_slot_decl_t *slots; // the machine's slot table (topology)
     nubus_card_t *cards[NUBUS_MAX_SLOTS]; // cards[$9..$E]; NULL elsewhere
     uint16_t slot_irq_mask; // bitmap; bit $9 .. bit $E
 };
@@ -60,24 +64,60 @@ const nubus_card_kind_t *nubus_card_find(const char *id) {
     return NULL;
 }
 
-// === Pending video-card selection ===========================================
+// === Staged per-slot configuration (proposal §5.6, stage 2) =================
 //
-// The VIDEO slot defaults to its declared default_card; this pending slot
-// lets the config dialog / a test override the pick for the next boot
-// without a machine-framework change.  At most 31 chars + NUL fits any
-// card id ("display_card_24ac" etc.).
-static char s_pending_video_card[32] = "";
+// One entry per slot ($9..$E) plus the WILDCARD entry [0] meaning "the
+// machine's first SOCKET" (the machine-independent channel behind the
+// `machine.nubus.video_card` / `video_mode` aliases and the headless
+// `video_card=` startup arg).  nubus_init consumes the whole table and
+// clears it so a stale pick can't leak into the next boot.
+typedef struct nubus_staged_slot {
+    char card[32]; // staged card-kind id ("" = none)
+    char mode[40]; // staged video-mode id ("" = none)
+} nubus_staged_slot_t;
+static nubus_staged_slot_t s_staged[NUBUS_MAX_SLOTS];
 
-void nubus_pending_video_card_set(const char *id) {
-    if (!id || !*id) {
-        s_pending_video_card[0] = '\0';
+// Valid staged-table keys: the wildcard, or a physical slot number.
+static bool staged_slot_valid(int slot) {
+    return slot == NUBUS_STAGED_WILDCARD || (slot >= 9 && slot < NUBUS_MAX_SLOTS);
+}
+
+void nubus_staged_card_set(int slot, const char *id) {
+    if (!staged_slot_valid(slot))
         return;
-    }
-    snprintf(s_pending_video_card, sizeof s_pending_video_card, "%s", id);
+    snprintf(s_staged[slot].card, sizeof s_staged[slot].card, "%s", (id && *id) ? id : "");
+}
+
+const char *nubus_staged_card_get(int slot) {
+    if (!staged_slot_valid(slot))
+        return NULL;
+    return s_staged[slot].card[0] ? s_staged[slot].card : NULL;
+}
+
+void nubus_staged_mode_set(int slot, const char *id) {
+    if (!staged_slot_valid(slot))
+        return;
+    snprintf(s_staged[slot].mode, sizeof s_staged[slot].mode, "%s", (id && *id) ? id : "");
+}
+
+const char *nubus_staged_mode_get(int slot) {
+    if (!staged_slot_valid(slot))
+        return NULL;
+    return s_staged[slot].mode[0] ? s_staged[slot].mode : NULL;
+}
+
+// Wildcard conveniences — the pre-stage-2 names, kept for the alias
+// attribute and the headless startup arg.
+void nubus_pending_video_card_set(const char *id) {
+    nubus_staged_card_set(NUBUS_STAGED_WILDCARD, id);
 }
 
 const char *nubus_pending_video_card_get(void) {
-    return s_pending_video_card[0] ? s_pending_video_card : NULL;
+    return nubus_staged_card_get(NUBUS_STAGED_WILDCARD);
+}
+
+static void staged_clear_all(void) {
+    memset(s_staged, 0, sizeof s_staged);
 }
 
 // Card ↔ slot compatibility, COMPUTED from the two declarations (see the
@@ -88,24 +128,54 @@ const char *nubus_pending_video_card_get(void) {
 bool nubus_card_fits_socket(const nubus_slot_decl_t *s, const nubus_card_kind_t *kind) {
     if (!s || !kind)
         return false;
-    if (s->kind != NUBUS_SLOT_VIDEO) // stage 2 renames this kind to SOCKET
+    if (s->kind != NUBUS_SLOT_SOCKET)
         return false;
     return kind->attach == CARD_ATTACH_NUBUS;
 }
 
-// Resolve the VIDEO slot's card id: honour the pending selection iff that
-// kind physically fits the slot, else fall back to default_card.  The
-// rejection logs at level 0 so a bad pick is visible by default instead of
-// silently booting the wrong card.
-static const char *video_slot_card_id(const nubus_slot_decl_t *s) {
-    const char *pending = nubus_pending_video_card_get();
-    if (pending) {
-        if (nubus_card_fits_socket(s, nubus_card_find(pending)))
-            return pending;
-        LOG(0, "nubus: pending video_card '%s' does not fit slot $%X; using default '%s'", pending, s->slot,
+// Resolve a SOCKET slot's card id: a staged pick for this exact slot beats
+// the wildcard (honoured only on the machine's FIRST socket, preserving the
+// single-pending era's semantics); both are honoured iff the named kind
+// physically fits the slot; the fallback is the declared default_card
+// (NULL = the socket ships empty).  Rejections log at level 0 so a bad pick
+// is visible by default instead of silently booting the wrong card.
+static const char *socket_card_id(const nubus_slot_decl_t *s, bool is_first_socket) {
+    const char *staged = nubus_staged_card_get(s->slot);
+    if (!staged && is_first_socket)
+        staged = nubus_staged_card_get(NUBUS_STAGED_WILDCARD);
+    if (staged) {
+        if (nubus_card_fits_socket(s, nubus_card_find(staged)))
+            return staged;
+        LOG(0, "nubus: staged card '%s' does not fit slot $%X; using default '%s'", staged, s->slot,
             s->default_card ? s->default_card : "(none)");
     }
     return s->default_card;
+}
+
+// The staged video-mode id for a SOCKET slot: this exact slot's entry, or
+// the wildcard's on the machine's first socket.
+static const char *socket_staged_mode(const nubus_slot_decl_t *s, bool is_first_socket) {
+    const char *mode = nubus_staged_mode_get(s->slot);
+    if (!mode && is_first_socket)
+        mode = nubus_staged_mode_get(NUBUS_STAGED_WILDCARD);
+    return mode;
+}
+
+// Route a staged video-mode id into the resolved card kind's pending-mode
+// channel — the per-driver static its factory consumes at init.  Validated
+// against the kind's own catalog so a mode staged for a different card is
+// skipped with a log rather than silently mis-seeding the slot PRAM.
+static void stage_mode_for_kind(int slot, const nubus_card_kind_t *kind, const char *mode) {
+    if (!mode || !*mode || !kind)
+        return;
+    if (kind == &mdc_8_24_kind && jmfb_video_mode_lookup(mode, NULL, NULL))
+        jmfb_pending_video_mode_set(mode);
+    else if (kind == &display_card_24ac_kind && display_card_24ac_video_mode_lookup(mode, NULL, NULL))
+        display_card_24ac_pending_video_mode_set(mode);
+    else if (kind == &display_card_824gc_kind && display_card_824gc_video_mode_lookup(mode, NULL, NULL))
+        display_card_824gc_pending_video_mode_set(mode);
+    else
+        LOG(0, "nubus: staged video_mode '%s' does not belong to slot $%X card '%s' — ignored", mode, slot, kind->id);
 }
 
 // === Bus controller =========================================================
@@ -117,23 +187,32 @@ nubus_bus_t *nubus_init(config_t *cfg, const nubus_slot_decl_t *slots, checkpoin
     if (!bus)
         return NULL;
     bus->cfg = cfg;
+    bus->slots = slots;
 
-    // Walk the slot table.  Per proposal §3.2.2: BUILTIN slots resolve
-    // their card via nubus_card_find(.builtin_card_id); VIDEO slots read
-    // the user's pick from the video.* pending statics (added later) and
-    // resolve through the same path.  Step 3 leaves both branches as
-    // skeletons because the registry is empty.
+    // Walk the slot table.  BUILTIN slots resolve their card via
+    // nubus_card_find(.builtin_card_id); each SOCKET resolves its staged
+    // pick (or default) independently, so a machine boots as many cards as
+    // its sockets carry configuration for (multi-display, proposal §5.6).
     if (slots) {
+        // The machine's first SOCKET — the slot the WILDCARD staged entry
+        // (the `machine.nubus.video_card` alias) applies to.
+        int first_socket = -1;
+        for (const nubus_slot_decl_t *s = slots; s->slot != 0; s++) {
+            if (s->kind == NUBUS_SLOT_SOCKET) {
+                first_socket = s->slot;
+                break;
+            }
+        }
         for (const nubus_slot_decl_t *s = slots; s->slot != 0; s++) {
             const nubus_card_kind_t *kind = NULL;
+            const char *staged_mode = NULL;
             switch (s->kind) {
             case NUBUS_SLOT_BUILTIN:
                 kind = nubus_card_find(s->builtin_card_id);
                 break;
-            case NUBUS_SLOT_VIDEO:
-                // Honour a pending `nubus.video_card` pick if that kind
-                // fits this slot; otherwise the slot default.
-                kind = nubus_card_find(video_slot_card_id(s));
+            case NUBUS_SLOT_SOCKET:
+                kind = nubus_card_find(socket_card_id(s, s->slot == first_socket));
+                staged_mode = socket_staged_mode(s, s->slot == first_socket);
                 break;
             case NUBUS_SLOT_ABSENT:
             case NUBUS_SLOT_EMPTY:
@@ -141,6 +220,11 @@ nubus_bus_t *nubus_init(config_t *cfg, const nubus_slot_decl_t *slots, checkpoin
             }
             if (!kind || !kind->factory)
                 continue;
+            // Route this slot's staged video mode into the kind's pending
+            // channel immediately before its factory consumes it, so each
+            // socket's mode seeds its own card even with several sockets.
+            if (staged_mode)
+                stage_mode_for_kind(s->slot, kind, staged_mode);
             nubus_card_t *card = kind->factory(s->slot, cfg, cp);
             if (!card) {
                 // Factory returned NULL — typically a missing/invalid VROM
@@ -155,11 +239,12 @@ nubus_bus_t *nubus_init(config_t *cfg, const nubus_slot_decl_t *slots, checkpoin
                 bus->cards[s->slot] = card;
         }
     }
-    // Consume the pending video-card pick so a stale selection doesn't
-    // leak into the next machine.boot (mirrors jmfb's pending-sense reset).
-    nubus_pending_video_card_set(NULL);
-    // Project the populated slots into the object model (proposal §3.8):
-    // machine.nubus.slot[N].card.{framebuffer,declrom,clut,mode,…}.
+    // Consume the whole staged table so a stale selection doesn't leak
+    // into the next machine.boot (mirrors jmfb's pending-sense reset).
+    staged_clear_all();
+    // Project the declared slots into the object model (proposal §3.8):
+    // machine.nubus.slot[N].card.{framebuffer,declrom,clut,mode,…} for
+    // populated slots, staged card_id/video_mode attrs on empty sockets.
     nubus_objects_build(bus);
     return bus;
 }
@@ -180,6 +265,16 @@ void nubus_delete(nubus_bus_t *bus) {
         bus->cards[i] = NULL;
     }
     free(bus);
+}
+
+const nubus_slot_decl_t *nubus_slot_decl_get(nubus_bus_t *bus, int slot) {
+    if (!bus || !bus->slots)
+        return NULL;
+    for (const nubus_slot_decl_t *s = bus->slots; s->slot != 0; s++) {
+        if (s->slot == slot)
+            return s;
+    }
+    return NULL;
 }
 
 nubus_card_t *nubus_card(nubus_bus_t *bus, int slot) {

--- a/src/core/peripherals/nubus/nubus.h
+++ b/src/core/peripherals/nubus/nubus.h
@@ -26,14 +26,16 @@ typedef struct config config_t;
 typedef struct checkpoint checkpoint_t;
 typedef struct display display_t;
 
-// Slot-table kinds.  See proposal §3.2.2.
+// Slot-table kinds.  See proposal §3.2.2 and
+// proposal-nubus-computed-card-compatibility.md §5.2.
 typedef enum nubus_slot_kind {
     NUBUS_SLOT_ABSENT = 0, // physical absence — bus errors on access
-    NUBUS_SLOT_EMPTY, // physically present, no card seated — GLUE rule
+    NUBUS_SLOT_EMPTY, // electrically decoded as empty (GLUE rule) but NOT
+                      // user-populatable — no connector (SE/30 $9..$B)
     NUBUS_SLOT_BUILTIN, // machine populates with a fixed card (e.g. SE/30 slot $E)
-    NUBUS_SLOT_VIDEO, // single user-configurable video slot — pick card,
-                      // monitor, depth from the dialog.  At most one VIDEO
-                      // entry per machine in v1.
+    NUBUS_SLOT_SOCKET, // physical connector — user-populatable; behaves
+                       // exactly like EMPTY when no card is configured.
+                       // A machine may declare any number of sockets.
 } nubus_slot_kind_t;
 
 // One entry in a machine's slot table.  Sentinel-terminated arrays end at
@@ -47,7 +49,8 @@ typedef struct nubus_slot_decl {
     int slot; // $9..$E (0 ends the array)
     nubus_slot_kind_t kind;
     const char *builtin_card_id; // BUILTIN: card-id resolved via nubus_card_find()
-    const char *default_card; // VIDEO: default when user hasn't picked
+    const char *default_card; // SOCKET: factory-default population when the
+                              // user hasn't staged a pick (NULL = ships empty)
 } nubus_slot_decl_t;
 
 // True iff card kind `kind` may be seated in slot `s`.  Compatibility is
@@ -79,14 +82,35 @@ static inline uint32_t nubus_super_slot_base(int slot) {
 nubus_bus_t *nubus_init(config_t *cfg, const nubus_slot_decl_t *slots, checkpoint_t *cp);
 void nubus_delete(nubus_bus_t *bus);
 
-// Pending user-selected video card id for the next machine.boot's VIDEO
-// slot.  Set via `machine.nubus.video_card = "display_card_24ac"` before boot;
-// nubus_init honours it iff the named kind fits the slot per
-// nubus_card_fits_socket (else it logs and falls back to default_card).  Cleared
-// after consumption so a stale pick doesn't leak into the next boot.
-// Passing NULL or "" clears the pending selection.
+// === Staged per-slot configuration (proposal §5.6, stage 2) ================
+//
+// User picks for the NEXT machine.boot live in a small staged table keyed by
+// slot number, consumed (and cleared) by nubus_init.  Slot 0 is the WILDCARD
+// entry meaning "the machine's first SOCKET" — the machine-independent
+// staging channel behind `machine.nubus.video_card` (and the headless
+// `video_card=` startup arg), preserved from the single-pending era.
+// Concrete slots ($9..$E) are staged via `machine.nubus.slot[N].card_id` /
+// `.video_mode`; a concrete entry beats the wildcard for that slot.  At
+// boot, a staged card is honoured iff it fits the slot per
+// nubus_card_fits_socket (else it logs and the slot falls back to
+// default_card); a staged mode is routed to the resolved card kind's
+// pending-mode channel just before its factory runs.
+#define NUBUS_STAGED_WILDCARD 0 // staged-table key for "first socket"
+void nubus_staged_card_set(int slot, const char *id); // NULL/"" clears
+const char *nubus_staged_card_get(int slot);
+void nubus_staged_mode_set(int slot, const char *id); // NULL/"" clears
+const char *nubus_staged_mode_get(int slot);
+
+// Wildcard-entry conveniences — the pre-stage-2 API, kept for the alias
+// attribute and the headless startup arg.  Equivalent to
+// nubus_staged_card_set/get(NUBUS_STAGED_WILDCARD, id).
 void nubus_pending_video_card_set(const char *id);
 const char *nubus_pending_video_card_get(void);
+
+// The slot declaration for slot `slot` on the running bus, or NULL when the
+// bus doesn't declare it.  Backs the object model's staged-attr validation
+// and empty-socket node enumeration.
+const nubus_slot_decl_t *nubus_slot_decl_get(nubus_bus_t *bus, int slot);
 
 // Per-slot IRQ assertion.  The bus aggregates and drives VIA2 PA[0..5]
 // (active-low) plus pulses CA1 on the umbrella transition.

--- a/src/core/peripherals/nubus/nubus_class.c
+++ b/src/core/peripherals/nubus/nubus_class.c
@@ -77,25 +77,28 @@ static value_t nubus_attr_video_sense_set(struct object *self, const member_t *m
     return val_none();
 }
 
-// `nubus.video_mode` — get/set a pending high-level video-mode id
-// for the next machine.boot.  The id matches one of the entries in
-// `machine.profile(...).video_modes[].id` (e.g. "13in_rgb_8bpp").
-// When the JMFB factory consumes the pending id it resolves it to a
-// (monitor, depth) tuple, overrides nubus.video_sense to the
-// monitor's sense_code, and writes the boot-ROM PRAM validity tokens
-// plus the slot-PRAMRec bytes so the Slot Manager's GET_SLOT_DEPTH
-// lands on the requested mode.  Reading returns the pending id (or
-// the empty string when none is set); writing "" clears it.
+// True iff `id` names a video mode in ANY registered card's catalog —
+// the set-time typo guard for staged video-mode ids.  Which card the mode
+// finally seeds is decided at boot (nubus_init routes each slot's staged
+// mode into its resolved card kind; a kind mismatch logs and is ignored).
+static bool video_mode_id_known(const char *id) {
+    return jmfb_video_mode_lookup(id, NULL, NULL) || display_card_24ac_video_mode_lookup(id, NULL, NULL) ||
+           display_card_824gc_video_mode_lookup(id, NULL, NULL);
+}
+
+// `nubus.video_mode` — get/set the staged high-level video-mode id for the
+// next machine.boot's FIRST socket (the wildcard staged entry — the
+// machine-independent alias, see nubus.h §staged configuration).  The id
+// matches one of `machine.profile(...).video_modes[].id` (e.g.
+// "13in_rgb_8bpp").  At boot the id is routed into the resolved card's
+// pending-mode channel; the card factory then writes the boot-ROM PRAM
+// validity tokens plus the slot-PRAMRec bytes so the Slot Manager's
+// GET_SLOT_DEPTH lands on the requested mode.  Reading returns the staged
+// id (or the empty string); writing "" clears it.
 static value_t nubus_attr_video_mode_get(struct object *self, const member_t *m) {
     (void)self;
     (void)m;
-    // Either card may hold the pending mode (the setter routes the id to the
-    // card whose catalog matched it); return whichever is set.
-    const char *id = jmfb_pending_video_mode_get();
-    if (!id)
-        id = display_card_24ac_pending_video_mode_get();
-    if (!id)
-        id = display_card_824gc_pending_video_mode_get();
+    const char *id = nubus_staged_mode_get(NUBUS_STAGED_WILDCARD);
     return val_str(id ? id : "");
 }
 
@@ -107,39 +110,22 @@ static value_t nubus_attr_video_mode_set(struct object *self, const member_t *m,
         return val_err("nubus.video_mode: expected string id (e.g. \"13in_rgb_8bpp\")");
     }
     const char *id = in.s ? in.s : "";
-    // Route the id to whichever card's catalog matches it (the monitor-name
-    // prefixes don't collide between cards), and clear the other card's
-    // pending so a stale pick can't leak.  Validate up front so a typo is
-    // caught at set time.  Empty string clears both.
-    if (!*id) {
-        jmfb_pending_video_mode_set("");
-        display_card_24ac_pending_video_mode_set("");
-        display_card_824gc_pending_video_mode_set("");
-    } else if (jmfb_video_mode_lookup(id, NULL, NULL)) {
-        jmfb_pending_video_mode_set(id);
-        display_card_24ac_pending_video_mode_set("");
-        display_card_824gc_pending_video_mode_set("");
-    } else if (display_card_24ac_video_mode_lookup(id, NULL, NULL)) {
-        display_card_24ac_pending_video_mode_set(id);
-        jmfb_pending_video_mode_set("");
-        display_card_824gc_pending_video_mode_set("");
-    } else if (display_card_824gc_video_mode_lookup(id, NULL, NULL)) {
-        display_card_824gc_pending_video_mode_set(id);
-        jmfb_pending_video_mode_set("");
-        display_card_24ac_pending_video_mode_set("");
-    } else {
+    // Validate up front so a typo is caught at set time; "" clears.
+    if (*id && !video_mode_id_known(id)) {
         value_t err = val_err("nubus.video_mode: unknown video-mode id '%s'", id);
         value_free(&in);
         return err;
     }
+    nubus_staged_mode_set(NUBUS_STAGED_WILDCARD, id);
     value_free(&in);
     return val_none();
 }
 
 // `nubus.video_card` — get/set the card id to install into the next
-// machine.boot's VIDEO slot.  Writes stage a pending pick that nubus_init
-// honours iff that kind fits the slot per nubus_card_fits_socket (else it
-// falls back to the slot default).  Reads return the pending id, or "" when none is
+// machine.boot's FIRST socket (the wildcard staged entry; concrete slots
+// stage via `slot[N].card_id`).  nubus_init honours the pick iff that kind
+// fits the socket per nubus_card_fits_socket (else it logs and falls back
+// to the slot default).  Reads return the staged id, or "" when none is
 // staged.  Settable from integration scripts via
 // `machine.nubus.video_card = "display_card_24ac"` before machine.boot.  The id
 // is validated against the registered card drivers so a typo is caught at
@@ -177,8 +163,10 @@ static value_t nubus_attr_video_card_set(struct object *self, const member_t *m,
 // node objects are created by nubus_objects_build() (called from nubus_init,
 // once the cards exist) and live here keyed by slot; nubus_objects_teardown()
 // (from nubus_delete) frees the trees before the cards they read go away.
-// Every node's instance_data is the nubus_card_t, so the accessors read live
-// card state (the display_t, the declrom, the card engine) and copy nothing.
+// The card node and its resource children carry the nubus_card_t as
+// instance_data, so their accessors read live card state (the display_t,
+// the declrom, the card engine) and copy nothing; the slot wrapper carries
+// only its slot number (an empty socket has no card to point at).
 // Resolution and SYSTEM-tab enumeration both work through object_attach: the
 // `slot` indexed member returns the slot wrapper, whose attached `card` child
 // (and its attached resource children) the resolver/meta-walker discover.
@@ -590,27 +578,119 @@ static const class_desc_t nubus_card_class = {
     .name = "card", .members = card_members, .n_members = sizeof(card_members) / sizeof(card_members[0])};
 
 // --- slot wrapper node ------------------------------------------------------
+//
+// Slot nodes exist for every declared SOCKET (populated or not) and every
+// BUILTIN slot, so an empty socket can be configured for the next boot via
+// its staged attrs.  Instance data is a per-slot int (the slot number) —
+// NOT the card — because empty sockets have no card; the card CHILD node
+// keeps the card pointer as before.
+static int s_slot_numbers[NUBUS_OBJ_SLOTS]; // instance data for slot nodes
+
+static int node_slot_number(struct object *self) {
+    const int *n = (const int *)object_data(self);
+    return n ? *n : -1;
+}
+
 static value_t slot_attr_number(struct object *self, const member_t *m) {
     (void)m;
-    nubus_card_t *c = node_card(self);
-    return val_int(c ? c->slot : -1);
+    return val_int(node_slot_number(self));
 }
+
+// `slot[N].card_id` — stage a card pick for THIS slot for the next
+// machine.boot (the concrete-slot sibling of the `nubus.video_card`
+// wildcard alias; a concrete entry beats the wildcard).  Only SOCKET slots
+// accept a pick; reads return the staged id ("" when none, and always ""
+// on builtin slots).  Cleared when nubus_init consumes it.
+static value_t slot_attr_card_id_get(struct object *self, const member_t *m) {
+    (void)m;
+    const char *id = nubus_staged_card_get(node_slot_number(self));
+    return val_str(id ? id : "");
+}
+
+static value_t slot_attr_card_id_set(struct object *self, const member_t *m, value_t in) {
+    (void)m;
+    int slot = node_slot_number(self);
+    if (in.kind != V_STRING) {
+        value_free(&in);
+        return val_err("slot[%X].card_id: expected card-id string (e.g. \"824gc\")", slot);
+    }
+    const char *id = in.s ? in.s : "";
+    const nubus_slot_decl_t *decl = nubus_slot_decl_get(g_obj_bus, slot);
+    if (!decl || decl->kind != NUBUS_SLOT_SOCKET) {
+        value_free(&in);
+        return val_err("slot[%X].card_id: slot is not a user-configurable socket", slot);
+    }
+    // "" clears; a non-empty id must name a registered card (typo guard).
+    if (*id && !nubus_card_find(id)) {
+        value_t err = val_err("slot[%X].card_id: unknown card id '%s' (see nubus.cards())", slot, id);
+        value_free(&in);
+        return err;
+    }
+    nubus_staged_card_set(slot, id);
+    value_free(&in);
+    return val_none();
+}
+
+// `slot[N].video_mode` — stage a video-mode id for THIS slot for the next
+// machine.boot (concrete-slot sibling of the `nubus.video_mode` alias).
+// At boot the id is routed into the slot's resolved card kind; a mode that
+// doesn't belong to that card logs and is ignored.
+static value_t slot_attr_video_mode_get(struct object *self, const member_t *m) {
+    (void)m;
+    const char *id = nubus_staged_mode_get(node_slot_number(self));
+    return val_str(id ? id : "");
+}
+
+static value_t slot_attr_video_mode_set(struct object *self, const member_t *m, value_t in) {
+    (void)m;
+    int slot = node_slot_number(self);
+    if (in.kind != V_STRING) {
+        value_free(&in);
+        return val_err("slot[%X].video_mode: expected string id (e.g. \"gc_640x480_8bpp\")", slot);
+    }
+    const char *id = in.s ? in.s : "";
+    const nubus_slot_decl_t *decl = nubus_slot_decl_get(g_obj_bus, slot);
+    if (!decl || decl->kind != NUBUS_SLOT_SOCKET) {
+        value_free(&in);
+        return val_err("slot[%X].video_mode: slot is not a user-configurable socket", slot);
+    }
+    if (*id && !video_mode_id_known(id)) {
+        value_t err = val_err("slot[%X].video_mode: unknown video-mode id '%s'", slot, id);
+        value_free(&in);
+        return err;
+    }
+    nubus_staged_mode_set(slot, id);
+    value_free(&in);
+    return val_none();
+}
+
 static const member_t slot_members[] = {
     {.kind = M_ATTR,
      .name = "number",
      .doc = "NuBus slot number ($9..$E)",
      .flags = VAL_RO,
-     .attr = {.type = V_INT, .presentation_flags = VAL_HEX, .get = slot_attr_number}},
+     .attr = {.type = V_INT, .presentation_flags = VAL_HEX, .get = slot_attr_number}             },
+    {.kind = M_ATTR,
+     .name = "card_id",
+     .doc = "Staged card pick for this socket for the next machine.boot (\"\" = none)",
+     .flags = 0,
+     .attr = {.type = V_STRING, .get = slot_attr_card_id_get, .set = slot_attr_card_id_set}      },
+    {.kind = M_ATTR,
+     .name = "video_mode",
+     .doc = "Staged video-mode id for this socket for the next machine.boot (\"\" = none)",
+     .flags = 0,
+     .attr = {.type = V_STRING, .get = slot_attr_video_mode_get, .set = slot_attr_video_mode_set}},
 };
 static const class_desc_t nubus_slot_class = {
     .name = "slot", .members = slot_members, .n_members = sizeof(slot_members) / sizeof(slot_members[0])};
 
-// --- indexed `slot` member: enumerate populated slots -----------------------
+// --- indexed `slot` member: enumerate declared slots -------------------------
+// A slot node exists for every populated slot AND every declared (possibly
+// empty) SOCKET — nubus_objects_build decides; enumeration keys off the
+// node's existence so the two can't disagree.
 static struct object *nubus_slot_get(struct object *self, int index) {
     (void)self;
     if (!g_obj_bus || index < 0 || index >= NUBUS_OBJ_SLOTS)
-        return NULL;
-    if (!nubus_card(g_obj_bus, index))
         return NULL;
     return g_slot_nodes[index].slot;
 }
@@ -620,7 +700,7 @@ static int nubus_slot_count(struct object *self) {
         return 0;
     int n = 0;
     for (int i = NUBUS_OBJ_FIRST; i <= NUBUS_OBJ_LAST; i++)
-        if (nubus_card(g_obj_bus, i))
+        if (g_slot_nodes[i].slot)
             n++;
     return n;
 }
@@ -629,7 +709,7 @@ static int nubus_slot_next(struct object *self, int prev_index) {
     if (!g_obj_bus)
         return -1;
     for (int i = prev_index + 1; i <= NUBUS_OBJ_LAST; i++)
-        if (nubus_card(g_obj_bus, i))
+        if (g_slot_nodes[i].slot)
             return i;
     return -1;
 }
@@ -694,15 +774,23 @@ void nubus_objects_build(nubus_bus_t *bus) {
     g_obj_bus = bus;
     for (int i = NUBUS_OBJ_FIRST; i <= NUBUS_OBJ_LAST; i++) {
         nubus_card_t *card = nubus_card(bus, i);
-        if (!card)
+        // A node exists for every populated slot and every declared SOCKET
+        // (even when empty — its staged card_id/video_mode attrs are how an
+        // empty socket gets configured for the next boot).
+        const nubus_slot_decl_t *decl = nubus_slot_decl_get(bus, i);
+        if (!card && (!decl || decl->kind != NUBUS_SLOT_SOCKET))
             continue;
         nubus_slot_nodes_t *n = &g_slot_nodes[i];
 
-        n->slot = object_new(&nubus_slot_class, card, "slot");
+        s_slot_numbers[i] = i;
+        n->slot = object_new(&nubus_slot_class, &s_slot_numbers[i], "slot");
         if (!n->slot)
             continue;
         object_set_label(n->slot, "Slot");
         object_set_order(n->slot, i);
+
+        if (!card)
+            continue; // empty socket: just the wrapper + staged attrs
 
         n->card = object_new(&nubus_card_class, card, "card");
         if (n->card) {

--- a/src/machines/glue/iicx.c
+++ b/src/machines/glue/iicx.c
@@ -244,9 +244,9 @@ static void iicx_via2_shift_out(void *context, uint8_t byte) {
 // ============================================================
 
 static const nubus_slot_decl_t iicx_slots[] = {
-    {.slot = 0x9, .kind = NUBUS_SLOT_VIDEO, .default_card = "mdc_8_24"},
-    {.slot = 0xA, .kind = NUBUS_SLOT_EMPTY},
-    {.slot = 0xB, .kind = NUBUS_SLOT_EMPTY},
+    {.slot = 0x9, .kind = NUBUS_SLOT_SOCKET, .default_card = "mdc_8_24"},
+    {.slot = 0xA, .kind = NUBUS_SLOT_SOCKET},
+    {.slot = 0xB, .kind = NUBUS_SLOT_SOCKET},
     {0},
 };
 

--- a/src/machines/glue/iix.c
+++ b/src/machines/glue/iix.c
@@ -86,12 +86,12 @@ static void iix_via2_shift_out(void *context, uint8_t byte) {
 // ============================================================
 
 static const nubus_slot_decl_t iix_slots[] = {
-    {.slot = 0x9, .kind = NUBUS_SLOT_VIDEO, .default_card = "mdc_8_24"},
-    {.slot = 0xA, .kind = NUBUS_SLOT_EMPTY},
-    {.slot = 0xB, .kind = NUBUS_SLOT_EMPTY},
-    {.slot = 0xC, .kind = NUBUS_SLOT_EMPTY},
-    {.slot = 0xD, .kind = NUBUS_SLOT_EMPTY},
-    {.slot = 0xE, .kind = NUBUS_SLOT_EMPTY},
+    {.slot = 0x9, .kind = NUBUS_SLOT_SOCKET, .default_card = "mdc_8_24"},
+    {.slot = 0xA, .kind = NUBUS_SLOT_SOCKET},
+    {.slot = 0xB, .kind = NUBUS_SLOT_SOCKET},
+    {.slot = 0xC, .kind = NUBUS_SLOT_SOCKET},
+    {.slot = 0xD, .kind = NUBUS_SLOT_SOCKET},
+    {.slot = 0xE, .kind = NUBUS_SLOT_SOCKET},
     {0},
 };
 

--- a/src/machines/machine.c
+++ b/src/machines/machine.c
@@ -247,8 +247,10 @@ static void encode_video_slots(json_builder_t *b, const hw_profile_t *p) {
         return;
     }
     for (const struct nubus_slot_decl *s = p->nubus_slots; s->slot; s++) {
-        // Only slots that can carry a video card appear here.
-        if (s->kind != NUBUS_SLOT_BUILTIN && s->kind != NUBUS_SLOT_VIDEO)
+        // Only slots that can carry a video card appear here.  Every SOCKET
+        // is emitted (a machine may declare several); the dialog's single
+        // picker configures the first one, per-socket UI comes later.
+        if (s->kind != NUBUS_SLOT_BUILTIN && s->kind != NUBUS_SLOT_SOCKET)
             continue;
         const char *default_card = (s->kind == NUBUS_SLOT_BUILTIN) ? s->builtin_card_id : s->default_card;
 
@@ -288,11 +290,13 @@ static void encode_video_slots(json_builder_t *b, const hw_profile_t *p) {
 }
 
 // The card id a slot exposes to the dialog: BUILTIN → its single card,
-// VIDEO → its default card, anything else → NULL.  Mirrors encode_video_slots.
+// SOCKET → its default card (NULL for defaultless sockets, which therefore
+// contribute nothing to the legacy view), anything else → NULL.  Mirrors
+// the pre-stage-2 single-video-slot shape web-legacy still reads.
 static const char *legacy_slot_card_id(const struct nubus_slot_decl *s) {
-    return (s->kind == NUBUS_SLOT_BUILTIN) ? s->builtin_card_id
-           : (s->kind == NUBUS_SLOT_VIDEO) ? s->default_card
-                                           : NULL;
+    return (s->kind == NUBUS_SLOT_BUILTIN)  ? s->builtin_card_id
+           : (s->kind == NUBUS_SLOT_SOCKET) ? s->default_card
+                                            : NULL;
 }
 
 // Count the (monitor, depth) tuples a card kind offers.

--- a/src/machines/mdu/iici.c
+++ b/src/machines/mdu/iici.c
@@ -239,9 +239,11 @@ static void iici_via1_shift_out(void *context, uint8_t byte) {
 // user-visible NuBus expansion slots (empty in v1).
 static const nubus_slot_decl_t iici_slots[] = {
     {.slot = 0xB, .kind = NUBUS_SLOT_BUILTIN, .builtin_card_id = "builtin_rbv_video"},
-    {.slot = 0xC, .kind = NUBUS_SLOT_EMPTY},
-    {.slot = 0xD, .kind = NUBUS_SLOT_EMPTY},
-    {.slot = 0xE, .kind = NUBUS_SLOT_EMPTY},
+    // The three physical sockets ship empty (no default_card): the RBV
+    // built-in video is the factory display; a socketed card is an add-on.
+    {.slot = 0xC, .kind = NUBUS_SLOT_SOCKET},
+    {.slot = 0xD, .kind = NUBUS_SLOT_SOCKET},
+    {.slot = 0xE, .kind = NUBUS_SLOT_SOCKET},
     {0},
 };
 

--- a/src/machines/oss/iifx.c
+++ b/src/machines/oss/iifx.c
@@ -1387,12 +1387,12 @@ static void iifx_reset(config_t *cfg) {
 
 // Slot table for the six-slot IIfx NuBus cage.
 static const nubus_slot_decl_t iifx_slots[] = {
-    {.slot = 0x9, .kind = NUBUS_SLOT_VIDEO, .default_card = "mdc_8_24"},
-    {.slot = 0xA, .kind = NUBUS_SLOT_EMPTY},
-    {.slot = 0xB, .kind = NUBUS_SLOT_EMPTY},
-    {.slot = 0xC, .kind = NUBUS_SLOT_EMPTY},
-    {.slot = 0xD, .kind = NUBUS_SLOT_EMPTY},
-    {.slot = 0xE, .kind = NUBUS_SLOT_EMPTY},
+    {.slot = 0x9, .kind = NUBUS_SLOT_SOCKET, .default_card = "mdc_8_24"},
+    {.slot = 0xA, .kind = NUBUS_SLOT_SOCKET},
+    {.slot = 0xB, .kind = NUBUS_SLOT_SOCKET},
+    {.slot = 0xC, .kind = NUBUS_SLOT_SOCKET},
+    {.slot = 0xD, .kind = NUBUS_SLOT_SOCKET},
+    {.slot = 0xE, .kind = NUBUS_SLOT_SOCKET},
     {0},
 };
 

--- a/tests/integration/iicx-dual-display/config.mk
+++ b/tests/integration/iicx-dual-display/config.mk
@@ -1,0 +1,15 @@
+# Integration test configuration: IIcx dual display (stage 2 multi-card).
+#
+# Two video cards on one machine: the default 8•24 (JMFB) in socket $9 plus
+# an 8•24 GC staged into socket $A via the per-slot config surface
+# (machine.nubus.slot[10].card_id — proposal-nubus-computed-card-compatibility.md
+# §5.6).  Before stage 2 the slot table froze every non-video slot as EMPTY
+# and the single pending pick could only populate one slot.
+
+TEST_NAME := IIcx dual display
+TEST_DESC := Boot the IIcx with two video cards (JMFB in $9 + 8•24 GC staged into $A) and pin the dual-card contract
+
+TEST_ROM := roms/IIcx.rom
+
+# The harness boots the IIcx once; the script stages socket $A and re-boots.
+TEST_ARGS := model=iicx ram=8192

--- a/tests/integration/iicx-dual-display/test.script
+++ b/tests/integration/iicx-dual-display/test.script
@@ -1,0 +1,53 @@
+# Integration test: IIcx dual display — JMFB in $9 (default) + 8•24 GC in $A.
+#
+# Stage 2 of the computed-card-compatibility proposal: every socket resolves
+# its configuration independently, so a machine boots as many cards as its
+# sockets carry.  This pins the multi-card contract end-to-end:
+#   * the per-slot staged pick populates socket $A while $9 keeps its
+#     declared default;
+#   * both cards run their full init (declaration ROMs mapped);
+#   * the IIcx ROM's boot-screen selection with virgin PRAM lands on the
+#     HIGHEST video slot — the ROM paints the gray desktop dither into the
+#     GC's framebuffer in $A (observed contract, same with a 24AC in $A);
+#   * `machine.screen` follows nubus_primary_display — the FIRST video card
+#     in declared slot order ($9) — which therefore stays unpainted in this
+#     pre-OS dual configuration.  (Multi-display UI selection is future
+#     work; the rule is deliberately deterministic.)
+
+# Stage the second card into socket $A ($A = slot index 10); socket $9
+# keeps its declared default (mdc_8_24).
+machine.nubus.slot[10].card_id = "824gc"
+machine.boot "iicx" 8192
+machine.rom.reload
+
+# Same budget as the single-card ROM-only boots: the blinking-? screen is
+# painted and stable well within 100M instructions.
+scheduler.run 100000000
+
+assert ${machine.id == "iicx"} "machine.id != iicx"
+
+# Both sockets populated: the default in $9, the staged pick in $A.
+assert ${machine.nubus.slot[9].card.name == "Apple Macintosh Display Card 8•24"} "slot $9 card != 8•24 (default)"
+assert ${machine.nubus.slot[10].card.name == "Apple Macintosh Display Card 8•24 GC"} "slot $A card != 8•24 GC (staged)"
+assert ${machine.nubus.slot[9].card.declrom.present} "slot $9 declrom not present"
+assert ${machine.nubus.slot[10].card.declrom.present} "slot $A declrom not present"
+
+# The staged entry was consumed at boot.
+assert ${machine.nubus.slot[10].card_id == ""} "staged card_id not consumed at boot"
+
+# ROM-only boot never runs the GC accelerator (no System Folder INIT).
+assert ${machine.nubus.slot[10].card.gc.state == "reset"} "gc.state != reset in ROM-only boot"
+
+# The ROM chose the highest video slot for its boot screen: the gray
+# desktop dither sits in the GC's slot-$A framebuffer (super-slot window
+# $AC011400), pinned by exact pattern longs.
+assert ${machine.memory.peek.l(0xAC011400) == 0x6DB6DB6D} "slot $A fb: boot dither long 0 mismatch"
+assert ${machine.memory.peek.l(0xAC011440) == 0xB6DB6DB6} "slot $A fb: boot dither long 1 mismatch"
+
+# machine.screen = primary display = first video slot ($9): correct
+# geometry, deliberately unpainted in this pre-OS dual configuration.
+assert ${machine.screen.width == 640} "screen.width != 640"
+assert ${machine.screen.height == 480} "screen.height != 480"
+assert ${machine.screen.checksum() == 0} "primary ($9) unexpectedly painted — boot-screen contract changed"
+
+quit

--- a/tests/integration/machine-capabilities/run.sh
+++ b/tests/integration/machine-capabilities/run.sh
@@ -81,19 +81,34 @@ assert_contains iicx '"nubus":true'   "iicx has nubus"
 assert_contains iicx '"id":"mdc_8_24"'        "iicx 8·24 video card"
 assert_contains iicx '"requires_vrom":true'   "iicx card needs vrom"
 # IIci built-in RBV video carries its declaration in main ROM — no VROM.
-assert_contains iici '"id":"builtin_rbv_video"' "iici builtin video card"
-assert_absent   iici '"requires_vrom":true'     "iici card must not need vrom"
+# (Match the whole card object: since stage 2 the IIci also declares three
+# sockets whose pluggable candidates DO need a vROM, so a profile-wide
+# requires_vrom:true absence check would be wrong.)
+assert_contains iici '"id":"builtin_rbv_video","display_name":"Macintosh IIci Built-in Video","requires_vrom":false' \
+    "iici builtin video needs no vrom"
 
 # --- Computed card compatibility (no per-machine whitelists) --------------
 # Socket candidates are computed from the card registry by attachment
 # (nubus_card_fits_socket): every CARD_ATTACH_NUBUS video card is offered on
-# every machine with a user-configurable slot — IIcx, IIx, and IIfx must all
-# list the same three cards (proposal-nubus-computed-card-compatibility.md §5.3).
-for m in iicx iix iifx; do
+# every machine with a user-configurable socket — including the IIci's three
+# empty sockets next to its builtin video
+# (proposal-nubus-computed-card-compatibility.md §5.3).
+for m in iicx iix iifx iici; do
     assert_contains "$m" '"id":"mdc_8_24"'          "$m offers 8·24"
     assert_contains "$m" '"id":"display_card_24ac"' "$m offers 24AC"
     assert_contains "$m" '"id":"824gc"'             "$m offers 8·24 GC"
 done
+# Stage 2: machines declare EVERY socket (topology), not just one video
+# slot — the IIcx's three, the IIx/IIfx's six, the IIci's three.
+for m in iicx iix iifx; do
+    assert_contains "$m" '"slot":"9"' "$m declares socket \$9"
+    assert_contains "$m" '"slot":"A"' "$m declares socket \$A"
+    assert_contains "$m" '"slot":"B"' "$m declares socket \$B"
+done
+assert_contains iix  '"slot":"E"' "iix declares socket \$E"
+assert_contains iifx '"slot":"E"' "iifx declares socket \$E"
+assert_contains iici '"slot":"C"' "iici declares socket \$C"
+assert_contains iici '"slot":"E"' "iici declares socket \$E"
 # The attach gate: builtin pseudo-cards (motherboard circuitry impersonating
 # a slot device) must never be offered on a socket — only where a BUILTIN
 # slot decl names them.
@@ -101,6 +116,7 @@ for m in iicx iix iifx; do
     assert_absent "$m" '"id":"builtin_se30_video"' "$m must not offer the SE/30 builtin"
     assert_absent "$m" '"id":"builtin_rbv_video"'  "$m must not offer the RBV builtin"
 done
+assert_absent iici '"id":"builtin_se30_video"' "iici must not offer the SE/30 builtin"
 # Conversely a machine with no socket offers no pluggable cards: the SE/30's
 # $9..$B are decoded-but-connectorless (EMPTY), so only its builtin appears.
 assert_contains se30 '"id":"builtin_se30_video"' "se30 builtin video card"

--- a/tests/integration/nubus-staged-config/config.mk
+++ b/tests/integration/nubus-staged-config/config.mk
@@ -1,0 +1,15 @@
+# Integration test: per-slot staged NuBus configuration (stage 2).
+#
+# The object-model config surface of
+# proposal-nubus-computed-card-compatibility.md §5.6: empty sockets exist as
+# slot nodes with staged card_id / video_mode attributes; concrete-slot
+# staging beats the machine.nubus.video_card wildcard alias; everything is
+# consumed exactly once at machine.boot.  Structural assertions only — no
+# instruction budget beyond boot.
+
+TEST_NAME := NuBus per-slot staged config
+TEST_DESC := slot[N].card_id / video_mode staging, wildcard-alias equivalence, consume-at-boot
+
+TEST_ROM := roms/IIcx.rom
+
+TEST_ARGS := model=iicx ram=8192

--- a/tests/integration/nubus-staged-config/test.script
+++ b/tests/integration/nubus-staged-config/test.script
@@ -1,0 +1,48 @@
+# Integration test: per-slot staged NuBus configuration (stage 2).
+#
+# Pins the staged-config contract (proposal §5.6):
+#   * empty sockets are present in the object model (with their number);
+#   * slot[N].card_id stages a pick for THAT slot, honoured at boot;
+#   * the machine.nubus.video_card wildcard alias means "first socket" and
+#     a concrete slot entry beats it;
+#   * slot[N].video_mode seeds the resolved card's boot depth;
+#   * the whole staged table is consumed (cleared) by machine.boot.
+
+# --- Empty sockets exist as slot nodes before any staging. ---
+assert ${machine.nubus.slot[10].number == 10} "empty socket $A missing from object model"
+assert ${machine.nubus.slot[11].number == 11} "empty socket $B missing from object model"
+
+# --- Per-slot staging: pick the 24AC for socket $9, readable back. ---
+machine.nubus.slot[9].card_id = "display_card_24ac"
+assert ${machine.nubus.slot[9].card_id == "display_card_24ac"} "staged card_id not readable back"
+machine.boot "iicx" 8192
+machine.rom.reload
+assert ${machine.nubus.slot[9].card.name == "Apple Macintosh Display Card 24AC"} "per-slot pick not honoured"
+
+# --- Consumed exactly once: the staged table is empty after boot. ---
+assert ${machine.nubus.slot[9].card_id == ""} "slot[9].card_id not consumed at boot"
+assert ${machine.nubus.video_card == ""} "wildcard video_card not clear after boot"
+
+# --- Wildcard alias: video_card applies to the machine's first socket. ---
+machine.nubus.video_card = "824gc"
+machine.boot "iicx" 8192
+machine.rom.reload
+assert ${machine.nubus.slot[9].card.name == "Apple Macintosh Display Card 8•24 GC"} "wildcard alias not applied to first socket"
+
+# --- A concrete slot entry beats the wildcard for that slot. ---
+machine.nubus.video_card = "824gc"
+machine.nubus.slot[9].card_id = "display_card_24ac"
+machine.boot "iicx" 8192
+machine.rom.reload
+assert ${machine.nubus.slot[9].card.name == "Apple Macintosh Display Card 24AC"} "concrete staging must beat the wildcard"
+
+# --- Per-slot video_mode: the 8-bpp seed reaches the resolved card. ---
+machine.nubus.slot[9].card_id = "824gc"
+machine.nubus.slot[9].video_mode = "gc_640x480_8bpp"
+machine.boot "iicx" 8192
+machine.rom.reload
+assert ${machine.nubus.slot[9].card.name == "Apple Macintosh Display Card 8•24 GC"} "mode test: card not seated"
+assert ${machine.nubus.slot[9].card.mode.depth == 8} "per-slot video_mode seed did not set 8 bpp"
+assert ${machine.nubus.slot[9].video_mode == ""} "slot[9].video_mode not consumed at boot"
+
+quit


### PR DESCRIPTION
## Summary

Stage 2 of `proposal-nubus-computed-card-compatibility.md` (stage 1: #61). Stage 1 computed which cards fit a socket; this stage lets every socket be one — machines declare their full physical topology, sockets are configured per slot through the object model, and a machine boots as many cards as its sockets carry.

## Changes

- **`NUBUS_SLOT_SOCKET` replaces `NUBUS_SLOT_VIDEO`** — the "at most one user-configurable video slot" restriction is gone. `EMPTY` → `SOCKET` on the real connectors: IIcx $A/$B, IIx/IIfx $A–$E, and the IIci's $C–$E (empty by default next to its builtin RBV video). The SE/30's $9–$B stay `EMPTY`: electrically decoded, no connector.
- **Per-slot staged configuration** (`nubus.c`): one staged table keyed by slot, entry 0 being the wildcard *"the machine's first socket."* Every declared socket — populated or empty — now has an object-model slot node carrying staged `card_id` / `video_mode` attributes, consumed exactly once by `machine.boot`. A concrete slot entry beats the wildcard. `machine.nubus.video_card` / `video_mode` remain as wildcard aliases, so web2's boot path, the headless `video_card=` startup arg, and every existing test work unchanged. (The attr is `card_id` because `slot[N].card` is already the populated card's child node.)
- **Multi-card boot**: each `SOCKET` resolves independently in `nubus_init`; each slot's staged video mode is routed into the resolved card kind's existing pending-mode channel immediately before that slot's factory runs — **zero card-driver changes**, and two same-kind cards with different staged modes work.
- **Profile**: `machine.profile` emits every socket in `video_slots` (all offering the same computed card list). web2's dialog configures `video_slots[0]` — builtin-first machines (SE/30, IIci, IIsi) keep their exact previous no-picker/vROM-row behavior; a per-socket dialog UI is future work. Caveat: multi-socket profiles exceed the shell's 4 KB `${...}` expansion cap — use the shell form (`machine.profile iicx`), which is what `run.sh` and gsEval already do.
- **Drive-by fix**: `jmfb.c` never published `card->declrom`, so `slot[N].card.declrom.present` read false for the JMFB even with its vROM loaded, unlike the 24AC / 8•24 GC. Now uniform (buffer ownership moves to `nubus_delete`, matching the other cards). Caught by the new dual-display test.

## Discovered and pinned

With two video cards and virgin PRAM, the IIcx ROM paints its boot screen on the **highest** video slot, while `machine.screen` — primary display, deliberately deterministic as *first populated video slot in declared order* — stays unpainted pre-OS. `iicx-dual-display` pins both facts (exact dither longs in the slot-$A framebuffer, blank primary).

## Tests

- New **`nubus-staged-config`**: per-slot staging honoured at boot, wildcard-alias equivalence, concrete-beats-wildcard, per-slot 8 bpp mode seed reaching the card, consume-at-boot semantics.
- New **`iicx-dual-display`**: JMFB in $9 (default) + 8•24 GC staged into $A; both cards seat with declroms; boot-screen contract pinned.
- **`machine-capabilities`** extended: the IIci now offers all three cards on its sockets; per-machine socket-topology assertions ($9–$B / $9–$E / $C–$E); builtin-attach gate still verified.
- Full integration suite **99/99**; web2 **339/339** + svelte-check clean; headless and wasm builds green.

## Not in this PR

Stage 3 — retiring the wildcard pending statics/aliases and the `encode_legacy_video_compat` block — stays gated on the web-legacy retirement work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)