### PR TITLE
Performance optimizations: MMU ATC cache, core fast paths, wasm audio/pacing/observability (+51% headless, +40% browser turbo)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,8 @@ LDFLAGS := $(MODE_CFLAGS) \
            -s EXPORTED_FUNCTIONS="['_main','_get_js_bridge']" \
            -s STACK_SIZE=5MB \
            -s ALLOW_MEMORY_GROWTH=1 \
-           -s USE_WEBGL2=1
+           -s USE_WEBGL2=1 \
+           $(EXTRA_CFLAGS) $(EXTRA_LDFLAGS)
 
 # -- Phony targets --
 

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,11 @@ ifeq ($(MODE),debug)
 else ifeq ($(MODE),sanitize)
 	MODE_CFLAGS := -O1 -g -DGS_DEBUG -fsanitize=address,undefined -sSTACK_OVERFLOW_CHECK=2
 else
-	MODE_CFLAGS := -O2
+	# Production profile: GS_ASSERT / scheduler invariant walks / libc assert
+	# compiled out (perf proposal P4) — measured +4.5% native, more in wasm
+	# (the invariant walks run per RAF frame-unit and per event insert).
+	# Debug/sanitize builds keep them all.
+	MODE_CFLAGS := -O2 -DGS_FAST -DNDEBUG
 endif
 
 # -- Include paths --

--- a/Makefile.headless
+++ b/Makefile.headless
@@ -7,7 +7,7 @@
 CC ?= gcc
 CFLAGS_BASE := -Wall -Wextra -std=c11 -D_GNU_SOURCE -D_POSIX_C_SOURCE=200809L -MMD -MP
 
-# -- Build mode (release | debug | sanitize) --
+# -- Build mode (release | debug | sanitize | fast) --
 
 MODE ?= release
 
@@ -16,6 +16,11 @@ ifeq ($(MODE),debug)
 else ifeq ($(MODE),sanitize)
 	CFLAGS_MODE := -g -O1 -DGS_DEBUG -fsanitize=address,undefined -fno-omit-frame-pointer
 	LDFLAGS_MODE := -fsanitize=address,undefined
+else ifeq ($(MODE),fast)
+	# Benchmarking profile: GS_ASSERT/invariant walks and libc assert compiled
+	# out (perf proposal P4).  NOT the default — the headless binary is the
+	# debugging tool and CI runs the assert-enabled build.
+	CFLAGS_MODE := -O2 -DGS_FAST -DNDEBUG
 else
 	# No -DNDEBUG: keep assertions active in the headless test/debug tool
 	CFLAGS_MODE := -O2
@@ -23,7 +28,14 @@ endif
 
 # -- Directories --
 
+# fast mode builds into its own tree: CFLAGS changes don't retrigger object
+# rebuilds, so sharing build/headless would silently mix assert-enabled and
+# assert-free objects.
+ifeq ($(MODE),fast)
+BUILD_DIR     := build/headless-fast
+else
 BUILD_DIR     := build/headless
+endif
 CORE_DIR      := src/core
 MACHINES_DIR  := src/machines
 PLATFORM_DIR  := src/platform/headless

--- a/app/web2/src/bus/emulator.ts
+++ b/app/web2/src/bus/emulator.ts
@@ -12,6 +12,7 @@ import {
   machine,
   setSchedulerMode,
   setAcceleratedSpeed,
+  setPerfStats,
   type MachineStatus,
   type MmuKind,
   type SchedulerMode,
@@ -76,6 +77,7 @@ interface EmscriptenModuleConfig {
   onLogEmit?(line: string): void;
   onFloppyChange?(drive: number, present: boolean): void;
   onSchedulerSpeed?(speedX256: number): void;
+  onPerfUpdate?(mipsX100: number, tpsX10: number): void;
 }
 
 type CreateModule = (config: EmscriptenModuleConfig) => Promise<EmscriptenModule>;
@@ -147,6 +149,7 @@ export async function bootstrap(canvas: HTMLCanvasElement, wasmArgs: string[] = 
     onLogEmit: routeLogEmit,
     onFloppyChange: onFloppyDriveChange,
     onSchedulerSpeed: handleSchedulerSpeed,
+    onPerfUpdate: handlePerfUpdate,
   });
 
   bridgePtr = Module._get_js_bridge();
@@ -329,6 +332,13 @@ function handleRunStateChange(running: boolean): void {
 // Accelerated mode. Divide by 256 for the multiplier.
 function handleSchedulerSpeed(speedX256: number): void {
   setAcceleratedSpeed((speedX256 | 0) / 256);
+}
+
+// Core-pushed performance metrics, ~1 Hz (perf proposal P12): emulated MIPS
+// from instr_count deltas and the RAF tick rate. Fixed-point on the wire
+// (x100 / x10) since MAIN_THREAD_ASYNC_EM_ASM carries ints.
+function handlePerfUpdate(mipsX100: number, tpsX10: number): void {
+  setPerfStats((mipsX100 | 0) / 100, (tpsX10 | 0) / 10);
 }
 
 function handleScreenResize(w: number, h: number, parW?: number, parH?: number): void {

--- a/app/web2/src/components/status-bar/StatusBar.svelte
+++ b/app/web2/src/components/status-bar/StatusBar.svelte
@@ -58,7 +58,9 @@
       {#if machine.status === 'running' && machine.mips > 0}
         <div
           class="sb-item sb-mips"
-          title="Emulated CPU throughput: {machine.mips.toFixed(1)} million instructions/second ({machine.ticksPerSecond.toFixed(0)} ticks/s)"
+          title="Emulated CPU throughput: {machine.mips.toFixed(
+            1,
+          )} million instructions/second ({machine.ticksPerSecond.toFixed(0)} ticks/s)"
         >
           <span class="label">{machine.mips.toFixed(1)} MIPS</span>
         </div>

--- a/app/web2/src/components/status-bar/StatusBar.svelte
+++ b/app/web2/src/components/status-bar/StatusBar.svelte
@@ -55,6 +55,14 @@
           <Icon name="chip" size={13} /><span class="label">{speedLabel}</span>
         </div>
       {/if}
+      {#if machine.status === 'running' && machine.mips > 0}
+        <div
+          class="sb-item sb-mips"
+          title="Emulated CPU throughput: {machine.mips.toFixed(1)} million instructions/second ({machine.ticksPerSecond.toFixed(0)} ticks/s)"
+        >
+          <span class="label">{machine.mips.toFixed(1)} MIPS</span>
+        </div>
+      {/if}
       <DriveActivity label="HD" title="Hard disk" activity={machine.driveActivity.hd} />
       <DriveActivity label="FD" title="Floppy disk" activity={machine.driveActivity.fd} />
       <DriveActivity label="CD" title="CD-ROM" activity={machine.driveActivity.cd} />
@@ -144,6 +152,10 @@
   }
   .sb-speed :global(.icon) {
     opacity: 0.85;
+  }
+  .sb-mips {
+    font-variant-numeric: tabular-nums;
+    opacity: 0.75;
   }
   .sb-upload {
     gap: 6px;

--- a/app/web2/src/state/machine.svelte.ts
+++ b/app/web2/src/state/machine.svelte.ts
@@ -48,6 +48,11 @@ interface MachineState {
   // where the adaptive governor moves it; pushed from the core on change
   // (bus/emulator.ts handleSchedulerSpeed). 1 in every other mode.
   acceleratedSpeed: number;
+  // Live performance readout, pushed from the core ~1 Hz (perf proposal P12):
+  // emulated MIPS from instruction-count deltas, and the RAF tick rate the
+  // main loop is achieving. 0 until the first push after machine start.
+  mips: number;
+  ticksPerSecond: number;
   zoom: number;
 }
 
@@ -62,6 +67,8 @@ export const machine: MachineState = $state({
   driveActivity: { hd: 'idle', fd: 'idle', cd: 'idle' },
   scheduler: 'live',
   acceleratedSpeed: 1,
+  mips: 0,
+  ticksPerSecond: 0,
   zoom: 200,
 });
 
@@ -87,6 +94,12 @@ export function setSchedulerMode(mode: SchedulerMode): void {
 // Core-pushed effective CPU speed multiplier (bus/emulator.ts handleSchedulerSpeed).
 export function setAcceleratedSpeed(multiplier: number): void {
   machine.acceleratedSpeed = multiplier;
+}
+
+// Core-pushed live performance metrics (bus/emulator.ts handlePerfUpdate).
+export function setPerfStats(mips: number, ticksPerSecond: number): void {
+  machine.mips = mips;
+  machine.ticksPerSecond = ticksPerSecond;
 }
 
 // ---- Drive activity mock ----

--- a/src/core/common.h
+++ b/src/core/common.h
@@ -23,10 +23,19 @@ extern "C" {
 // Failure handler prints diagnostics (host + target backtraces, process info) then pauses the scheduler
 void gs_assert_fail(const char *expr, const char *file, int line, const char *func, const char *fmt, ...);
 
-// Basic assert macros (always enabled; use conditional build guards yourself if desired)
+// Basic assert macros.  Enabled in every build except the GS_FAST production
+// profile (wasm release / headless MODE=fast), where they compile to nothing —
+// measured ~4.5% of steady-state gameplay host time (perf proposal §5.3).
+// The default headless build keeps them: it is the debugging tool, and CI
+// runs it so the checks retain their value.
+#ifdef GS_FAST
+#define GS_ASSERT(cond)            ((void)0)
+#define GS_ASSERTF(cond, fmt, ...) ((void)0)
+#else
 #define GS_ASSERT(cond) ((cond) ? (void)0 : gs_assert_fail(#cond, __FILE__, __LINE__, __func__, NULL))
 #define GS_ASSERTF(cond, fmt, ...)                                                                                     \
     ((cond) ? (void)0 : gs_assert_fail(#cond, __FILE__, __LINE__, __func__, (fmt), ##__VA_ARGS__))
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/core/cpu/cpu_68030.c
+++ b/src/core/cpu/cpu_68030.c
@@ -162,7 +162,7 @@ static void cpu_pmmu_general(cpu_t *cpu, uint16_t opcode) {
                     fc = cpu->supervisor != 0 ? 5u : 1u; // undefined encoding — fall back
                 bool fc_supervisor = (fc & 4u) != 0;
                 uint32_t ea = calculate_ea(cpu, 4, ea_mode, ea_reg, true);
-                mmu_handle_fault(mmu, ea, rw == 0, fc_supervisor);
+                mmu_pload(mmu, ea, rw == 0, fc_supervisor);
             }
         } else if (mmu) {
             // PFLUSH variants: invalidate ATC entries

--- a/src/core/cpu/cpu_internal.h
+++ b/src/core/cpu/cpu_internal.h
@@ -166,7 +166,8 @@ static inline uint32_t ea_index_value(cpu_t *restrict cpu, uint16_t ext_word) {
 }
 
 // 68020+ full extension word EA calculation (bit 8 = 1)
-static inline uint32_t calculate_ea_full(cpu_t *restrict cpu, uint16_t ext, uint32_t base_reg, bool increment) {
+static __attribute__((noinline)) uint32_t calculate_ea_full(cpu_t *restrict cpu, uint16_t ext, uint32_t base_reg,
+                                                            bool increment) {
     // The extension word (ext) was already fetched by the caller via fetch_16(cpu, increment).
     // With increment=true, cpu->pc now points past the ext word (correct for BD/OD reads).
     // With increment=false, cpu->pc still points AT the ext word (not yet advanced).
@@ -249,30 +250,14 @@ static inline uint32_t calculate_ea_full(cpu_t *restrict cpu, uint16_t ext, uint
     return result;
 }
 
-// Calculate the effective address for an operand based on mode and register
-static inline uint32_t calculate_ea(cpu_t *restrict cpu, int size, int mode, int reg, bool increment) {
+// Cold tail of calculate_ea: the less-frequent EA modes (indexed/extension,
+// absolute, PC-relative, immediate).  Kept out of line so the force-inlined
+// hot switch below stays small at each of the decoder's several hundred call
+// sites (full inlining of every mode measured flat: the saved call overhead
+// was paid back in I-cache pressure — the -O3 lesson in miniature).
+static __attribute__((noinline)) uint32_t calculate_ea_slow(cpu_t *restrict cpu, int size, int mode, int reg,
+                                                            bool increment) {
     switch (mode) {
-    case 2: // (An)
-        return cpu->a[reg];
-    case 3: // (An)+
-    {
-        uint32_t ea = cpu->a[reg];
-        if (increment)
-            cpu->a[reg] += (reg == 7 && size == 1) ? 2 : size; // stack byte adjust
-        return ea;
-    }
-    case 4: // -(An)
-    {
-        uint32_t ea = cpu->a[reg] - ((reg == 7 && size == 1) ? 2 : size);
-        if (increment)
-            cpu->a[reg] = ea;
-        return ea;
-    }
-    case 5: // (d16,An)
-    {
-        int16_t disp = fetch_16(cpu, increment);
-        return cpu->a[reg] + (int32_t)disp;
-    }
     case 6: // (d8,An,Xn) or 68020+ full extension word
     {
         uint16_t ext = fetch_16(cpu, increment);
@@ -325,8 +310,42 @@ static inline uint32_t calculate_ea(cpu_t *restrict cpu, int size, int mode, int
     return (uint32_t)-1;
 }
 
+// Calculate the effective address for an operand based on mode and register.
+// Force-inlined hot switch covering the frequent register-indirect modes
+// (An)/(An)+/-(An)/(d16,An); everything else takes the out-of-line cold tail
+// above.  Out-of-line entirely, these helpers measured ~11% of gameplay
+// runtime in call overhead (perf proposal §5.2).
+static inline __attribute__((always_inline)) uint32_t calculate_ea(cpu_t *restrict cpu, int size, int mode, int reg,
+                                                                   bool increment) {
+    switch (mode) {
+    case 2: // (An)
+        return cpu->a[reg];
+    case 3: // (An)+
+    {
+        uint32_t ea = cpu->a[reg];
+        if (increment)
+            cpu->a[reg] += (reg == 7 && size == 1) ? 2 : size; // stack byte adjust
+        return ea;
+    }
+    case 4: // -(An)
+    {
+        uint32_t ea = cpu->a[reg] - ((reg == 7 && size == 1) ? 2 : size);
+        if (increment)
+            cpu->a[reg] = ea;
+        return ea;
+    }
+    case 5: // (d16,An)
+    {
+        int16_t disp = fetch_16(cpu, increment);
+        return cpu->a[reg] + (int32_t)disp;
+    }
+    default:
+        return calculate_ea_slow(cpu, size, mode, reg, increment);
+    }
+}
+
 // Read an 8-bit value from the effective address specified in the opcode
-static inline uint8_t read_ea_8(cpu_t *restrict cpu, uint16_t opcode, bool increment) {
+static inline __attribute__((always_inline)) uint8_t read_ea_8(cpu_t *restrict cpu, uint16_t opcode, bool increment) {
     uint16_t mode = opcode >> 3 & 7;
     uint16_t reg = opcode & 7;
 
@@ -339,7 +358,7 @@ static inline uint8_t read_ea_8(cpu_t *restrict cpu, uint16_t opcode, bool incre
 }
 
 // Read a 16-bit value from the effective address specified in the opcode
-static inline uint16_t read_ea_16(cpu_t *restrict cpu, uint16_t opcode, bool increment) {
+static inline __attribute__((always_inline)) uint16_t read_ea_16(cpu_t *restrict cpu, uint16_t opcode, bool increment) {
     uint16_t mode = opcode >> 3 & 7;
     uint16_t reg = opcode & 7;
 
@@ -352,7 +371,7 @@ static inline uint16_t read_ea_16(cpu_t *restrict cpu, uint16_t opcode, bool inc
 }
 
 // Read a 32-bit value from the effective address specified in the opcode
-static inline uint32_t read_ea_32(cpu_t *restrict cpu, uint16_t opcode, bool increment) {
+static inline __attribute__((always_inline)) uint32_t read_ea_32(cpu_t *restrict cpu, uint16_t opcode, bool increment) {
     uint16_t mode = opcode >> 3 & 7;
     uint16_t reg = opcode & 7;
 
@@ -371,7 +390,8 @@ static inline uint32_t read_ea_32(cpu_t *restrict cpu, uint16_t opcode, bool inc
 // restored to pre-instruction values.  Our calculate_ea pre-increments /
 // pre-decrements An for modes 3/4; we snapshot An on entry and roll it back
 // in the slow path if the write faults.  See also movem_from_register.
-static inline void write_ea_8(cpu_t *restrict cpu, uint16_t mode, uint16_t reg, uint8_t value) {
+static inline __attribute__((always_inline)) void write_ea_8(cpu_t *restrict cpu, uint16_t mode, uint16_t reg,
+                                                             uint8_t value) {
     if (mode == 0)
         cpu->d[reg] = (cpu->d[reg] & 0xFFFFFF00) | value;
     else if (mode == 1)
@@ -385,7 +405,8 @@ static inline void write_ea_8(cpu_t *restrict cpu, uint16_t mode, uint16_t reg, 
 }
 
 // Write a 16-bit value to the effective address specified by mode and register
-static inline void write_ea_16(cpu_t *restrict cpu, uint16_t mode, uint16_t reg, uint16_t value) {
+static inline __attribute__((always_inline)) void write_ea_16(cpu_t *restrict cpu, uint16_t mode, uint16_t reg,
+                                                              uint16_t value) {
     if (mode == 0)
         cpu->d[reg] = (cpu->d[reg] & 0xFFFF0000) | value;
     else if (mode == 1)
@@ -399,7 +420,8 @@ static inline void write_ea_16(cpu_t *restrict cpu, uint16_t mode, uint16_t reg,
 }
 
 // Write a 32-bit value to the effective address specified by mode and register
-static inline void write_ea_32(cpu_t *restrict cpu, uint16_t mode, uint16_t reg, uint32_t value) {
+static inline __attribute__((always_inline)) void write_ea_32(cpu_t *restrict cpu, uint16_t mode, uint16_t reg,
+                                                              uint32_t value) {
     if (mode == 0)
         cpu->d[reg] = value;
     else if (mode == 1)
@@ -555,7 +577,7 @@ static inline uint8_t sbcd(cpu_t *restrict cpu, uint8_t xx, uint8_t yy) {
 }
 
 // Test CPU condition codes (M68000PRM table 3-19)
-static inline bool conditional_test(cpu_t *restrict cpu, uint8_t test) {
+static inline __attribute__((always_inline)) bool conditional_test(cpu_t *restrict cpu, uint8_t test) {
     assert(test < 16);
 
     switch (test) {

--- a/src/core/memory/mmu.c
+++ b/src/core/memory/mmu.c
@@ -53,6 +53,86 @@ void tlb_track_page(uint32_t page_index) {
 }
 
 // ============================================================================
+// ATC-style block-descriptor cache
+// ============================================================================
+
+// The guest's tables use early-termination block descriptors covering large
+// ranges (e.g. one level-A descriptor covering 32 MB).  The real 68030 ATC
+// caches one descriptor for the whole covered range and never re-walks; the
+// old emulator approximation eagerly materialised every covered 4 KB page
+// into the SoA arrays (~9,200 entries per walk), which dominated steady-state
+// host time under System 6's per-VBL _SwapMMUMode invalidation storm (see
+// docs/proposals/proposal-performance-optimizations.md §5.1).  Instead, cache
+// the walked descriptor itself; on a later fault inside the covered range,
+// fill only the touched 4 KB page from the cached descriptor — no re-walk.
+typedef struct atc_block {
+    uint32_t log_base; // logical range base (aligned to coverage)
+    uint32_t log_mask; // ~(coverage-1)
+    uint32_t phys_base; // physical range base (same alignment)
+    bool supervisor_only; // S bit from the walked descriptor
+    bool write_protected; // W bit from the walked descriptor
+    bool fc_super; // FC class of the walk (matters when TC.SRE=1)
+    bool valid; // entry live?
+} atc_block_t;
+#define ATC_BLOCKS 16 // small, round-robin; the real 68030 ATC holds 22 entries
+
+static atc_block_t g_atc_blocks[ATC_BLOCKS]; // cached block descriptors
+static int g_atc_next = 0; // round-robin replacement cursor
+
+// Drop every cached block descriptor.  Runs wherever a real ATC dies: any
+// invalidation that actually zeroes the SoA (PMOVE to TC/CRP/SRP/TT without
+// FD, PFLUSH variants, machine reset).  The FD (flush-disable) PMOVE forms
+// skip mmu_invalidate_tlb entirely, so cached blocks survive them — exactly
+// the hardware contract A/UX's "clear root after PMOVE, rely on ATC
+// residency" sequence needs.
+static void atc_flush(void) {
+    memset(g_atc_blocks, 0, sizeof(g_atc_blocks));
+    g_atc_next = 0;
+}
+
+// Find the cached block covering logical_addr for this FC class, if any.
+// When TC.SRE=0 a single walk serves both FC classes (super and user share
+// the CRP), so the FC recorded at walk time doesn't restrict the hit.
+static inline atc_block_t *atc_probe(mmu_state_t *mmu, uint32_t logical_addr, bool supervisor) {
+    bool sre_split = TC_SRE(mmu->tc) != 0;
+    for (int i = 0; i < ATC_BLOCKS; i++) {
+        atc_block_t *b = &g_atc_blocks[i];
+        if (!b->valid)
+            continue;
+        if ((logical_addr & b->log_mask) != b->log_base)
+            continue;
+        if (sre_split && b->fc_super != supervisor)
+            continue;
+        return b;
+    }
+    return NULL;
+}
+
+// Invalidate any cached block covering logical_addr for this FC class.
+// Called before recording a fresh walk so a re-walked range (PLOAD, or a
+// mapping the guest reshaped from block to page tables) can never leave a
+// stale duplicate behind.
+static void atc_invalidate_covering(mmu_state_t *mmu, uint32_t logical_addr, bool supervisor) {
+    atc_block_t *b;
+    while ((b = atc_probe(mmu, logical_addr, supervisor)) != NULL)
+        b->valid = false;
+}
+
+// Record a successful walk's early-termination descriptor in the block cache.
+static void atc_record(uint32_t log_base, uint32_t log_mask, uint32_t phys_base, bool supervisor_only,
+                       bool write_protected, bool fc_super) {
+    atc_block_t *b = &g_atc_blocks[g_atc_next];
+    g_atc_next = (g_atc_next + 1) % ATC_BLOCKS;
+    b->log_base = log_base;
+    b->log_mask = log_mask;
+    b->phys_base = phys_base;
+    b->supervisor_only = supervisor_only;
+    b->write_protected = write_protected;
+    b->fc_super = fc_super;
+    b->valid = true;
+}
+
+// ============================================================================
 // Helpers: physical memory access during table walks
 // ============================================================================
 
@@ -467,6 +547,8 @@ void mmu_delete(mmu_state_t *mmu) {
         // back to a full memset (matches the file-scope default).
         g_tlb_track_count = 0;
         g_tlb_track_overflow = true;
+        // Cached block descriptors belong to this machine's tables too.
+        atc_flush();
     }
     free(mmu);
 }
@@ -586,6 +668,10 @@ void mmu_invalidate_tlb(mmu_state_t *mmu) {
     }
     if (mmu)
         mmu->tlb_was_enabled = now_enabled;
+    // A real invalidation is where the hardware ATC dies too: drop the cached
+    // block descriptors along with the SoA fill.  (The dis→dis early-out above
+    // and the FD PMOVE forms — which never call here — both preserve them.)
+    atc_flush();
     if (g_tlb_track_overflow) {
         // Tracking overflowed — fall back to zeroing everything
         size_t sz = (size_t)g_page_count * sizeof(uintptr_t);
@@ -628,8 +714,36 @@ void mmu_invalidate_tlb(mmu_state_t *mmu) {
     // CPU time. See docs/notes/mmu-tlb-invalidate-perf.md.
 }
 
+// Shared tail of the fault path: after a fill attempt, if the SoA entry
+// stayed zero (physical page is device, unmapped, or logpoint-suppressed),
+// decide bus error vs silent success.
+//
+// On real hardware, unmapped physical addresses cause bus errors.  However,
+// Mac OS legitimately probes RAM expansion addresses (e.g. $00F80000,
+// $80000000) via page table entries and expects to read $FF without
+// faulting, and our deferred bus error mechanism is incompatible with the
+// ROM's bail-out handler for data probes.  So only bus error for physical
+// addresses that are clearly garbage — outside all known hardware regions.
+static inline bool mmu_fault_epilogue(mmu_state_t *mmu, uint32_t emu_page, uint32_t phys_page, bool write) {
+    uint32_t page_index = emu_page >> PAGE_SHIFT;
+    if ((int)page_index < g_page_count) {
+        uintptr_t *active = write ? g_active_write : g_active_read;
+        if (active && active[page_index] == 0) {
+            // For closer ranges (e.g., $006DB000 from corrupted page tables),
+            // the f_trap handler detects unmapped instruction fetches separately.
+            if (phys_page >= mmu->ram_size_max && phys_page < mmu->rom_phys_base)
+                return false;
+        }
+    }
+    return true;
+}
+
 // Handle a TLB miss: perform table walk or TT check, fill SoA entry.
-bool mmu_handle_fault(mmu_state_t *mmu, uint32_t logical_addr, bool write, bool supervisor) {
+// `probe_atc` selects whether the block-descriptor cache may satisfy the miss
+// without a walk; PLOAD passes false to force a fresh table walk (its whole
+// purpose is to reload the ATC from the current guest tables).
+static bool mmu_handle_fault_internal(mmu_state_t *mmu, uint32_t logical_addr, bool write, bool supervisor,
+                                      bool probe_atc) {
     if (!mmu || !mmu->enabled)
         return false;
 
@@ -656,6 +770,22 @@ bool mmu_handle_fault(mmu_state_t *mmu, uint32_t logical_addr, bool write, bool 
             }
         }
         return true;
+    }
+
+    // Block-descriptor cache: a prior walk of this range cached its
+    // early-termination descriptor (the ATC residency the real 68030 gives).
+    // On hit, fill just the touched page — no guest-table re-walk, and
+    // mmu->mmusr stays untouched (matching ATC-hit behaviour on hardware).
+    // Accesses the cached permissions would REJECT fall through to the real
+    // walk so the failure publishes MMUSR exactly as before (A/UX's bus-error
+    // path reads it).
+    if (probe_atc) {
+        atc_block_t *b = atc_probe(mmu, logical_addr, supervisor);
+        if (b && !(b->supervisor_only && !supervisor) && !(b->write_protected && write)) {
+            uint32_t phys_page = b->phys_base + (emu_page - b->log_base);
+            mmu_fill_soa_entry(mmu, emu_page, phys_page, b->supervisor_only, b->write_protected, supervisor, false);
+            return mmu_fault_epilogue(mmu, emu_page, phys_page, write);
+        }
     }
 
     // Perform table walk
@@ -709,52 +839,37 @@ bool mmu_handle_fault(mmu_state_t *mmu, uint32_t logical_addr, bool write, bool 
     // When the descriptor covers more than one emulator 4KB page (e.g. an
     // early-termination page descriptor at level A with 32 MB coverage), the
     // real 68030 ATC caches a single entry for the whole range and never
-    // re-walks.  Mirror that by filling every 4KB SoA entry in the covered
-    // logical range — otherwise the guest can clear the page-table root and
-    // still execute correctly on real HW, but our emulator will re-walk the
-    // next 4KB page and (correctly) find the now-invalid root.  Observed in
-    // A/UX 3.0.1 boot where the kernel clears $104000 immediately after
-    // PMOVE TC while relying on ATC residency.
+    // re-walks — the guest can clear the page-table root and still execute
+    // correctly on real HW (observed in A/UX 3.0.1 boot, which clears
+    // $104000 immediately after PMOVE TC while relying on ATC residency).
+    // Mirror that by caching the walked descriptor; later faults inside the
+    // range fill their page from the cache without re-walking.  Any stale
+    // cached block for this range is dropped first so a fresh walk (PLOAD,
+    // or a mapping reshaped from block to page tables) always supersedes it.
+    atc_invalidate_covering(mmu, logical_addr, supervisor);
     uint32_t ps_bits = result.page_size_bits;
-    if (ps_bits > PAGE_SHIFT) {
-        uint32_t coverage = 1u << ps_bits;
-        uint32_t range_start = logical_addr & ~(coverage - 1);
-        uint32_t phys_base = result.physical_addr & ~(coverage - 1);
-        for (uint32_t off = 0; off < coverage; off += (1u << PAGE_SHIFT)) {
-            uint32_t lp = range_start + off;
-            if (lp == emu_page)
-                continue; // already filled above
-            mmu_fill_soa_entry(mmu, lp, phys_base + off, result.supervisor_only, result.write_protected, supervisor,
-                               false);
-        }
+    if (ps_bits > PAGE_SHIFT && ps_bits < 32) {
+        uint32_t log_mask = ~((1u << ps_bits) - 1);
+        atc_record(logical_addr & log_mask, log_mask, result.physical_addr & log_mask, result.supervisor_only,
+                   result.write_protected, supervisor);
     }
 
     // If phys_to_host returned NULL (unmapped physical), the SoA entry
     // stays zero.  On real hardware, the physical bus access would fail
-    // (no device responds) and generate a bus error.
-    //
-    // However, Mac OS legitimately probes RAM expansion addresses (e.g.
-    // $00F80000, $80000000) via page table entries and expects to read
-    // $FF without faulting.  Only bus error for physical addresses that
-    // are clearly garbage — outside all known hardware regions.  The gap
-    // $60000000-$EFFFFFFF has no hardware on any 68k Mac.
-    uint32_t page_index = emu_page >> PAGE_SHIFT;
-    if ((int)page_index < g_page_count) {
-        uintptr_t *active = write ? g_active_write : g_active_read;
-        if (active && active[page_index] == 0) {
-            // On real hardware, unmapped physical addresses cause bus errors.
-            // However, our deferred bus error mechanism is incompatible with
-            // the ROM's bail-out handler for data probes (the probe instruction
-            // completes before the bus error fires, breaking the expected flow).
-            // So we only bus error for addresses far beyond any hardware range.
-            // For closer ranges (e.g., $006DB000 from corrupted page tables),
-            // the f_trap handler detects unmapped instruction fetches separately.
-            if (phys_page >= mmu->ram_size_max && phys_page < mmu->rom_phys_base)
-                return false;
-        }
-    }
+    // (no device responds) and generate a bus error — see mmu_fault_epilogue.
+    return mmu_fault_epilogue(mmu, emu_page, phys_page, write);
+}
 
-    return true;
+// Handle a TLB miss: perform table walk or TT check, fill SoA entry.
+bool mmu_handle_fault(mmu_state_t *mmu, uint32_t logical_addr, bool write, bool supervisor) {
+    return mmu_handle_fault_internal(mmu, logical_addr, write, supervisor, true);
+}
+
+// PLOAD: force a fresh table walk and (re)load the cached translation,
+// bypassing the block-descriptor cache — the freshly walked descriptor
+// replaces any stale cached block for the range.
+bool mmu_pload(mmu_state_t *mmu, uint32_t logical_addr, bool write, bool supervisor) {
+    return mmu_handle_fault_internal(mmu, logical_addr, write, supervisor, false);
 }
 
 // PTEST: test address translation without faulting

--- a/src/core/memory/mmu.h
+++ b/src/core/memory/mmu.h
@@ -160,6 +160,11 @@ void tlb_track_page(uint32_t page_index);
 // Returns false if translation failed (invalid descriptor → caller raises bus error).
 bool mmu_handle_fault(mmu_state_t *mmu, uint32_t logical_addr, bool write, bool supervisor);
 
+// PLOAD instruction: like mmu_handle_fault, but always performs a fresh table
+// walk, bypassing the block-descriptor cache (PLOAD's purpose is to reload
+// the ATC from the current guest tables).
+bool mmu_pload(mmu_state_t *mmu, uint32_t logical_addr, bool write, bool supervisor);
+
 // Test address translation without faulting (PTEST instruction).
 // Performs table walk and returns MMUSR value.
 // If desc_addr_out is non-NULL, also returns the physical address of the last

--- a/src/core/scheduler/scheduler.c
+++ b/src/core/scheduler/scheduler.c
@@ -477,6 +477,43 @@ static const event_type_t *find_event_type(struct scheduler *s, void *source, ev
     return NULL;
 }
 
+// ============================================================================
+// Event allocation pool
+// ============================================================================
+
+// Events churn at the emulated-sample rate — the ASC FIFO drain re-arms one
+// event per sample (22,257/s during audio playback), each a calloc at insert
+// plus a free at fire (perf proposal §5.4 / P7.1).  Recycle them through a
+// small LIFO free list instead.  The pool is process-global (event_t carries
+// no per-scheduler state) and bounded; the live queue stays ~5 entries deep,
+// so the cap covers any realistic burst.
+#define EVENT_POOL_MAX 64
+static event_t *g_event_pool = NULL; // LIFO free list, linked via ->next
+static int g_event_pool_count = 0; // entries currently pooled
+
+// Pop a recycled event (zeroed, like calloc) or fall back to the allocator.
+static event_t *event_alloc(void) {
+    event_t *e = g_event_pool;
+    if (e != NULL) {
+        g_event_pool = e->next;
+        g_event_pool_count--;
+        memset(e, 0, sizeof(*e));
+        return e;
+    }
+    return (event_t *)calloc(1, sizeof(event_t));
+}
+
+// Return an event to the pool (or to the allocator once the pool is full).
+static void event_free(event_t *e) {
+    if (g_event_pool_count < EVENT_POOL_MAX) {
+        e->next = g_event_pool;
+        g_event_pool = e;
+        g_event_pool_count++;
+        return;
+    }
+    free(e);
+}
+
 // Insert an event into the queue, maintaining timestamp order
 static event_t *insert_event_queue(event_t *queue, event_t *new_event) {
     GS_ASSERT(new_event != NULL);
@@ -512,7 +549,7 @@ static event_t *add_event_internal(struct scheduler *restrict s, event_callback_
     else
         cycles = ns * s->frequency / NS_PER_SEC;
 
-    event_t *event = (event_t *)calloc(1, sizeof(event_t));
+    event_t *event = event_alloc();
     if (event == NULL)
         return NULL;
 
@@ -537,7 +574,7 @@ static void process_event_queue(event_t **queue, uint64_t current_time) {
         event_t *e = *queue;
         *queue = e->next;
         (e->callback)(e->source, e->data);
-        free(e);
+        event_free(e);
     }
 }
 
@@ -751,11 +788,12 @@ void scheduler_delete(struct scheduler *scheduler) {
         scheduler->object = NULL;
     }
 
-    // Free pending CPU events
+    // Free pending CPU events (through the pool so a follow-up scheduler
+    // instance can recycle them)
     event_t *e = scheduler->cpu_events;
     while (e) {
         event_t *next = e->next;
-        free(e);
+        event_free(e);
         e = next;
     }
 
@@ -862,7 +900,7 @@ void scheduler_start(struct scheduler *restrict s) {
                    saved->event_name);
 
         // Recreate and insert event
-        event_t *e = (event_t *)calloc(1, sizeof(event_t));
+        event_t *e = event_alloc();
         GS_ASSERT(e != NULL);
 
         e->timestamp = saved->timestamp;
@@ -962,7 +1000,7 @@ void remove_event(struct scheduler *restrict scheduler, event_callback_t callbac
         if ((*ev)->callback == callback && ((*ev)->source == source || source == NULL)) {
             event_t *to_remove = *ev;
             *ev = to_remove->next;
-            free(to_remove);
+            event_free(to_remove);
         } else {
             ev = &(*ev)->next;
         }
@@ -980,7 +1018,7 @@ void remove_event_by_data(struct scheduler *restrict scheduler, event_callback_t
         if ((*ev)->callback == callback && ((*ev)->source == source || source == NULL) && (*ev)->data == data) {
             event_t *to_remove = *ev;
             *ev = to_remove->next;
-            free(to_remove);
+            event_free(to_remove);
         } else {
             ev = &(*ev)->next;
         }

--- a/src/core/scheduler/scheduler.c
+++ b/src/core/scheduler/scheduler.c
@@ -51,8 +51,12 @@ LOG_USE_CATEGORY_NAME("scheduler");
 
 // Unthrottled ("turbo") mode: fraction of the host tick period to fill with
 // emulation, leaving the rest as idle headroom for the browser (rendering,
-// input, GC). Previously a hard-coded 0.5.
-#define TURBO_HOST_HEADROOM 0.5
+// input, GC). Raised from 0.5 (perf proposal P11): with WebGL rendering and
+// the SAB audio ring (P6) the browser work per tick is small, and reserving
+// half of every slice was measured to cost exactly its share of turbo
+// throughput; 0.7 keeps the UI responsive (in-browser bench terminal probes
+// still answer promptly) while returning ~40% more turbo speed.
+#define TURBO_HOST_HEADROOM 0.7
 
 // Accelerated mode: bounds for the fixed speed multiplier, x256 fixed point.
 // Floor 1x = authentic (the mode never runs the guest slower than real

--- a/src/core/scheduler/scheduler.c
+++ b/src/core/scheduler/scheduler.c
@@ -327,7 +327,16 @@ static void scheduler_governor_tick(struct scheduler *s, double host_secs_this_v
     }
 }
 
-// Validate all critical scheduler invariants at key transition points
+// Validate all critical scheduler invariants at key transition points.
+// GS_FAST (production profile): the full-queue walk itself is the cost — it
+// runs at entry and exit of scheduler_run/scheduler_run_instructions — so the
+// whole function compiles to nothing, not just its asserts.
+#ifdef GS_FAST
+static inline void scheduler_check_invariants(struct scheduler *s, const char *context) {
+    (void)s;
+    (void)context;
+}
+#else
 static void scheduler_check_invariants(struct scheduler *s, const char *context) {
     if (s == NULL)
         return;
@@ -381,6 +390,7 @@ static void scheduler_check_invariants(struct scheduler *s, const char *context)
     // CPU pointer must remain valid
     GS_ASSERTF(s->cpu != NULL, "[%s] cpu pointer is NULL", context);
 }
+#endif // GS_FAST
 
 // Convenience macro to check invariants with automatic context
 #define CHECK_INVARIANTS(s) scheduler_check_invariants((s), __func__)
@@ -428,7 +438,14 @@ static void reconcile_sprint(struct scheduler *s) {
     s->sprint_burndown = 0;
 }
 
-// Validate that the CPU event queue is properly ordered
+// Validate that the CPU event queue is properly ordered.
+// GS_FAST: compiled out — this walk runs on every event insertion (22,257×
+// per emulated second during ASC playback; perf proposal §5.3).
+#ifdef GS_FAST
+static inline void validate_cpu_events(struct scheduler *s) {
+    (void)s;
+}
+#else
 static void validate_cpu_events(struct scheduler *s) {
     GS_ASSERT(s != NULL);
 
@@ -447,6 +464,7 @@ static void validate_cpu_events(struct scheduler *s) {
         prev_ts = e->timestamp;
     }
 }
+#endif // GS_FAST
 
 // Look up registered event type names for a given source+callback pair
 static const event_type_t *find_event_type(struct scheduler *s, void *source, event_callback_t cb) {

--- a/src/platform/wasm/em_audio.c
+++ b/src/platform/wasm/em_audio.c
@@ -3,9 +3,10 @@
 
 // em_audio.c
 // Audio subsystem for Emscripten platform — implements WebAudio streaming via
-// AudioWorklet with a ring buffer. One parameterized stream serves every
-// machine: interleaved int16 frames, mono or stereo, at a runtime-settable
-// source rate (22,255 / 22,257 / 22,050 / 44,100 Hz).
+// AudioWorklet fed from a SharedArrayBuffer ring (perf proposal P6). One
+// parameterized stream serves every machine: interleaved int16 frames, mono
+// or stereo, at a runtime-settable source rate (22,255 / 22,257 / 22,050 /
+// 44,100 Hz).
 //
 // Real-time machinery lives here on the consumer side (per the sound-emulation
 // strategy): linear-interpolation resampling with PI rate trim (±2000 ppm),
@@ -13,10 +14,17 @@
 // volume ramping, and a one-pole LPF. Producers stay deterministic.
 //
 // With PROXY_TO_PTHREAD, the emulator runs on a worker thread.  AudioContext
-// and AudioWorklet are main-thread-only APIs, so all WebAudio calls must be
-// proxied to the main thread.  We define EM_JS functions for the JS code
-// and use emscripten_sync_run_in_main_runtime_thread() to ensure they
-// execute on the main thread.
+// and AudioWorklet are main-thread-only APIs, so the *control-plane* calls
+// (init / open / rate change / resume) are proxied to the main thread with
+// emscripten_sync_run_in_main_runtime_thread().  The *data plane* is not:
+// with -pthread the wasm heap is a SharedArrayBuffer whose static addresses
+// never move (shared WebAssembly.Memory grows in place, it never replaces
+// the buffer), so the worklet consumes frames directly from a C-side ring
+// via Atomics.  platform_audio_push used to be a synchronous worker→main
+// round trip (~348/s during playback) doing a heap copy, a silence scan and
+// a transfer postMessage — recurring stalls of the emulation thread whose
+// jitter fed the governor's audio back-off.  It is now a local memcpy plus
+// two atomic stores, and the governor's ring-fill query is an atomic load.
 
 // ============================================================================
 // Includes
@@ -34,6 +42,42 @@
 #include <string.h>
 
 #include "platform.h"
+
+#include <stdatomic.h>
+
+// ============================================================================
+// SharedArrayBuffer audio ring (emulator worker → AudioWorklet)
+// ============================================================================
+
+// Ring geometry: power-of-two frame count, ~2.9 s at 22 kHz.  The struct
+// lives in static storage, so its address is fixed for the process lifetime
+// and stays valid across wasm memory growth (shared memory grows in place).
+#define GS_ARING_FRAMES 65536
+#define GS_ARING_MAX_CH 2
+
+// Header field indices, as seen by the worklet's Int32Array view.  Keep in
+// sync with the worklet code below.
+//   [0] write_idx      frames, masked; producer-owned (release-stored last)
+//   [1] read_idx       frames, masked; consumer-owned (producer CAS-advances
+//                      it only on overflow, overwrite-oldest semantics)
+//   [2] vol            0..7, latest producer volume
+//   [3] silent_pushes  consecutive all-equal pushes (silence-aware depth trim)
+//   [4] fill_pm        worklet→producer: ring fill vs target depth, per-mille
+//   [5] push_seq       bumped per push; the worklet's quiet-stream detector
+typedef struct gs_audio_ring {
+    _Atomic uint32_t write_idx;
+    _Atomic uint32_t read_idx;
+    _Atomic int32_t vol;
+    _Atomic int32_t silent_pushes;
+    _Atomic int32_t fill_pm;
+    _Atomic uint32_t push_seq;
+    _Atomic uint32_t reserved[2]; // pad header to 32 bytes
+    int16_t data[GS_ARING_FRAMES * GS_ARING_MAX_CH];
+} gs_audio_ring_t;
+
+static gs_audio_ring_t g_aring; // the one shared ring
+static int g_aring_channels = 1; // set by platform_audio_open
+static double g_last_push_time = -1.0; // producer-side freshness for ring_fill
 
 // ============================================================================
 // WebAudio (AudioWorklet) Implementation
@@ -59,8 +103,25 @@ EM_JS(void, gs_audio_init_js, (), {
     ga.modReady = false;
     ga.ctx = ga.ctx || new (self.AudioContext || self.webkitAudioContext)();
 
-    // AudioWorklet processor — internal int16 frame ring fed via MessagePort.
-    var RING_FRAMES = 1 << 16; // 65536 frames ~ 2.9s at 22 kHz
+    // Autoplay policy: a suspended AudioContext may only resume from a user
+    // gesture.  The data path no longer touches the main thread (SAB ring),
+    // so the old per-push resume nudge is gone — hook input gestures once
+    // instead (resume() on a running context is a no-op).
+    var resumeOnGesture = function() {
+        try {
+            if (ga.ctx.state === 'suspended')
+                ga.ctx.resume();
+        } catch (e) {
+        }
+    };
+    self.addEventListener('pointerdown', resumeOnGesture, true);
+    self.addEventListener('keydown', resumeOnGesture, true);
+
+    // AudioWorklet processor — consumes int16 frames straight from the
+    // emulator's SharedArrayBuffer ring (the wasm heap): write/read indices,
+    // volume, silence count and the fill report all live in the ring header,
+    // accessed with Atomics. No per-push messages; the MessagePort carries
+    // only rare control traffic (rate changes).
     var workletCode = [
         "class GSAudioProcessor extends AudioWorkletProcessor {",
         "  constructor(opts){",
@@ -69,11 +130,13 @@ EM_JS(void, gs_audio_init_js, (), {
         "    this.ch=o.channels||1;",
         "    this.srcRate=o.srcRate||22257;",
         "    this.targetLatency=o.targetLatency||0.083;",
-        "    var RF=" + RING_FRAMES + ";",
-        "    this.mask=RF-1;",
-        "    this.data=new Int16Array(RF*this.ch);",
-        "    this.wIdx=0; this.rIdx=0;", // ring indices in FRAMES
-        "    this.vol=0; this.silentCount=0; this.underruns=0;",
+        "    this.mask=(o.ringFrames||65536)-1;",
+        // Header (Int32) + frame data (Int16) views over the wasm heap SAB.
+        // The ring is static C storage: its address never changes, and shared
+        // WebAssembly.Memory grows in place, so the views stay valid.
+        "    this.hdr=new Int32Array(o.sab,o.ringPtr,8);",
+        "    this.data=new Int16Array(o.sab,o.ringPtr+32,(this.mask+1)*this.ch);",
+        "    this.underruns=0;",
         "    this.targetFrames=Math.floor(this.targetLatency*this.srcRate);",
         "    this.dstRate=sampleRate;",
         "    this.step=this.srcRate/this.dstRate;",
@@ -86,7 +149,7 @@ EM_JS(void, gs_audio_init_js, (), {
         // full-scale click. fc ~20 Hz: inaudible, settles in a few ms.
         "    this.dcX=[0,0]; this.dcYv=[0,0];",
         "    this.dcR=1-2*Math.PI*20/this.dstRate;",
-        "    this.quietQ=0;", // process() quanta since the last data push
+        "    this.quietQ=0; this.lastSeq=0;", // quanta since the push_seq moved
         "    this.curGain=0; this.started=false;",
         "    var self2=this;",
         "    this.port.onmessage=function(e){",
@@ -95,43 +158,33 @@ EM_JS(void, gs_audio_init_js, (), {
         "        self2.srcRate=d.rate;",
         "        self2.step=self2.srcRate/self2.dstRate;",
         "        self2.targetFrames=Math.floor(self2.targetLatency*self2.srcRate);",
-        "        self2.rIdx=self2.wIdx; self2.frac=0; self2.errI=0;",
+        "        Atomics.store(self2.hdr,1,Atomics.load(self2.hdr,0));", // rIdx=wIdx
+        "        self2.frac=0; self2.errI=0;",
         "        self2.started=false; self2.curGain=0;",
-        "        return;",
         "      }",
-        "      var src=new Int16Array(d.buf);",
-        "      var ch=self2.ch;",
-        "      var n=(src.length/ch)|0;", // payload length in frames
-        "      self2.vol=d.vol;",
-        "      self2.quietQ=0;",
-        "      if(d.sil){self2.silentCount++;}else{self2.silentCount=0;}",
-        "      var w=self2.wIdx, r=self2.rIdx, mask=self2.mask;",
-        "      var used=(w-r)&mask, free=mask-used;",
-        "      if(n>free){self2.rIdx=(r+n-free)&mask;}", // overwrite oldest
-        "      for(var i=0;i<n;i++){",
-        "        var di=((w+i)&mask)*ch;",
-        "        for(var c=0;c<ch;c++)self2.data[di+c]=src[i*ch+c];",
-        "      }",
-        "      self2.wIdx=(w+n)&mask;",
         "    };",
         "  }",
         "  process(inputs,outputs){",
         "    var out=outputs[0]; var frames=out[0].length;",
         "    var ch=this.ch; var oc=out.length<ch?out.length:ch;",
-        "    var w=this.wIdx, r=this.rIdx, mask=this.mask;",
+        "    var hdr=this.hdr, mask=this.mask;",
+        "    var w=Atomics.load(hdr,0), r=Atomics.load(hdr,1);",
+        "    var rStart=r;",
         "    var avail=(w-r)&mask;",
-        "    this.quietQ++;",
-        // Fill-level report every 32 quanta (~85 ms at 48 kHz): the node side
-        // caches it and the emulator's adaptive governor reads it as back-
+        // Quiet-stream detector: quanta since the producer's push_seq moved.
+        "    var seq=Atomics.load(hdr,5);",
+        "    if(seq!==this.lastSeq){this.lastSeq=seq;this.quietQ=0;}else{this.quietQ++;}",
+        // Fill-level report every 32 quanta (~85 ms at 48 kHz): stored in the
+        // ring header, read by the emulator's adaptive governor as back-
         // pressure (a draining ring = the real-time deadline being missed).
         "    if(((this.statQ=(this.statQ||0)+1)&31)===0){",
-        "      this.port.postMessage({fill:avail/(this.targetFrames||1)});",
+        "      Atomics.store(hdr,4,Math.max(0,Math.min(2000,Math.round(avail/(this.targetFrames||1)*1000))));",
         "    }",
         // Start gate: stay silent until the ring reaches the target depth, OR
         // until the stream has evidently ended short of it (data pending but
         // no push for 12 quanta ~32 ms) — so sounds shorter than the cushion
         // still play out. An active producer pushes every ~3 ms, so the quiet
-        // threshold must sit above main-thread jank (tens of ms) or the gate
+        // threshold must sit above scheduling jank (tens of ms) or the gate
         // opens mid-fill with a shallow ring and the crackle returns.
         "    if(!this.started){",
         "      var ready=avail>=this.targetFrames||(avail>0&&this.quietQ>=12);",
@@ -139,7 +192,7 @@ EM_JS(void, gs_audio_init_js, (), {
         "      this.started=true;",
         "    }",
         "    var ts=this.targetFrames;",
-        "    var targetGain=Math.min(Math.max(this.vol,0),7)/7;",
+        "    var targetGain=Math.min(Math.max(Atomics.load(hdr,2),0),7)/7;",
         // PI controller trims the resample step ±2000 ppm toward target depth
         "    var error=avail-ts;",
         "    this.errI=this.errI*0.995+error*0.005;",
@@ -167,21 +220,26 @@ EM_JS(void, gs_audio_init_js, (), {
         "      var consumed=this.frac|0;",
         "      if(consumed>0){this.frac-=consumed;var wc=consumed<have?consumed:have;r=(r+wc)&mask;}",
         "    }",
-        "    this.rIdx=r;",
+        // Publish consumption with CAS from the value we started from: if the
+        // producer overflow-advanced read_idx meanwhile (overwrite-oldest),
+        // its newer value wins and we resync next quantum — glitch-level
+        // consequences only in an already-overflowing stream.
+        "    Atomics.compareExchange(hdr,1,rStart,r);",
         // Re-arm the start gate when the stream runs dry (a sound ended, or a
         // deep underrun): without this only the FIRST sound after page load
         // gets the target-depth cushion — every later one plays against a
         // near-empty ring and crackles on every scheduling hiccup. The <2
         // remnant frame must be discarded (rIdx=wIdx): a nonzero depth would
         // let the quiet-stream early-open defeat the gate for the next sound.
-        "    if(this.started&&((this.wIdx-r)&mask)<2){",
-        "      this.started=false;this.rIdx=this.wIdx;this.frac=0;this.errI=0;",
+        "    var w2=Atomics.load(hdr,0);",
+        "    if(this.started&&((w2-r)&mask)<2){",
+        "      this.started=false;Atomics.store(hdr,1,w2);this.frac=0;this.errI=0;",
         "    }",
         // Silence-aware depth trim: during sustained silence, clamp ring depth
         // to the target so latency can't grow when the emulator outruns real time
-        "    if(this.silentCount>=8){",
-        "      var depth=(this.wIdx-this.rIdx)&mask;",
-        "      if(depth>ts){this.rIdx=(this.rIdx+depth-ts)&mask;}",
+        "    if(Atomics.load(hdr,3)>=8){",
+        "      var depth=(w2-Atomics.load(hdr,1))&mask;",
+        "      if(depth>ts){Atomics.store(hdr,1,(Atomics.load(hdr,1)+depth-ts)&mask);}",
         "    }",
         "    return true;",
         "  }",
@@ -205,6 +263,10 @@ EM_JS(void, gs_audio_init_js, (), {
         ga.srcRate = p.rate;
         ga.channels = p.ch;
         try {
+            // Hand the worklet the wasm heap (a SharedArrayBuffer under
+            // -pthread) plus the ring's fixed address; it consumes frames
+            // and publishes fill reports through it with Atomics.
+            var heap = (typeof HEAPU8 !== 'undefined') ? HEAPU8 : Module.HEAPU8;
             ga.node = new AudioWorkletNode(ga.ctx, 'gs-audio-worklet', {
                 numberOfInputs: 0,
                 numberOfOutputs: 1,
@@ -212,21 +274,22 @@ EM_JS(void, gs_audio_init_js, (), {
                 processorOptions: {
                     srcRate: p.rate,
                     channels: p.ch,
-                    targetLatency: ga.targetLatency
+                    targetLatency: ga.targetLatency,
+                    sab: heap.buffer,
+                    ringPtr: p.ringPtr,
+                    ringFrames: p.ringFrames
                 }
             });
-            // Cache the worklet's periodic fill reports for the governor's
-            // ring-pressure query (returned by gs_audio_push_js).
-            ga.node.port.onmessage = function(e) {
-                var d = e.data;
-                if (d && typeof d.fill === 'number') {
-                    ga.fill = d.fill;
-                    ga.fillAt = performance.now();
-                }
-            };
             ga.node.connect(ga.ctx.destination);
+            // Opportunistic resume: covers a context suspended before the
+            // node existed when a qualifying gesture already happened.
+            try {
+                if (ga.ctx.state === 'suspended')
+                    ga.ctx.resume();
+            } catch (e) {
+            }
             console.log('[audio] worklet open rate=' + p.rate + 'Hz ch=' + p.ch +
-                        ' targetLatency=' + (ga.targetLatency * 1000).toFixed(1) + 'ms');
+                        ' targetLatency=' + (ga.targetLatency * 1000).toFixed(1) + 'ms (SAB ring)');
         } catch (e) {
             console.error('[audio] worklet node creation failed', e);
         }
@@ -258,7 +321,8 @@ EM_JS(void, gs_audio_resume_js, (), {
 
 // Open (or re-parameterize) the stream: same channel count = in-place rate
 // change (worklet restart), different channel count = node re-creation.
-EM_JS(void, gs_audio_open_js, (int rate, int channels), {
+// ring_ptr / ring_frames locate the shared ring inside the wasm heap.
+EM_JS(void, gs_audio_open_js, (int rate, int channels, uint32_t ring_ptr, int ring_frames), {
     gs_audio_init_js();
     var ga = Module.gsAudio;
     if (ga.node && ga.channels === channels) {
@@ -268,7 +332,7 @@ EM_JS(void, gs_audio_open_js, (int rate, int channels), {
         }
         return;
     }
-    ga.pend = {rate: rate, ch: channels};
+    ga.pend = {rate: rate, ch: channels, ringPtr: ring_ptr, ringFrames: ring_frames};
     if (ga.modReady)
         ga.makeNode();
 });
@@ -289,50 +353,6 @@ EM_JS(void, gs_audio_set_rate_js, (int rate), {
         ga.node.port.postMessage({rate: rate});
 });
 
-// Push interleaved int16 frames to the worklet via MessagePort. Returns the
-// worklet's last-reported ring fill against target depth in per-mille (0 =
-// empty, 1000 = at target), or -1 when no fresh report exists — piggybacked
-// on the push so the emulator thread gets the governor's audio-pressure
-// signal with no extra main-thread round trips.
-EM_JS(int, gs_audio_push_js, (uint32_t ptr, int nframes, int volume), {
-    var ga = Module.gsAudio;
-    if (!ga || !ga.ctx || !ga.node || nframes <= 0)
-        return -1;
-    gs_audio_resume_js();
-
-    var heap = (typeof HEAPU8 !== 'undefined') ? HEAPU8 : Module.HEAPU8;
-    if (!heap)
-        return -1;
-    var bytes = nframes * ga.channels * 2;
-    var end = Math.min(ptr + bytes, heap.length);
-    if (ptr >= end || ((end - ptr) & 1))
-        return -1;
-
-    // Copy samples from WASM heap (must copy — heap can grow/move); the
-    // slice's fresh ArrayBuffer is viewed as Int16Array in the worklet.
-    var raw = heap.slice(ptr, end);
-    var samples = new Int16Array(raw.buffer);
-
-    // Silence detection (all samples equal — any DC level counts)
-    var silent = true;
-    for (var k = 1; k < samples.length; k++) {
-        if (samples[k] !== samples[0]) {
-            silent = false;
-            break;
-        }
-    }
-
-    // Send to worklet via MessagePort (transfer the underlying buffer)
-    ga.node.port.postMessage(
-        {buf: raw.buffer, vol: (volume | 0) & 7, sil: silent},
-        [raw.buffer]
-    );
-
-    // Fresh (<500 ms) worklet fill report, if any
-    if (ga.fillAt !== undefined && (performance.now() - ga.fillAt) < 500)
-        return Math.max(0, Math.min(2000, Math.round(ga.fill * 1000)));
-    return -1;
-});
 // clang-format on
 
 // ============================================================================
@@ -360,10 +380,12 @@ static void gs_audio_resume(void) {
 }
 
 static void gs_audio_open(int rate, int channels) {
+    uint32_t ring_ptr = (uint32_t)(uintptr_t)&g_aring;
     if (emscripten_is_main_browser_thread()) {
-        gs_audio_open_js(rate, channels);
+        gs_audio_open_js(rate, channels, ring_ptr, GS_ARING_FRAMES);
     } else {
-        emscripten_sync_run_in_main_runtime_thread(EM_FUNC_SIG_VII, gs_audio_open_js, rate, channels);
+        emscripten_sync_run_in_main_runtime_thread(EM_FUNC_SIG_VIIII, gs_audio_open_js, rate, channels, ring_ptr,
+                                                   GS_ARING_FRAMES);
     }
 }
 
@@ -372,26 +394,6 @@ static void gs_audio_set_rate(int rate) {
         gs_audio_set_rate_js(rate);
     } else {
         emscripten_sync_run_in_main_runtime_thread(EM_FUNC_SIG_VI, gs_audio_set_rate_js, rate);
-    }
-}
-
-// Last worklet-reported ring fill (fraction of target depth) and when it was
-// captured, in host seconds. Written on the emulator thread (the only pusher)
-// and read by the scheduler's governor on the same thread.
-static double g_ring_fill = -1.0;
-static double g_ring_fill_time = -1.0;
-
-static void gs_audio_push(uint32_t ptr, int nframes, int volume) {
-    int fill_pm;
-    if (emscripten_is_main_browser_thread()) {
-        fill_pm = gs_audio_push_js(ptr, nframes, volume);
-    } else {
-        fill_pm =
-            (int)emscripten_sync_run_in_main_runtime_thread(EM_FUNC_SIG_IIII, gs_audio_push_js, ptr, nframes, volume);
-    }
-    if (fill_pm >= 0) {
-        g_ring_fill = (double)fill_pm / 1000.0;
-        g_ring_fill_time = host_time();
     }
 }
 
@@ -415,14 +417,75 @@ void em_audio_resume(void) {
 
 // Open (or re-parameterize) the host audio stream
 void platform_audio_open(uint32_t src_rate_hz, int channels) {
+    if (channels < 1)
+        channels = 1;
+    if (channels > GS_ARING_MAX_CH)
+        channels = GS_ARING_MAX_CH;
+    g_aring_channels = channels;
+    // Fresh stream: reset the ring so stale frames from a previous machine
+    // or stream shape can't play into the new one.
+    atomic_store_explicit(&g_aring.read_idx, atomic_load_explicit(&g_aring.write_idx, memory_order_relaxed),
+                          memory_order_relaxed);
+    atomic_store_explicit(&g_aring.silent_pushes, 0, memory_order_relaxed);
+    atomic_store_explicit(&g_aring.fill_pm, -1, memory_order_relaxed);
     gs_audio_open((int)src_rate_hz, channels);
 }
 
-// Push interleaved int16 frames to the stream
+// Push interleaved int16 frames to the stream: a local copy into the shared
+// ring plus atomic index/volume updates.  No main-thread round trip — this
+// runs entirely on the emulation thread (perf proposal P6).
 void platform_audio_push(const int16_t *frames, int nframes, int vol_0_7) {
     if (!frames || nframes <= 0)
         return;
-    gs_audio_push((uint32_t)(uintptr_t)frames, nframes, vol_0_7);
+    gs_audio_ring_t *ring = &g_aring;
+    int ch = g_aring_channels;
+    uint32_t n = (uint32_t)nframes;
+    uint32_t mask = GS_ARING_FRAMES - 1;
+    if (n > mask)
+        return; // nonsensical push (larger than the ring)
+
+    // Silence detection (all samples equal — any DC level counts); this scan
+    // used to run on the main thread inside the push proxy.
+    int total = nframes * ch;
+    bool silent = true;
+    for (int k = 1; k < total; k++) {
+        if (frames[k] != frames[0]) {
+            silent = false;
+            break;
+        }
+    }
+
+    uint32_t w = atomic_load_explicit(&ring->write_idx, memory_order_relaxed);
+    uint32_t r = atomic_load_explicit(&ring->read_idx, memory_order_acquire);
+    uint32_t used = (w - r) & mask;
+    uint32_t free_frames = mask - used;
+    if (n > free_frames) {
+        // Overwrite-oldest (matches the old worklet-side behaviour): advance
+        // read_idx past the frames about to be clobbered.  CAS so a racing
+        // consumer update isn't stomped; on failure the consumer freed space.
+        uint32_t need = n - free_frames;
+        uint32_t r_new = (r + need) & mask;
+        atomic_compare_exchange_strong(&ring->read_idx, &r, r_new);
+    }
+
+    // Copy the frames in at most two contiguous spans.
+    uint32_t first = GS_ARING_FRAMES - w;
+    if (first > n)
+        first = n;
+    memcpy(&ring->data[w * ch], frames, (size_t)first * ch * sizeof(int16_t));
+    if (n > first)
+        memcpy(&ring->data[0], frames + first * ch, (size_t)(n - first) * ch * sizeof(int16_t));
+
+    // Publish: data first, then the release-store of write_idx the consumer
+    // acquires — the worklet never reads frames it can't see completely.
+    atomic_store_explicit(&ring->write_idx, (w + n) & mask, memory_order_release);
+    atomic_store_explicit(&ring->vol, vol_0_7 & 7, memory_order_relaxed);
+    if (silent)
+        atomic_fetch_add_explicit(&ring->silent_pushes, 1, memory_order_relaxed);
+    else
+        atomic_store_explicit(&ring->silent_pushes, 0, memory_order_relaxed);
+    atomic_fetch_add_explicit(&ring->push_seq, 1, memory_order_relaxed);
+    g_last_push_time = host_time();
 }
 
 // Change the source sample rate mid-stream
@@ -430,12 +493,16 @@ void platform_audio_set_rate(uint32_t src_rate_hz) {
     gs_audio_set_rate((int)src_rate_hz);
 }
 
-// Ring fill fraction against target depth for the accelerated-mode governor.
-// Fresh only while the producer is actively pushing (each push refreshes the
-// cache from the worklet's periodic reports); goes stale — and reads as
-// "no signal" — within half a second of the stream idling.
+// Ring fill fraction against target depth for the accelerated-mode governor:
+// an atomic read of the worklet's periodic report in the ring header.
+// Meaningful only while the producer is actively pushing — reads as "no
+// signal" within half a second of the stream idling, matching the governor's
+// contract from the proxy-based implementation.
 double platform_audio_ring_fill(void) {
-    if (g_ring_fill < 0.0 || g_ring_fill_time < 0.0 || host_time() - g_ring_fill_time > 0.5)
+    if (g_last_push_time < 0.0 || host_time() - g_last_push_time > 0.5)
         return -1.0;
-    return g_ring_fill;
+    int32_t pm = atomic_load_explicit(&g_aring.fill_pm, memory_order_relaxed);
+    if (pm < 0)
+        return -1.0;
+    return (double)pm / 1000.0;
 }

--- a/src/platform/wasm/em_main.c
+++ b/src/platform/wasm/em_main.c
@@ -730,16 +730,27 @@ int shell_poll(void) {
 void em_main_tick(void) {
     tick_counter++;
 
-    // Calculate performance metrics every PERF_UPDATE_INTERVAL ticks
+    // Calculate performance metrics every PERF_UPDATE_INTERVAL ticks and
+    // push them to the UI (perf proposal P12: MIPS from instr_count deltas —
+    // without this, nothing in web2 would reveal a throughput regression).
     if (tick_counter % PERF_UPDATE_INTERVAL == 0) {
         double current_time = emscripten_get_now();
+        uint64_t instr_now = cpu_instr_count();
+        static uint64_t last_instr = 0;
 
         if (last_time > 0) {
             double elapsed_ms = current_time - last_time;
             ticks_per_second = (PERF_UPDATE_INTERVAL * 1000.0) / elapsed_ms;
+            double mips = (double)(instr_now - last_instr) / (elapsed_ms * 1000.0);
+            // clang-format off
+            MAIN_THREAD_ASYNC_EM_ASM(
+                { if (typeof Module.onPerfUpdate === 'function') Module.onPerfUpdate($0, $1); },
+                (int)(mips * 100.0), (int)(ticks_per_second * 10.0));
+            // clang-format on
         }
 
         last_time = current_time;
+        last_instr = instr_now;
     }
 
     // Execute based on emulation state

--- a/tests/e2e/web2-specs/perf-bench.spec.ts
+++ b/tests/e2e/web2-specs/perf-bench.spec.ts
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) pappadf
+
+// web2 in-browser throughput benchmark (perf proposal P5 validation / P12
+// tracked number).  Boots an SE/30 with no media — the ROM free-runs at the
+// flashing-? insert prompt, a busy-wait that retires instructions at full
+// rate without any test data — then measures two numbers:
+//
+//   1. PRIMARY — Accelerated mode, engaged through the web2 toolbar exactly
+//      as a user would: wait for the adaptive governor to plateau, then
+//      measure effective instructions/second and the multiplier in force.
+//      This is the user-facing deliverable (and what P11's knob re-tune
+//      moves).
+//   2. SECONDARY — turbo mode (via the shell): raw engine throughput within
+//      the fixed TURBO_HOST_HEADROOM RAF budget.  Finer-grained for build-
+//      flag A/Bs, and still meaningful when every variant saturates the
+//      accelerated governor's ladder cap.
+//
+// Measurement: one `echo` samples machine.cpu.instr_count and
+// scheduler.host_wall_ns in the SAME expansion inside the worker, so the
+// instruction and clock samples are atomic and terminal round-trip latency
+// never enters the measured interval.
+//
+// Results are emitted as `PERFBENCH label=<...> mode=<...> ...` lines on
+// stdout — a tracked number, not a gate (assertions are sanity-only).  Label
+// comes from PERF_LABEL in the environment (defaults to "unlabeled").
+
+import { test, expect, type Page } from '@playwright/test';
+import * as path from 'node:path';
+import { gotoWeb2 } from '../helpers/web2-fs';
+
+const DATA = path.resolve(__dirname, '../../data');
+const SE30_ROM = path.join(DATA, 'roms', 'SE30.rom');
+
+const LABEL = process.env.PERF_LABEL ?? 'unlabeled';
+const WINDOWS = Number(process.env.PERF_WINDOWS ?? 3);
+const WINDOW_SECS = Number(process.env.PERF_WINDOW_SECS ?? 8);
+
+// Type one shell line into the Terminal panel's xterm (same pattern as
+// scheduler-accelerated.spec.ts).
+async function terminalRun(page: Page, line: string): Promise<void> {
+  const term = page.locator('.xterm');
+  await term.click();
+  await page.keyboard.type(line);
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(250);
+}
+
+// Atomically sample {instr_count, host_wall_ns} inside the worker via a
+// single echo expansion, keyed so stale terminal echoes can't match.
+let probeSeq = 0;
+async function probeSample(
+  page: Page,
+): Promise<{ instr: number; wallNs: number }> {
+  for (let attempt = 0; attempt < 30; attempt++) {
+    const key = `pb${++probeSeq}`;
+    await terminalRun(
+      page,
+      `echo ${key}=\${machine.cpu.instr_count},\${scheduler.host_wall_ns}`,
+    );
+    await page.waitForTimeout(400);
+    const text = await page.locator('.xterm-rows').innerText();
+    const m = text.match(new RegExp(`${key}=(\\d+),(\\d+)`));
+    if (m) return { instr: Number(m[1]), wallNs: Number(m[2]) };
+  }
+  throw new Error('terminal sample probe never answered');
+}
+
+// Read a string/number expression through the terminal (strict value pattern
+// so the echoed input line can't satisfy the match).
+async function probeString(page: Page, expr: string): Promise<string> {
+  for (let attempt = 0; attempt < 30; attempt++) {
+    const key = `ps${++probeSeq}`;
+    await terminalRun(page, `echo ${key}=[${'$'}{${expr}}]`);
+    await page.waitForTimeout(400);
+    const text = await page.locator('.xterm-rows').innerText();
+    const m = text.match(new RegExp(`${key}=\\[([A-Za-z0-9_.-]+)\\]`));
+    if (m) return m[1];
+  }
+  throw new Error('terminal string probe never answered');
+}
+
+// Measure `windows` intervals of WINDOW_SECS and report MIPS per window plus
+// the live multiplier alongside each sample.
+async function measureWindows(
+  page: Page,
+  modeLabel: string,
+  windows: number,
+): Promise<number[]> {
+  const mipsPerWindow: number[] = [];
+  for (let w = 1; w <= windows; w++) {
+    const a = await probeSample(page);
+    await page.waitForTimeout(WINDOW_SECS * 1000);
+    const b = await probeSample(page);
+    const mips = (b.instr - a.instr) / ((b.wallNs - a.wallNs) / 1e9) / 1e6;
+    const speed = await probeString(page, 'scheduler.speed');
+    mipsPerWindow.push(mips);
+    console.log(
+      `PERFBENCH label=${LABEL} mode=${modeLabel} window=${w} mips=${mips.toFixed(2)} speed=${speed}`,
+    );
+  }
+  const sorted = [...mipsPerWindow].sort((x, y) => x - y);
+  const median = sorted[Math.floor(sorted.length / 2)];
+  console.log(
+    `PERFBENCH label=${LABEL} mode=${modeLabel} median mips=${median.toFixed(2)}`,
+  );
+  return mipsPerWindow;
+}
+
+test('perf-bench: accelerated + turbo throughput (tracked numbers)', async ({
+  page,
+}) => {
+  test.setTimeout(15 * 60 * 1000);
+  await gotoWeb2(page);
+
+  // SE/30 ROM via the Welcome "Upload ROM..." button; built-in video.
+  const [romChooser] = await Promise.all([
+    page.waitForEvent('filechooser'),
+    page.getByRole('button', { name: 'Upload ROM...' }).click(),
+  ]);
+  await romChooser.setFiles(SE30_ROM);
+
+  // New Machine: SE/30, 8 MB, no media.
+  await page.getByRole('button', { name: 'New Machine...' }).click();
+  const model = page.locator('#cfg-model');
+  await expect(model.locator('option[value="se30"]')).toHaveCount(1, {
+    timeout: 30_000,
+  });
+  await model.selectOption('se30');
+  await page.locator('#cfg-ram').selectOption('8 MB');
+  await page.getByRole('button', { name: 'Start Machine' }).click();
+  await expect(
+    page.locator('.toast .msg').filter({ hasText: 'Machine started' }),
+  ).toBeVisible({ timeout: 60_000 });
+
+  // Terminal up (the typed path to the object model).
+  await page.locator('button.ptab[data-tab="terminal"]').click();
+  await expect(page.locator('.xterm')).toBeVisible({ timeout: 15_000 });
+
+  // --- PRIMARY: Accelerated via the web2 toolbar ----------------------------
+  await page.getByRole('button', { name: 'accelerated', exact: true }).click();
+  await expect
+    .poll(async () => probeString(page, 'scheduler.mode'), { timeout: 30_000 })
+    .toBe('accelerated');
+  expect(await probeString(page, 'scheduler.speed_auto')).toBe('true');
+
+  // Wait for the adaptive governor to plateau: the multiplier must hold the
+  // same value across two consecutive 4 s samples (the ladder dwells ~2 s per
+  // rung while climbing), or 90 s elapses.
+  let lastSpeed = '';
+  let stable = 0;
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline && stable < 2) {
+    await page.waitForTimeout(4_000);
+    const s = await probeString(page, 'scheduler.speed');
+    stable = s === lastSpeed ? stable + 1 : 0;
+    lastSpeed = s;
+  }
+  console.log(`PERFBENCH label=${LABEL} governor plateau speed=${lastSpeed}`);
+
+  const accel = await measureWindows(page, 'accel', WINDOWS);
+
+  // --- SECONDARY: turbo engine throughput -----------------------------------
+  await terminalRun(page, 'scheduler.mode = "turbo"');
+  expect(await probeString(page, 'scheduler.mode')).toBe('turbo');
+  await page.waitForTimeout(3_000);
+  const turbo = await measureWindows(page, 'turbo', WINDOWS);
+
+  // P12 observability: the status bar's live MIPS readout (pushed from the
+  // core ~1 Hz) must be visible while running and read a plausible number.
+  const mipsChip = page.locator('.gs-statusbar .sb-mips .label');
+  await expect(mipsChip).toBeVisible({ timeout: 15_000 });
+  const shownMips = parseFloat(await mipsChip.innerText());
+  console.log(`PERFBENCH label=${LABEL} statusbar mips=${shownMips}`);
+  expect(shownMips).toBeGreaterThan(0.5);
+
+  // Sanity only — this spec reports tracked numbers, it does not gate.
+  expect(Math.max(...accel)).toBeGreaterThan(0.5);
+  expect(Math.max(...turbo)).toBeGreaterThan(0.5);
+});


### PR DESCRIPTION
Implements `local/gs-docs/proposals/proposal-performance-optimizations.md` with **per-item measurement gating every adoption** — each commit carries its numbers; two items were implemented, measured, and deliberately *not* adopted.

## Adopted — core (headless Marathon steady-state bench, 1B-instr window, all pixel-exact with identical retirement)

| Item | Change | Measured effect |
|---|---|---|
| P1 | ATC-style block-descriptor cache replaces the eager MMU coverage fill | the dominant win; boot memset storm also gone |
| P3 | Force-inline hot EA helpers, `calculate_ea` hot/cold split | +1.9%, 6/6 pairwise wins (full inlining measured flat: I-cache) |
| P4 | `GS_FAST` profile: asserts + scheduler invariant walks compiled out (wasm release, opt-in headless `MODE=fast`) | +6.5%, 3/3 pairs; default headless build keeps all checks |
| P7.1 | Scheduler event free-list pool | +3.0%, 3/3 pairs |

**Core total, same host state: 57.5 → 82.6 MIPS default (+44%) → 87.0 MIPS `MODE=fast` (+51%)** — matching the proposal's predicted +52% for P1+P3+P4.

## Adopted — browser (in-browser bench `perf-bench.spec.ts`: SE/30 busy-wait, Accelerated via toolbar primary + turbo secondary, atomic counter sampling through the terminal)

| Item | Change | Measured / validated |
|---|---|---|
| P6 | SharedArrayBuffer audio ring — the worklet consumes a static C ring via Atomics; the ~348/s synchronous worker→main push proxies, per-push heap copy and silence scan are gone; governor fill query is an atomic load; autoplay resume moves to one-shot gesture hooks | e2e green, chime path exercised every boot, silent-workload throughput unchanged; manual listen check of boot chimes, 824gc beep and MusicWorks playback passed |
| P11 | Turbo host headroom 0.5 → 0.7 | turbo 21.6 → 30.3 MIPS (+40%), terminal round-trips stayed prompt on a 2-vCPU host; isolated one-line commit, easy to drop/tune if low-end caution wins. Ladder-cap extension deliberately NOT taken (governor never sustains 8x on the bench host — unvalidatable) |
| P12 | Live MIPS readout in the status bar (wires the dead `ticks_per_second`), pushed ~1 Hz from the core; guarded by a bench assertion | visible + plausible in every bench run |
| P5 (infra) | In-browser benchmark spec + `EXTRA_CFLAGS/EXTRA_LDFLAGS` reaching the emcc link step | the tooling that made the flag matrix measurable |

## Measured and NOT adopted

- **P2 — per-MMU-configuration cached SoA sets**: fully implemented and suite-green, parked on branch `perf-p2-per-config-soa-sets`. No measurable gain over P1 on idle gameplay, a busier demo scene, or boot (P1's single-page fills already removed the memset storm). Revisit for wasm paired with the P2a write-protect backstop.
- **P5 — wasm codegen flags** (`-O3`, `-msimd128`, `-flto`, `-sINITIAL_MEMORY`): all within noise on properly paired browser runs. An initial sweep suggested +6% for simd/lto; within-pair alternation exposed it as a cold-first-slot **order effect** (baseline always ran first per round). Benchmark discipline note for future work.

## Deferred with findings

- **P9 dirty tracking**: the 824gc framebuffer is dual-mapped — the slot aperture is a host region on the SoA fast path (unhookable without slow-pathing every write); only the super-slot aperture is device-dispatched. Authoritative dirty tracking is partial at best; needs a Marathon-in-browser bench to justify.
- **P7.2 ASC batching, P8 single-level dispatch, P10 micro-opts, governor anti-hunting**: measurement tooling for all of these now exists on this branch.

## Validation

- 100/100 headless integration tests on the rebased branch (including the new `iifx-aux3-x11` row — a further exercise of P1's A/UX ATC-residency contract)
- 21/21 web2 Playwright e2e (scheduler-accelerated, checkpoint-resume, A/UX realtime, Lisa Xenix, video modes, perf-bench)
- 68000 (136 mnemonics / 108M tests) + 68030 (180 mnemonics) single-step suites
- web2 typecheck; wasm + ui2 release builds; manual audio listen check
- Benchmark anchors held on every run: boot-to-gameplay signature `553055803`, framebuffer checksum `818782449`, bit-identical retirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)
