### PR TITLE
test-data: canonical ROM/vROM filenames + rom-naming conformance test

### DIFF
--- a/.agents/skills/disasm-tool/SKILL.md
+++ b/.agents/skills/disasm-tool/SKILL.md
@@ -131,7 +131,7 @@ $40802A72  6600  BNE       *+$01CA       ; -> $40802C3C
 SE/30 ROM is mapped at `0x40800000`:
 
 ```bash
-./tools/disasm/disasm -a 0x40800000 -n 50 tests/data/roms/SE30.rom
+./tools/disasm/disasm -a 0x40800000 -n 50 tests/data/roms/iix-iicx-se30-97221136.rom
 ```
 
 ### Disassemble from a specific offset
@@ -139,7 +139,7 @@ SE/30 ROM is mapped at `0x40800000`:
 The SE/30 entry point is at ROM offset `0x90`:
 
 ```bash
-./tools/disasm/disasm -a 0x40800000 -o 0x90 -n 20 tests/data/roms/SE30.rom
+./tools/disasm/disasm -a 0x40800000 -o 0x90 -n 20 tests/data/roms/iix-iicx-se30-97221136.rom
 ```
 
 ### Disassemble a specific byte range
@@ -147,7 +147,7 @@ The SE/30 entry point is at ROM offset `0x90`:
 Show exactly 256 bytes starting at offset `0x3F61C`:
 
 ```bash
-./tools/disasm/disasm -a 0x40800000 -o 0x3F61C -l 256 tests/data/roms/SE30.rom
+./tools/disasm/disasm -a 0x40800000 -o 0x3F61C -l 256 tests/data/roms/iix-iicx-se30-97221136.rom
 ```
 
 ### View a code region without address remapping
@@ -155,7 +155,7 @@ Show exactly 256 bytes starting at offset `0x3F61C`:
 If you just want raw offsets (no base address):
 
 ```bash
-./tools/disasm/disasm -o 0x90 -n 10 tests/data/roms/SE30.rom
+./tools/disasm/disasm -o 0x90 -n 10 tests/data/roms/iix-iicx-se30-97221136.rom
 ```
 
 Addresses will start from `0x00000090`.
@@ -172,9 +172,9 @@ Works on any raw 68K binary (disk sector dumps, code resources, etc.):
 
 | Machine | ROM file | Base address |
 |---------|----------|-------------|
-| SE/30 | `tests/data/roms/SE30.rom` | `0x40800000` |
-| Mac Plus | `tests/data/roms/Plus_v3.rom` | `0x00400000` |
-| IIcx | `tests/data/roms/IIcx.rom` | `0x40800000` |
+| SE/30 | `tests/data/roms/iix-iicx-se30-97221136.rom` | `0x40800000` |
+| Mac Plus | `tests/data/roms/plus-v3-4d1f8172.rom` | `0x00400000` |
+| IIcx | `tests/data/roms/iix-iicx-se30-97221136.rom` | `0x40800000` |
 
 ## 7. Tips
 

--- a/.agents/skills/headless-debug/SKILL.md
+++ b/.agents/skills/headless-debug/SKILL.md
@@ -54,15 +54,15 @@ Binary: `build/headless/gs-headless`.
 
 ```bash
 ./build/headless/gs-headless --daemon --kill --speed=max --no-prompt \
-    rom=tests/data/roms/SE30.rom [hd=disk.img] [fd=floppy.dsk] &
+    rom=tests/data/roms/iix-iicx-se30-97221136.rom [hd=disk.img] [fd=floppy.dsk] &
 sleep 2  # or block-read for "READY" on stdout
 ```
 
 Flags:
 - `--daemon` — required, enables TCP socket mode.
 - `rom=<file>` — required. ROMs live under `tests/data/roms/`
-  (`SE30.rom`, `Plus_v3.rom`, `IIcx.rom`; vrom: `SE30.vrom`,
-  `Apple-341-0868.vrom`).
+  (`iix-iicx-se30-97221136.rom`, `plus-v3-4d1f8172.rom`, `iix-iicx-se30-97221136.rom`; vrom: `builtin-se30-video-4f71ff1a.vrom`,
+  `mdc-8-24-revb-d1629664.vrom`).
 - `hd=<file>` (×8) / `fd=<file>` (×2) — pre-attach disks.
 - `--port=N` — TCP port (default **6800**).
 - `--speed=max|realtime|hardware` — default `realtime`. Use `max` for
@@ -94,7 +94,7 @@ this is a launch-environment problem.
 
 ```bash
 ./build/headless/gs-headless --daemon --kill --speed=max --no-prompt \
-    rom=tests/data/roms/SE30.rom &
+    rom=tests/data/roms/iix-iicx-se30-97221136.rom &
 sleep 2
 echo "objects" | nc -w 2 localhost 6800
 ```
@@ -455,7 +455,7 @@ machine.profile "plus"                                # ditto
 machine.rom.path                                              # currently loaded ROM
 machine.rom.checksum                                          # "97221136" (8-hex string)
 machine.rom.name                                              # "Universal IIx/IIcx/SE/30 ROM"
-machine.rom.identify "tests/data/roms/Plus_v3.rom"            # full info map (JSON)
+machine.rom.identify "tests/data/roms/plus-v3-4d1f8172.rom"            # full info map (JSON)
 ```
 
 `machine.profile(id)` returns a JSON-string carrying `id`, `name`,

--- a/Makefile
+++ b/Makefile
@@ -440,4 +440,4 @@ help:
 	@echo "  SPEED=max|realtime|hardware   Emulation speed"
 	@echo ""
 	@echo "Example:"
-	@echo "  make run ROM=tests/data/roms/Plus_v3.rom HD0=tests/data/systems/hd.zip"
+	@echo "  make run ROM=tests/data/roms/plus-v3-4d1f8172.rom HD0=tests/data/systems/hd.zip"

--- a/USAGE.md
+++ b/USAGE.md
@@ -18,7 +18,7 @@ You can specify images directly in the page URL as query arguments (e.g., `rom=.
 
 **Example:**
 ```
-https://your-emulator-page?rom=https://example.com/Plus_v3.rom&fd0=https://example.com/System_6_0_8.dsk
+https://your-emulator-page?rom=https://example.com/plus-v3-4d1f8172.rom&fd0=https://example.com/System_6_0_8.dsk
 ```
 This will download the ROM and floppy disk images and place them under `/persist/boot/rom` and `/persist/boot/fd0` respectively.
 

--- a/app/web2/src/bus/opfs.ts
+++ b/app/web2/src/bus/opfs.ts
@@ -107,8 +107,16 @@ class MockOpfs implements OpfsBackend {
 
   async scanRoms(): Promise<RomInfo[]> {
     return [
-      { name: 'Macintosh Plus v3.rom', path: '/opfs/images/rom/plus-v3-4d1f8172.rom', size: 128 * 1024 },
-      { name: 'iix-iicx-se30-97221136.rom', path: '/opfs/images/rom/iix-iicx-se30-97221136.rom', size: 256 * 1024 },
+      {
+        name: 'Macintosh Plus v3.rom',
+        path: '/opfs/images/rom/plus-v3-4d1f8172.rom',
+        size: 128 * 1024,
+      },
+      {
+        name: 'iix-iicx-se30-97221136.rom',
+        path: '/opfs/images/rom/iix-iicx-se30-97221136.rom',
+        size: 256 * 1024,
+      },
     ];
   }
 

--- a/app/web2/src/bus/opfs.ts
+++ b/app/web2/src/bus/opfs.ts
@@ -69,8 +69,8 @@ class MockOpfs implements OpfsBackend {
     this.dirs.add('/opfs/checkpoints');
     this.dirs.add('/opfs/upload');
     this.dirs.add('/opfs/config');
-    this.files.set('/opfs/images/rom/Plus_v3.rom', { size: 128 * 1024 });
-    this.files.set('/opfs/images/rom/SE30.rom', { size: 256 * 1024 });
+    this.files.set('/opfs/images/rom/plus-v3-4d1f8172.rom', { size: 128 * 1024 });
+    this.files.set('/opfs/images/rom/iix-iicx-se30-97221136.rom', { size: 256 * 1024 });
     this.files.set('/opfs/images/vrom/ROM_97221136', { size: 256 * 1024 });
     this.files.set('/opfs/images/vrom/ROM_SE30_VROM', { size: 256 * 1024 });
     this.files.set('/opfs/images/fd/System_7.0_Install.dsk', { size: 1440 * 1024 });
@@ -107,14 +107,14 @@ class MockOpfs implements OpfsBackend {
 
   async scanRoms(): Promise<RomInfo[]> {
     return [
-      { name: 'Macintosh Plus v3.rom', path: '/opfs/images/rom/Plus_v3.rom', size: 128 * 1024 },
-      { name: 'SE30.rom', path: '/opfs/images/rom/SE30.rom', size: 256 * 1024 },
+      { name: 'Macintosh Plus v3.rom', path: '/opfs/images/rom/plus-v3-4d1f8172.rom', size: 128 * 1024 },
+      { name: 'iix-iicx-se30-97221136.rom', path: '/opfs/images/rom/iix-iicx-se30-97221136.rom', size: 256 * 1024 },
     ];
   }
 
   async scanImages(cat: ImageCategory): Promise<OpfsEntry[]> {
     const fixtures: Record<ImageCategory, string[]> = {
-      rom: ['Plus_v3.rom', 'SE30.rom'],
+      rom: ['plus-v3-4d1f8172.rom', 'iix-iicx-se30-97221136.rom'],
       vrom: ['ROM_97221136', 'ROM_SE30_VROM'],
       fd: ['System_7.0_Install.dsk', 'Disk_Tools.dsk'],
       hd: ['hd1.img', 'hd2.img'],

--- a/app/web2/src/lib/media.ts
+++ b/app/web2/src/lib/media.ts
@@ -109,7 +109,7 @@ export const MEDIA_TYPES: Record<MediaTypeId, MediaTypeDescriptor> = {
       }
     },
     // VROMs are stored under the canonical filename the core's card
-    // factories look up (e.g. JMFB hardcodes "Apple-341-0868.vrom" in
+    // factories look up (e.g. JMFB hardcodes "mdc-8-24-revb-d1629664.vrom" in
     // jmfb.c). The C-side `machine.vrom.identify` derives the canonical name
     // from the file's content hash; the UI doesn't carry any ROM
     // knowledge of its own.

--- a/app/web2/tests/component/ImagesView.test.ts
+++ b/app/web2/tests/component/ImagesView.test.ts
@@ -26,8 +26,8 @@ describe('ImagesView', () => {
       const names = Array.from(container.querySelectorAll('.image-row .name')).map(
         (e) => e.textContent,
       );
-      expect(names).toContain('Plus_v3.rom');
-      expect(names).toContain('SE30.rom');
+      expect(names).toContain('plus-v3-4d1f8172.rom');
+      expect(names).toContain('iix-iicx-se30-97221136.rom');
     });
   });
 

--- a/app/web2/tests/component/WelcomeConfigSlide.scan.test.ts
+++ b/app/web2/tests/component/WelcomeConfigSlide.scan.test.ts
@@ -130,7 +130,7 @@ describe('WelcomeConfigSlide OPFS scan', () => {
       new StubOpfs({
         rom: [
           { name: 'Plus_v1.rom', path: '/opfs/images/rom/Plus_v1.rom', kind: 'file' },
-          { name: 'Plus_v3.rom', path: '/opfs/images/rom/Plus_v3.rom', kind: 'file' },
+          { name: 'plus-v3-4d1f8172.rom', path: '/opfs/images/rom/plus-v3-4d1f8172.rom', kind: 'file' },
         ],
       }),
     );
@@ -148,8 +148,8 @@ describe('WelcomeConfigSlide OPFS scan', () => {
     setOpfsBackend(
       new StubOpfs({
         rom: [
-          { name: 'Plus_v3.rom', path: '/opfs/images/rom/Plus_v3.rom', kind: 'file' },
-          { name: 'SE30.rom', path: '/opfs/images/rom/SE30.rom', kind: 'file' },
+          { name: 'plus-v3-4d1f8172.rom', path: '/opfs/images/rom/plus-v3-4d1f8172.rom', kind: 'file' },
+          { name: 'iix-iicx-se30-97221136.rom', path: '/opfs/images/rom/iix-iicx-se30-97221136.rom', kind: 'file' },
         ],
       }),
     );

--- a/app/web2/tests/component/WelcomeConfigSlide.scan.test.ts
+++ b/app/web2/tests/component/WelcomeConfigSlide.scan.test.ts
@@ -130,7 +130,11 @@ describe('WelcomeConfigSlide OPFS scan', () => {
       new StubOpfs({
         rom: [
           { name: 'Plus_v1.rom', path: '/opfs/images/rom/Plus_v1.rom', kind: 'file' },
-          { name: 'plus-v3-4d1f8172.rom', path: '/opfs/images/rom/plus-v3-4d1f8172.rom', kind: 'file' },
+          {
+            name: 'plus-v3-4d1f8172.rom',
+            path: '/opfs/images/rom/plus-v3-4d1f8172.rom',
+            kind: 'file',
+          },
         ],
       }),
     );
@@ -148,8 +152,16 @@ describe('WelcomeConfigSlide OPFS scan', () => {
     setOpfsBackend(
       new StubOpfs({
         rom: [
-          { name: 'plus-v3-4d1f8172.rom', path: '/opfs/images/rom/plus-v3-4d1f8172.rom', kind: 'file' },
-          { name: 'iix-iicx-se30-97221136.rom', path: '/opfs/images/rom/iix-iicx-se30-97221136.rom', kind: 'file' },
+          {
+            name: 'plus-v3-4d1f8172.rom',
+            path: '/opfs/images/rom/plus-v3-4d1f8172.rom',
+            kind: 'file',
+          },
+          {
+            name: 'iix-iicx-se30-97221136.rom',
+            path: '/opfs/images/rom/iix-iicx-se30-97221136.rom',
+            kind: 'file',
+          },
         ],
       }),
     );

--- a/app/web2/tests/component/WelcomeConfigSlide.test.ts
+++ b/app/web2/tests/component/WelcomeConfigSlide.test.ts
@@ -17,7 +17,7 @@ vi.mock('@/bus/emulator', async (importOriginal) => {
     gsEval: async (path: string, args?: unknown[]) => {
       if (path === 'machine.rom.identify') {
         const p = (args?.[0] as string) ?? '';
-        if (p.endsWith('Plus_v3.rom')) {
+        if (p.endsWith('plus-v3-4d1f8172.rom')) {
           return JSON.stringify({
             recognised: true,
             checksum: 'plus-checksum',
@@ -26,7 +26,7 @@ vi.mock('@/bus/emulator', async (importOriginal) => {
             size: 128 * 1024,
           });
         }
-        if (p.endsWith('SE30.rom')) {
+        if (p.endsWith('iix-iicx-se30-97221136.rom')) {
           return JSON.stringify({
             recognised: true,
             checksum: 'se30-checksum',

--- a/app/web2/tests/lint/no-model-name-matching.test.ts
+++ b/app/web2/tests/lint/no-model-name-matching.test.ts
@@ -21,7 +21,7 @@ const SRC = join(here, '..', '..', 'src');
 const FORBIDDEN: { why: string; pattern: RegExp }[] = [
   {
     // The smoking gun: an escaped-slash model name inside a regex literal.
-    // "SE30.rom" (a filename) has no backslash, so it does not match this.
+    // "iix-iicx-se30-97221136.rom" (a filename) has no backslash, so it does not match this.
     why: 'regex literal matching the "SE/30" model name (use machine.profile capabilities instead)',
     pattern: /SE\\\/30/,
   },

--- a/app/web2/tests/unit/opfs.mock.test.ts
+++ b/app/web2/tests/unit/opfs.mock.test.ts
@@ -72,8 +72,8 @@ describe('scanImages/scanRoms hide AppleDouble sidecars', () => {
 
   it('excludes "._<name>" from the ROM listing', async () => {
     const be = new FakeListOpfs();
-    be.entries = ['SE30.rom', '._SE30.rom'];
+    be.entries = ['iix-iicx-se30-97221136.rom', '._iix-iicx-se30-97221136.rom'];
     const names = (await be.scanRoms()).map((r) => r.name);
-    expect(names).toEqual(['SE30.rom']);
+    expect(names).toEqual(['iix-iicx-se30-97221136.rom']);
   });
 });

--- a/docs/core/memory/pram.md
+++ b/docs/core/memory/pram.md
@@ -337,7 +337,7 @@ The SE/30 has **no programmable video device**: the built-in 9″ display is
 a fixed 512×342 1-bit framebuffer scanned out of main RAM by the GLUE
 ASIC. There is no CLUT, no depth control, and no real video driver in
 the System file. To make the Slot Manager and `_InitGraf` happy, however,
-the SE/30 ROM (and our `tests/data/roms/SE30.vrom` declaration ROM)
+the SE/30 ROM (and our `tests/data/roms/builtin-se30-video-4f71ff1a.vrom` declaration ROM)
 exposes the built-in display as a **pseudo-slot at slot $9** with a
 single mode-list entry (`spID = $80`, 1 bpp, 512×342). The 8-byte
 sPRAMRec at `$46..$4D` is therefore real and is maintained by the Slot
@@ -361,7 +361,7 @@ from an Apple-supplied or third-party NuBus card installed in one of
 slots `$9..$E`. In our integration test
 [tests/integration/iicx-floppy/config.mk](../tests/integration/iicx-floppy/config.mk),
 the card we install is the **Apple Macintosh Display Card 8•24** (Apple
-codename "JMFB", declaration ROM `Apple-341-0868.vrom`,
+codename "JMFB", declaration ROM `mdc-8-24-revb-d1629664.vrom`,
 [src/core/peripherals/nubus/cards/jmfb.c](../src/core/peripherals/nubus/cards/jmfb.c)).
 That card is multi-mode and multi-depth (1/2/4/8/16/24 bpp, multiple
 resolutions selected by the connected monitor's sense lines), so its
@@ -603,7 +603,7 @@ pram[0x02:0x04]       = b'\x4F\x48'
 #    On SE/30: built-in 1-bit pseudo-slot (only valid depth/mode is $80).
 #    On IIcx:  first NuBus card; for the Apple Display Card 8•24 (JMFB)
 #              the depth byte should match a depth advertised by
-#              Apple-341-0868.vrom (e.g. $80=1bpp, $81=2bpp, $82=4bpp,
+#              mdc-8-24-revb-d1629664.vrom (e.g. $80=1bpp, $81=2bpp, $82=4bpp,
 #              $83=8bpp) and the mode byte should match a mode-list
 #              entry advertised by the same vrom.
 slot9 = 0x46

--- a/docs/core/peripherals/nubus/cards/display_card_24ac.md
+++ b/docs/core/peripherals/nubus/cards/display_card_24ac.md
@@ -9,7 +9,7 @@ Catalogued in [`video.md`](../../video.md) §2.3; vROM byte-layout reference in
 | | |
 |---|---|
 | **Card kind** | `display_card_24ac` |
-| **vROM** | `display-card-24ac.vrom` (carries its own System 7 video driver) |
+| **vROM** | `display-card-24ac-d8daab87.vrom` (carries its own System 7 video driver) |
 | **Slot** | IIcx video slot `$9` (selectable via `machine.nubus.video_card`) |
 | **VRAM** | 4 MB, flat aperture at slot offset 0 (no VideoBase/RowWords register) |
 | **Depths** | 1 / 4 / 8 / 16 / 32 bpp (no 2 bpp) |

--- a/docs/core/peripherals/nubus/cards/display_card_8_24.md
+++ b/docs/core/peripherals/nubus/cards/display_card_8_24.md
@@ -17,7 +17,7 @@ byte-layout reference in [`nubus_vrom.md`](../../nubus_vrom.md).
 |---|---|
 | **Card kind** | `mdc_8_24` |
 | **ASIC** | Jackson / JMFB / Elmer (successor to Toby/TFB) |
-| **vROM** | `Apple-341-0868.vrom` (ROM `341-0868`, Rev B) |
+| **vROM** | `mdc-8-24-revb-d1629664.vrom` (ROM `341-0868`, Rev B) |
 | **Slot** | `$9` **default** video card on IIcx, IIx, IIfx |
 | **VRAM** | 2 MB (`defMinorLengthB`) |
 | **decl-ROM** | 32 KB chip → 128 KB bus footprint (byteLanes `$78`), at slot `0xFE0000` |
@@ -29,7 +29,7 @@ byte-layout reference in [`nubus_vrom.md`](../../nubus_vrom.md).
 Minimum-viable (proposal `proposal-machine-iicx-iix.md` §3.2.5): enough to boot
 System 7 to a colour desktop and let the Monitors control panel switch depth.
 
-- The card factory loads `Apple-341-0868.vrom` and registers VRAM, the
+- The card factory loads `mdc-8-24-revb-d1629664.vrom` and registers VRAM, the
   declaration ROM, and the register window on the bus.
 - One I/O dispatcher handles all four register blocks (JMFB / Stopwatch / CLUT /
   Endeavor). The registers the boot path depends on are **modelled**; everything

--- a/docs/guide/TEST_DATA.md
+++ b/docs/guide/TEST_DATA.md
@@ -31,8 +31,8 @@ Located in `tests/data/roms/`:
 
 | File         | Size    | Description            |
 |--------------|---------|------------------------|
-| `Plus_v3.rom`| 128 KB  | Macintosh Plus ROM v3  |
-| `IIcx.rom`   | 256 KB  | Macintosh IIcx ROM     |
+| `plus-v3-4d1f8172.rom`| 128 KB  | Macintosh Plus ROM v3  |
+| `iix-iicx-se30-97221136.rom`   | 256 KB  | Macintosh IIcx ROM     |
 
 **How to obtain:**
 - Extract from a physical Macintosh using ROM extraction tools
@@ -80,8 +80,8 @@ Your `tests/data/` directory should look like this:
 tests/data/
 ├── README.md           (this can remain - explains the directory)
 ├── roms/
-│   ├── Plus_v3.rom     (128 KB - Macintosh Plus ROM)
-│   └── IIcx.rom        (256 KB - optional)
+│   ├── plus-v3-4d1f8172.rom     (128 KB - Macintosh Plus ROM)
+│   └── iix-iicx-se30-97221136.rom        (256 KB - optional)
 ├── systems/
 │   ├── System_6_0_8.dsk   (819,200 bytes - primary test system)
 │   ├── System_7_1_0.dsk   (optional)
@@ -107,7 +107,7 @@ The test data is stored in a private GitHub repository. To set this up:
    ```
    gs-test-data/
    ├── roms/
-   │   └── Plus_v3.rom
+   │   └── plus-v3-4d1f8172.rom
    ├── systems/
    │   ├── System_6_0_8.dsk
    │   └── ...
@@ -198,4 +198,4 @@ ls -la tests/data/roms/
 ls -la tests/data/systems/
 ```
 
-The most commonly needed file is `tests/data/roms/Plus_v3.rom` and `tests/data/systems/System_6_0_8.dsk`.
+The most commonly needed file is `tests/data/roms/plus-v3-4d1f8172.rom` and `tests/data/systems/System_6_0_8.dsk`.

--- a/scripts/fetch-test-data.sh
+++ b/scripts/fetch-test-data.sh
@@ -55,7 +55,7 @@ check_data_available() {
         return 0
     fi
     # Also check for key files as fallback
-    if [[ -f "$DATA_DIR/roms/Plus_v3.rom" ]] && [[ -d "$DATA_DIR/systems" ]]; then
+    if [[ -f "$DATA_DIR/roms/plus-v3-4d1f8172.rom" ]] && [[ -d "$DATA_DIR/systems" ]]; then
         return 0
     fi
     return 1

--- a/scripts/rom-manifest.sh
+++ b/scripts/rom-manifest.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+#
+# rom-manifest.sh - Generate the human-readable roms/ manifest for gs-test-data.
+#
+# Machine-derives every fact it can (canonical name, size, checksum/CRC, kind,
+# compatible models / card id, family name) by running gs-headless
+# machine.(v)rom.identify over each file, then merges a small curated notes
+# table (provenance, Apple part numbers, Rev A/B, "16bpp requires this ROM")
+# that identify cannot know.  This is the tool from proposal-test-rom-naming.md
+# §4.4 — the manifest is regenerated, never hand-edited.
+#
+# Usage:
+#   scripts/rom-manifest.sh [ROMS_DIR] [OUT_FILE]
+#     ROMS_DIR  directory of *.rom / *.vrom files   (default: tests/data/roms)
+#     OUT_FILE  markdown file to write, or - for stdout (default: -)
+#
+# Env:
+#   HEADLESS_BIN  path to gs-headless (default: build/headless/gs-headless)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ROMS_DIR="${1:-$REPO_ROOT/tests/data/roms}"
+OUT_FILE="${2:--}"
+HEADLESS_BIN="${HEADLESS_BIN:-$REPO_ROOT/build/headless/gs-headless}"
+
+[ -d "$ROMS_DIR" ]     || { echo "rom-manifest: no such dir: $ROMS_DIR" >&2; exit 1; }
+[ -x "$HEADLESS_BIN" ] || { echo "rom-manifest: headless binary not built: $HEADLESS_BIN (run 'make headless')" >&2; exit 1; }
+
+# A boot ROM is required to start headless; use any *.rom in the dir.
+BOOT_ROM="$(find "$ROMS_DIR" -maxdepth 1 -name '*.rom' | sort | head -1)"
+[ -n "$BOOT_ROM" ] || { echo "rom-manifest: no *.rom to boot headless with in $ROMS_DIR" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+SCRIPT="$WORK/identify.script"
+: > "$SCRIPT"
+while IFS= read -r -d '' f; do
+    base="$(basename "$f")"
+    case "$base" in
+        *.rom)  obj="machine.rom.identify"  ;;
+        *.vrom) obj="machine.vrom.identify" ;;
+        *) continue ;;
+    esac
+    printf 'echo GSFILE %s\n' "$base" >> "$SCRIPT"
+    printf 'echo ${%s("%s")}\n' "$obj" "$f" >> "$SCRIPT"
+done < <(find "$ROMS_DIR" -maxdepth 1 -type f -print0 | sort -z)
+echo "quit" >> "$SCRIPT"
+
+OUT="$WORK/identify.out"
+GS_STORAGE_CACHE="$WORK/cache" "$HEADLESS_BIN" \
+    rom="$BOOT_ROM" --no-prompt --speed=max "script=$SCRIPT" > "$OUT" 2>/dev/null
+
+python3 - "$OUT" "$OUT_FILE" <<'PY'
+import re, sys, os
+
+out_path, dest = sys.argv[1], sys.argv[2]
+lines = open(out_path, encoding="utf-8", errors="replace").read().splitlines()
+
+def field(js, key):
+    # Comma-free scalar fields (checksum, crc, canonical_name, card_id, size,
+    # recognised). NOT for `name` / `compatible`, which can contain commas.
+    m = re.search(r'(?:^|[,{])' + re.escape(key) + r':([^,}]*)', js)
+    return m.group(1) if m else None
+
+def rom_name(js):
+    # rom.identify key order: ...,name:<free text>,canonical_name:...
+    m = re.search(r'(?:^|,)name:(.*?),canonical_name:', js)
+    return m.group(1) if m else ""
+
+def compatible(js):
+    m = re.search(r'compatible:\[([^\]]*)\]', js)
+    return m.group(1) if m else ""
+
+# Curated human notes keyed by canonical filename. Machine-derived columns
+# (size/checksum/models) come from identify; this is only what identify cannot
+# know: provenance, Apple part numbers, Rev A/B, the 16bpp fact.
+NOTES = {
+  "plus-v3-4d1f8172.rom":            "Macintosh Plus ROM Rev 3 (“Loud Harmonicas”).",
+  "iix-iicx-se30-97221136.rom":      "Universal 256 KB ROM — boots IIx, IIcx and SE/30 (byte-identical across all three; formerly stored twice as SE30.rom + IIcx.rom).",
+  "iifx-4147dd77.rom":               "Macintosh IIfx ROM.",
+  "iici-368cadfe.rom":               "Macintosh IIci (“Aurora”) ROM.",
+  "iisi-36b7fb6c.rom":               "Macintosh IIsi (“Erickson”) ROM.",
+  "lisa2-revh-098917b2.rom":         "Apple Lisa 2 boot ROM rev H (interleaved 16 KB image; checksum is the Mac-style computed value, not the stored reset SSP).",
+  "macxl-3a-094c82f0.rom":           "Macintosh XL boot ROM “3A” (interleaved 16 KB image).",
+  "builtin-se30-video-4f71ff1a.vrom":"SE/30 onboard-video declaration ROM — a built-in video slot, not a NuBus card.",
+  "mdc-8-24-revb-d1629664.vrom":     "Macintosh Display Card 8•24 (non-GC, JMFB). Apple part 341-0868, Rev B. Formerly stored twice as Apple-341-0868.vrom + 341-0868.vrom.",
+  "display-card-24ac-d8daab87.vrom": "Apple Macintosh Display Card 24AC.",
+  "824gc-v1.1-revb-d722b053.vrom":   "8•24 GC vROM v1.1 (16-Sep-91). Apple part 341-0266, the Rev B ROM — the ONLY 8•24 GC ROM with 16 bpp modes; catalog default.",
+  "824gc-v1.0-reva-9e9857e8.vrom":   "8•24 GC vROM v1.0 (shipping). Apple part 341-0812-02, Rev A — no 16 bpp modes.",
+  "824gc-v1.0a16-4740028d.vrom":     "8•24 GC vROM 1.00a16 alpha (codename “Dolphin”).",
+}
+
+# Old -> new alias table, kept permanently for grep-ability (proposal §7).
+ALIASES = [
+  ("Plus_v3.rom",            "plus-v3-4d1f8172.rom"),
+  ("SE30.rom, IIcx.rom",     "iix-iicx-se30-97221136.rom"),
+  ("4147DD77-IIfx.rom",      "iifx-4147dd77.rom"),
+  ("368CADFE-IIci.rom",      "iici-368cadfe.rom"),
+  ("36B7FB6C-IIsi.rom",      "iisi-36b7fb6c.rom"),
+  ("Lisa/roms/098917B2-LisaH.rom", "lisa2-revh-098917b2.rom"),
+  ("Lisa/roms/094C82F0-MacXL.rom", "macxl-3a-094c82f0.rom"),
+  ("SE30.vrom",              "builtin-se30-video-4f71ff1a.vrom"),
+  ("Apple-341-0868.vrom, 341-0868.vrom", "mdc-8-24-revb-d1629664.vrom"),
+  ("display-card-24ac.vrom", "display-card-24ac-d8daab87.vrom"),
+  ("Apple-341-0266.vrom",    "824gc-v1.1-revb-d722b053.vrom"),
+  ("341-0812-02_1.0.vrom",   "824gc-v1.0-reva-9e9857e8.vrom"),
+  ("Dolphin_1.0A16.vrom",    "824gc-v1.0a16-4740028d.vrom"),
+]
+
+rows, pending = [], None
+for ln in lines:
+    m = re.search(r'GSFILE (\S+)', ln)
+    if m:
+        pending = m.group(1); continue
+    if pending is not None and '{recognised:' in ln:
+        rows.append((pending, ln[ln.index('{recognised:'):])); pending = None
+
+def human_kb(n):
+    n = int(n)
+    return f"{n // 1024} KB" if n % 1024 == 0 else f"{n} B"
+
+out = []
+out.append("# gs-test-data ROM manifest")
+out.append("")
+out.append("> **Generated by `scripts/rom-manifest.sh` — do not hand-edit.**")
+out.append("> Canonical names, one flat `roms/` directory, and this table follow")
+out.append("> `proposal-test-rom-naming.md`. The `.rom`/`.vrom` extension distinguishes")
+out.append("> CPU ROMs from NuBus declaration ROMs (vROMs).")
+out.append("")
+out.append("## CPU ROMs (`*.rom`)")
+out.append("")
+out.append("| Canonical file | Size | Checksum | Family / hardware | Notes |")
+out.append("|---|---|---|---|---|")
+cpu = [(b, j) for b, j in rows if b.endswith(".rom")]
+vro = [(b, j) for b, j in rows if b.endswith(".vrom")]
+for base, js in sorted(cpu):
+    canon = field(js, "canonical_name") or base
+    size  = human_kb(field(js, "size") or "0")
+    chk   = field(js, "checksum") or ""
+    name  = rom_name(js)
+    comp  = compatible(js)
+    note  = NOTES.get(base, "")
+    hw = f"{name} — models: {comp}" if comp else name
+    out.append(f"| `{canon}` | {size} | `{chk}` | {hw} | {note} |")
+out.append("")
+out.append("## Declaration ROMs / vROMs (`*.vrom`)")
+out.append("")
+out.append("| Canonical file | Size | CRC | Card id | Notes |")
+out.append("|---|---|---|---|---|")
+for base, js in sorted(vro):
+    canon = field(js, "canonical_name") or base
+    size  = human_kb(field(js, "size") or "0")
+    crc   = field(js, "crc") or ""
+    card  = field(js, "card_id") or ""
+    note  = NOTES.get(base, "")
+    out.append(f"| `{canon}` | {size} | `{crc}` | `{card}` | {note} |")
+out.append("")
+out.append("## Legacy name aliases (for grep-ability)")
+out.append("")
+out.append("Old handover docs and agent notes reference the pre-rename names; this")
+out.append("table maps them to the canonical files. The renames preserved git history.")
+out.append("")
+out.append("| Legacy name(s) | Canonical file |")
+out.append("|---|---|")
+for old, new in ALIASES:
+    out.append(f"| `{old}` | `{new}` |")
+out.append("")
+
+text = "\n".join(out) + "\n"
+if dest == "-":
+    sys.stdout.write(text)
+else:
+    with open(dest, "w", encoding="utf-8") as f:
+        f.write(text)
+    print(f"rom-manifest: wrote {len(cpu)} CPU ROM(s) + {len(vro)} vROM(s) to {dest}", file=sys.stderr)
+PY

--- a/src/core/memory/rom.c
+++ b/src/core/memory/rom.c
@@ -49,13 +49,16 @@ static const char *const IISI_COMPATIBLE[] = {"iisi", NULL};
 
 // Master ROM signature table.
 static const rom_info_t ROM_TABLE[] = {
-    {"Macintosh Plus (Rev 1, Lonely Hearts)",   PLUS_COMPATIBLE,      0x4D1EEEE1, 128 * 1024},
-    {"Macintosh Plus (Rev 2, Lonely Heifers)",  PLUS_COMPATIBLE,      0x4D1EEAE1, 128 * 1024},
-    {"Macintosh Plus (Rev 3, Loud Harmonicas)", PLUS_COMPATIBLE,      0x4D1F8172, 128 * 1024},
-    {"Universal IIx/IIcx/SE/30 ROM",            UNIVERSAL_COMPATIBLE, 0x97221136, 256 * 1024},
-    {"Macintosh IIfx ROM",                      IIFX_COMPATIBLE,      0x4147DD77, 512 * 1024},
-    {"Macintosh IIci ROM",                      IICI_COMPATIBLE,      0x368CADFE, 512 * 1024},
-    {"Macintosh IIsi ROM",                      IISI_COMPATIBLE,      0x36B7FB6C, 512 * 1024},
+    // Only Rev 3 ("Loud Harmonicas") ships in tests/data; Rev 1/2 are catalogued
+    // for identify but have no canonical file (NULL — the conformance test never
+    // sees them on disk).
+    {"Macintosh Plus (Rev 1, Lonely Hearts)",   PLUS_COMPATIBLE,      0x4D1EEEE1, 128 * 1024, NULL                        },
+    {"Macintosh Plus (Rev 2, Lonely Heifers)",  PLUS_COMPATIBLE,      0x4D1EEAE1, 128 * 1024, NULL                        },
+    {"Macintosh Plus (Rev 3, Loud Harmonicas)", PLUS_COMPATIBLE,      0x4D1F8172, 128 * 1024, "plus-v3-4d1f8172.rom"      },
+    {"Universal IIx/IIcx/SE/30 ROM",            UNIVERSAL_COMPATIBLE, 0x97221136, 256 * 1024, "iix-iicx-se30-97221136.rom"},
+    {"Macintosh IIfx ROM",                      IIFX_COMPATIBLE,      0x4147DD77, 512 * 1024, "iifx-4147dd77.rom"         },
+    {"Macintosh IIci ROM",                      IICI_COMPATIBLE,      0x368CADFE, 512 * 1024, "iici-368cadfe.rom"         },
+    {"Macintosh IIsi ROM",                      IISI_COMPATIBLE,      0x36B7FB6C, 512 * 1024, "iisi-36b7fb6c.rom"         },
 };
 
 #define ROM_TABLE_COUNT (sizeof(ROM_TABLE) / sizeof(ROM_TABLE[0]))
@@ -79,8 +82,8 @@ typedef struct lisa_rom_sig {
 } lisa_rom_sig_t;
 
 static const lisa_rom_sig_t LISA_ROM_TABLE[] = {
-    {{"Apple Lisa 2 Boot ROM (rev H)", LISA_COMPATIBLE, 0x098917B2, LISA_ROM_SIZE},   0x0248},
-    {{"Macintosh XL Boot ROM (\"3A\")", MACXL_COMPATIBLE, 0x094C82F0, LISA_ROM_SIZE}, 0x0341},
+    {{"Apple Lisa 2 Boot ROM (rev H)", LISA_COMPATIBLE, 0x098917B2, LISA_ROM_SIZE, "lisa2-revh-098917b2.rom"}, 0x0248},
+    {{"Macintosh XL Boot ROM (\"3A\")", MACXL_COMPATIBLE, 0x094C82F0, LISA_ROM_SIZE, "macxl-3a-094c82f0.rom"}, 0x0341},
 };
 
 #define LISA_ROM_TABLE_COUNT (sizeof(LISA_ROM_TABLE) / sizeof(LISA_ROM_TABLE[0]))
@@ -367,7 +370,7 @@ static int install_rom_into_machine(const uint8_t *rom_data, size_t file_size, c
     }
 
     // Track the pending path so SE/30 init (which chains through machine
-    // reset) can find a sibling SE30.vrom file.
+    // reset) can find a sibling builtin-se30-video-4f71ff1a.vrom file.
     rom_pending_set(path);
 
     memory_install_rom(mem, rom_data, file_size, path);
@@ -532,10 +535,12 @@ static value_t rom_method_reload(struct object *self, const member_t *m, int arg
 }
 
 // rom.identify(path) → JSON-encoded info map describing the ROM file:
-//   { recognised, compatible, checksum, name, size }
-// recognised==false implies compatible==[] and name=="" but the checksum and
-// size are still populated from the file.  Returns V_ERROR if the path can
-// not be opened (caller treats that as "no info, skip this entry").
+//   { recognised, compatible, checksum, name, canonical_name, size }
+// recognised==false implies compatible==[], name=="", canonical_name=="" but
+// the checksum and size are still populated from the file.  canonical_name is
+// the enforced on-disk filename (proposal-test-rom-naming.md), empty for ROMs
+// that are recognised but don't ship in tests/data.  Returns V_ERROR if the
+// path can not be opened (caller treats that as "no info, skip this entry").
 static value_t rom_method_identify(struct object *self, const member_t *m, int argc, const value_t *argv) {
     (void)self;
     (void)m;
@@ -564,6 +569,12 @@ static value_t rom_method_identify(struct object *self, const member_t *m, int a
     json_str(b, hex);
     json_key(b, "name");
     json_str(b, fi.info ? fi.info->family_name : "");
+    // Canonical on-disk filename (proposal-test-rom-naming.md). Present and
+    // non-empty only for recognised ROMs that actually ship in tests/data;
+    // empty otherwise. The rom-naming conformance test asserts every file's
+    // basename equals this. Mirrors vrom.identify's canonical_name.
+    json_key(b, "canonical_name");
+    json_str(b, (fi.info && fi.info->canonical_name) ? fi.info->canonical_name : "");
     json_key(b, "size");
     json_int(b, (int64_t)fi.size);
     json_close_obj(b);

--- a/src/core/memory/rom.h
+++ b/src/core/memory/rom.h
@@ -28,6 +28,11 @@ typedef struct rom_info {
     const char *const *compatible; // NULL-terminated list of compatible model_ids
     uint32_t checksum; // Stored checksum (first 4 bytes, big-endian)
     uint32_t rom_size; // Expected file size in bytes
+    // Canonical on-disk filename in tests/data/roms, derived from this row per
+    // proposal-test-rom-naming.md (<targets>[-<rev>]-<checksum8>.rom). The
+    // load-bearing single source of truth for what the file MUST be named;
+    // rom.identify reports it and the rom-naming conformance test enforces it.
+    const char *canonical_name;
 } rom_info_t;
 
 // Look up a ROM by its stored checksum.
@@ -96,7 +101,7 @@ int rom_load_into_machine(const char *path);
 int rom_load_lisa_into_machine(const char *path_a, const char *path_b);
 
 // Path of the ROM passed to the most recent rom_load_into_machine().
-// Used by SE/30 init to auto-discover a sibling SE30.vrom file.
+// Used by SE/30 init to auto-discover a sibling builtin-se30-video-4f71ff1a.vrom file.
 // Returns NULL if no ROM has been loaded.
 const char *rom_pending_path(void);
 

--- a/src/core/memory/vrom.c
+++ b/src/core/memory/vrom.c
@@ -123,8 +123,9 @@ static uint32_t vrom_be32(const uint8_t *p) {
 }
 
 // Catalog of known VROM blobs.  Maps the declaration ROM's Format-Block CRC
-// to the canonical on-disk filename the C-side card factories expect (e.g.
-// jmfb.c hardcodes "Apple-341-0868.vrom") and the nubus card-kind id the
+// to the canonical on-disk filename the C-side card factories search for
+// (declrom_load_vrom_card / builtin_se30_video both take the filename from
+// vrom_catalog_name — no card hardcodes it) and the nubus card-kind id the
 // blob provides.  The id is the machine-readable link a UI uses to pick the
 // card (machine.nubus.video_card); the human label is owned by the card kind
 // (nubus_card_find(id)->display_name) so it never drifts.  Adding a new VROM
@@ -135,22 +136,27 @@ struct vrom_known {
     const char *canonical_name;
     const char *card_id;
 };
+// Canonical filenames follow proposal-test-rom-naming.md:
+// <card-id>[-<rev>]-<crc8>.vrom, card-id with `_`→`-`. Apple part numbers
+// (341-0868, 341-0266, …) live in the manifest / these comments, not the
+// filename — they identify the chip, not the card. The rom-naming conformance
+// test asserts every tests/data/roms/*.vrom basename equals its row here.
 static const struct vrom_known VROM_CATALOG[] = {
-    // Macintosh Display Card 8•24 (ROM rev 341-0868). Drives the JMFB
+    // Macintosh Display Card 8•24 (ROM rev 341-0868, "Rev B"). Drives the JMFB
     // NuBus card (id "mdc_8_24") on IIcx / IIx / IIfx; loaded by jmfb.c.
-    {0xD1629664u, 0x08000, "Apple-341-0868.vrom",    "mdc_8_24"          },
+    {0xD1629664u, 0x08000, "mdc-8-24-revb-d1629664.vrom",      "mdc_8_24"          },
     // SE/30 onboard video declaration ROM (byteLanes $0F, 4-lane); loaded
     // by builtin_se30_video.c (id "builtin_se30_video").
-    {0x4F71FF1Au, 0x08000, "SE30.vrom",              "builtin_se30_video"},
+    {0x4F71FF1Au, 0x08000, "builtin-se30-video-4f71ff1a.vrom", "builtin_se30_video"},
     // Apple Macintosh Display Card 24AC (id "display_card_24ac").
-    {0xD8DAAB87u, 0x08000, "display-card-24ac.vrom", "display_card_24ac" },
+    {0xD8DAAB87u, 0x08000, "display-card-24ac-d8daab87.vrom",  "display_card_24ac" },
     // Apple Macintosh Display Card 8•24 GC ("Dolphin", id "824gc"): the
     // accelerated card.  Its declaration ROMs are byteLanes $E1 (byte lane 0);
     // v1.1 is a 64 KB chip, v1.0 / the alpha are 32 KB.  All three carry the
     // same $5A932BC7 TestPattern, so they identify by Format-Block CRC.
-    {0xD722B053u, 0x10000, "Apple-341-0266.vrom",    "824gc"             }, // v1.1 (default)
-    {0x9E9857E8u, 0x08000, "341-0812-02_1.0.vrom",   "824gc"             }, // v1.0 (shipping)
-    {0x4740028Du, 0x08000, "Dolphin_1.0A16.vrom",    "824gc"             }, // 1.00a16 alpha
+    {0xD722B053u, 0x10000, "824gc-v1.1-revb-d722b053.vrom",    "824gc"             }, // part 341-0266, v1.1 (default; 16bpp)
+    {0x9E9857E8u, 0x08000, "824gc-v1.0-reva-9e9857e8.vrom",    "824gc"             }, // part 341-0812-02, v1.0 (shipping)
+    {0x4740028Du, 0x08000, "824gc-v1.0a16-4740028d.vrom",      "824gc"             }, // "Dolphin" 1.00a16 alpha
 };
 
 // Content-identification core shared by vrom.identify and the card factories'
@@ -237,7 +243,7 @@ const char *vrom_catalog_name(const char *card_id, int idx, size_t *out_chip_siz
 // the declaration ROM's Format-Block CRC:
 //   {
 //     "recognised":     bool,
-//     "canonical_name": "display-card-24ac.vrom",     // present when recognised
+//     "canonical_name": "display-card-24ac-d8daab87.vrom",     // present when recognised
 //     "card_id":        "display_card_24ac",          // nubus card-kind id
 //     "compatible":     ["display_card_24ac"],         // card ids this blob can drive
 //     "size":           32768,

--- a/src/core/peripherals/nubus/cards/display_card_24ac.c
+++ b/src/core/peripherals/nubus/cards/display_card_24ac.c
@@ -9,7 +9,7 @@
 // acceleration engine the dossier's hardware spec (doc 3) describes.
 //
 // Two halves (proposal §0):
-//   * Phase 1 (display): loads the genuine display-card-24ac.vrom and
+//   * Phase 1 (display): loads the genuine display-card-24ac-d8daab87.vrom and
 //     presents a linear framebuffer + CLUT + VBL slot IRQ.  The card's own
 //     System 7 video driver (in the vrom) programs the standard video
 //     registers; we model the ones it touches (CLUT, depth/mode latch,
@@ -796,7 +796,7 @@ static int card_init(nubus_card_t *card, config_t *cfg, checkpoint_t *cp) {
         // requires_vrom gates the dialog on a real file; reaching here means
         // CI ran without one.  Log loudly and continue with a zero declrom —
         // PrimaryInit finds no Format Header and the OS skips the slot.
-        LOG(0, "display-card-24ac.vrom not found; declaration ROM is zero-filled");
+        LOG(0, "display-card-24ac-d8daab87.vrom not found; declaration ROM is zero-filled");
     }
 
     // Publish the declaration ROM on the generic card handle so the

--- a/src/core/peripherals/nubus/cards/display_card_24ac.h
+++ b/src/core/peripherals/nubus/cards/display_card_24ac.h
@@ -117,7 +117,7 @@
 #define DISPLAY_CARD_24AC_COMMIT_CMD 0x00000004u
 
 // === Declaration ROM ========================================================
-// display-card-24ac.vrom: 32 KB chip, byteLanes = $78 (lane 3 only) → 128 KB
+// display-card-24ac-d8daab87.vrom: 32 KB chip, byteLanes = $78 (lane 3 only) → 128 KB
 // of bus space at slot_base + 0xFE0000 (identical layout to the 8•24).
 #define DISPLAY_CARD_24AC_DECLROM_CHIP_SIZE  0x008000u // 32 KB raw chip data (file size)
 #define DISPLAY_CARD_24AC_DECLROM_BUS_SIZE   0x020000u // 128 KB bus-space footprint (chip × 4)

--- a/src/core/peripherals/nubus/cards/jmfb.c
+++ b/src/core/peripherals/nubus/cards/jmfb.c
@@ -6,7 +6,7 @@
 // proposal-machine-iicx-iix.md §3.2.5 + jmfb.h for the contract.
 //
 // Implementation status (proposal step 6, minimum-viable):
-//   * Card factory loads `Apple-341-0868.vrom` and registers VRAM,
+//   * Card factory loads `mdc-8-24-revb-d1629664.vrom` and registers VRAM,
 //     declrom, and the register window on the bus.
 //   * I/O dispatcher in this file handles all four register blocks at
 //     a single switch.  Modelled handlers cover the registers the
@@ -17,7 +17,7 @@
 //     up the user's `monitor=` choice.
 //   * CLUT writes feed display.clut and set clut_dirty; depth changes
 //     via CLUTPBCR feed display.format and set shape_dirty.
-//   * Mode-table parsing inside `Apple-341-0868.vrom` is left to the
+//   * Mode-table parsing inside `mdc-8-24-revb-d1629664.vrom` is left to the
 //     System 7 driver — we present the bytes; it walks them.
 
 #include "jmfb.h"
@@ -682,7 +682,7 @@ static int card_init(nubus_card_t *card, config_t *cfg, checkpoint_t *cp) {
         // one.  Log loudly and continue with a zero-filled declrom —
         // PrimaryInit won't find a Format Header and the OS will skip
         // the slot, but the rest of the machine still boots.
-        LOG(0, "Apple-341-0868.vrom not found; declaration ROM is zero-filled");
+        LOG(0, "mdc-8-24-revb-d1629664.vrom not found; declaration ROM is zero-filled");
     }
     // Publish the declaration ROM on the card struct (drives the
     // slot[N].card.declrom object-model node, same as the 24AC / 8•24 GC);

--- a/src/core/peripherals/nubus/cards/jmfb.h
+++ b/src/core/peripherals/nubus/cards/jmfb.h
@@ -35,7 +35,7 @@
 #define CLUT_BLOCK_OFFSET      0x200200u
 #define ENDEAVOR_BLOCK_OFFSET  0x200300u
 #define JMFB_REGISTER_SIZE     0x000400u // covers all four blocks
-// Apple-341-0868.vrom is a 32 KB chip with byteLanes = $78 (lane 3 only,
+// mdc-8-24-revb-d1629664.vrom is a 32 KB chip with byteLanes = $78 (lane 3 only,
 // per "Designing Cards and Drivers for the Macintosh Family" 3rd ed.,
 // Table 8-2).  In bus-space layout the chip's bytes appear sparsely:
 // each chip byte at lane 3 of a longword, with lanes 0-2 inactive.  So

--- a/src/core/peripherals/nubus/declrom.h
+++ b/src/core/peripherals/nubus/declrom.h
@@ -63,7 +63,7 @@ void declrom_install(nubus_card_t *card, const declrom_builder_t *b);
 // Load a real declaration-ROM binary from disk into a freshly-allocated
 // buffer of size `expected_size`.  Returns the buffer (caller owns) on
 // success, NULL on miss.  Used by cards that prefer a real ROM file
-// (e.g. the JMFB card with `Apple-341-0868.vrom`) and fall back to the
+// (e.g. the JMFB card with `mdc-8-24-revb-d1629664.vrom`) and fall back to the
 // builder on miss.  v1 stub — body lands in step 6.
 uint8_t *declrom_load(const char *path, size_t expected_size);
 

--- a/src/machines/glue/builtin_se30_video.c
+++ b/src/machines/glue/builtin_se30_video.c
@@ -8,7 +8,7 @@
 //
 // What the card owns:
 //   * 64 KB VRAM at $FEE00000
-//   * 32 KB declaration ROM at $FEFF8000 (real SE30.vrom if available,
+//   * 32 KB declaration ROM at $FEFF8000 (real builtin-se30-video-4f71ff1a.vrom if available,
 //     synthesised fallback otherwise; the byte-banged synth is the same
 //     220-line sequence se30.c used to carry inline)
 //   * the display_t exposed via system_display() — 512×342×1bpp, with
@@ -50,7 +50,7 @@ typedef struct {
 // === VROM loading / synth (moved verbatim from se30.c) ======================
 
 // Build a minimal fallback NuBus declaration ROM (8 KB at the top of the
-// 32 KB buffer) when the real SE30.vrom is not available.  The byte
+// 32 KB buffer) when the real builtin-se30-video-4f71ff1a.vrom is not available.  The byte
 // sequence below is taken verbatim from the legacy se30_build_vrom_fallback
 // in src/machines/se30.c — see that history for rationale.
 static void synthesise_vrom_fallback(uint8_t *rom) {
@@ -227,10 +227,21 @@ static bool load_real_vrom(config_t *cfg, uint8_t *vrom_buf, char **out_path) {
         }
         LOG(0, "VROM file %s not found or wrong size", explicit_path);
     }
-    static const char *search_paths[] = {"/opfs/images/vrom/SE30.vrom", "tests/data/roms/SE30.vrom", "SE30.vrom", NULL};
-    for (const char **p = search_paths; *p; p++) {
-        if (try_load_vrom(*p, vrom_buf)) {
-            *out_path = strdup(*p);
+    // Canonical filename is owned by the vROM catalog (single source of truth —
+    // proposal-test-rom-naming.md), never hardcoded here. Search the standard
+    // prefixes, then the directory holding the loaded ROM.
+    const char *fname = vrom_catalog_name("builtin_se30_video", 0, NULL);
+    if (!fname)
+        fname = "builtin-se30-video-4f71ff1a.vrom"; // defensive; the catalog row must exist
+    static const char *const prefixes[] = {"/opfs/images/vrom/", "tests/data/roms/", "", NULL};
+    char vrom_path[512];
+    for (const char *const *pre = prefixes; *pre; pre++) {
+        if (strlen(*pre) + strlen(fname) + 1 > sizeof(vrom_path))
+            continue;
+        strcpy(vrom_path, *pre);
+        strcat(vrom_path, fname);
+        if (try_load_vrom(vrom_path, vrom_buf)) {
+            *out_path = strdup(vrom_path);
             return true;
         }
     }
@@ -241,10 +252,9 @@ static bool load_real_vrom(config_t *cfg, uint8_t *vrom_buf, char **out_path) {
         const char *slash = strrchr(rom_path, '/');
         if (slash) {
             size_t dir_len = (size_t)(slash - rom_path + 1);
-            char vrom_path[512];
-            if (dir_len + sizeof("SE30.vrom") <= sizeof(vrom_path)) {
+            if (dir_len + strlen(fname) + 1 <= sizeof(vrom_path)) {
                 memcpy(vrom_path, rom_path, dir_len);
-                memcpy(vrom_path + dir_len, "SE30.vrom", sizeof("SE30.vrom"));
+                strcpy(vrom_path + dir_len, fname);
                 if (try_load_vrom(vrom_path, vrom_buf)) {
                     *out_path = strdup(vrom_path);
                     return true;
@@ -252,7 +262,7 @@ static bool load_real_vrom(config_t *cfg, uint8_t *vrom_buf, char **out_path) {
             }
         }
     }
-    LOG(0, "FATAL: Real VROM (SE30.vrom) not found.");
+    LOG(0, "FATAL: Real VROM (%s) not found.", fname);
     return false;
 }
 
@@ -275,7 +285,7 @@ static int card_init(nubus_card_t *card, config_t *cfg, checkpoint_t *cp) {
         if (!cp) {
             // Real VROM was the long-standing requirement on cold boot;
             // fall back to the synthesised image so the SE/30 keeps booting
-            // even when SE30.vrom is absent in CI environments.
+            // even when builtin-se30-video-4f71ff1a.vrom is absent in CI environments.
             synthesise_vrom_fallback(p->vrom);
         }
         // Restoring from a checkpoint?  The VROM contents will be overwritten
@@ -358,7 +368,7 @@ const nubus_card_kind_t builtin_se30_video_kind = {
     .display_name = "Macintosh SE/30 Built-in Video",
     .attach = CARD_ATTACH_BUILTIN, // motherboard circuitry — never socketed
     // The SE/30 carries no video declaration ROM in main ROM; it needs the
-    // separate SE30.vrom file (the dialog's VROM picker drives this).
+    // separate builtin-se30-video-4f71ff1a.vrom file (the dialog's VROM picker drives this).
     .requires_vrom = true,
     .monitors = builtin_se30_monitors,
     .factory = factory,

--- a/src/machines/glue/builtin_se30_video.h
+++ b/src/machines/glue/builtin_se30_video.h
@@ -5,7 +5,7 @@
 // SE/30 built-in video as a NuBus card living in slot $E.  See
 // proposal-machine-iicx-iix.md §3.2.5 ("Built-in SE/30 video").  The card
 // owns 64 KB VRAM at $FEE00000, a 32 KB declaration ROM at $FEFF8000
-// (real `SE30.vrom` if available, synthesised fallback otherwise),
+// (real `builtin-se30-video-4f71ff1a.vrom` if available, synthesised fallback otherwise),
 // drives the slot-$E VBL pseudo-IRQ, and exposes a 512×342×1bpp
 // `display_t` for system_display().
 //

--- a/src/machines/glue/iicx.c
+++ b/src/machines/glue/iicx.c
@@ -332,7 +332,7 @@ const hw_profile_t machine_iicx = {
     .cdrom_id = 3,
     // The IIcx has no built-in video — its primary display comes from
     // a NuBus video card seated in slot $9 (Apple Display Card 8•24 by
-    // default).  That card needs Apple-341-0868.vrom to declare itself
+    // default).  That card needs mdc-8-24-revb-d1629664.vrom to declare itself
     // to the Slot Manager (without it, slot scan finds an empty slot
     // and the boot ROM can't bring up a framebuffer).  We mark
     // needs_vrom = true so the config dialog asks the user for a VROM

--- a/src/machines/glue/iix.c
+++ b/src/machines/glue/iix.c
@@ -175,7 +175,7 @@ const hw_profile_t machine_iix = {
     .has_cdrom = true,
     .cdrom_id = 3,
     // Same reasoning as IIcx: no built-in video, so the slot card's
-    // VROM (Apple-341-0868.vrom for the default JMFB card) must be
+    // VROM (mdc-8-24-revb-d1629664.vrom for the default JMFB card) must be
     // present.  See iicx.c for the full comment.
 
     .nubus_slots = iix_slots,

--- a/src/machines/glue/se30.c
+++ b/src/machines/glue/se30.c
@@ -406,9 +406,9 @@ static void se30_post_nubus(config_t *cfg) {
     se30->vram = builtin_se30_video_vram(se30->video_card);
     se30->vrom = builtin_se30_video_vrom(se30->video_card);
     if (!se30->vram || !se30->vrom) {
-        fprintf(stderr, "Error: SE/30 Video ROM (SE30.vrom) not found.\n"
+        fprintf(stderr, "Error: SE/30 Video ROM (builtin-se30-video-4f71ff1a.vrom) not found.\n"
                         "The SE/30 emulator requires a real VROM file for proper operation.\n"
-                        "Place SE30.vrom next to the ROM file or in tests/data/roms/.\n");
+                        "Place builtin-se30-video-4f71ff1a.vrom next to the ROM file or in tests/data/roms/.\n");
         exit(1);
     }
     memory_map_host_region(cfg->mem_map, "se30_vram", se30->vram, SE30_VRAM_BASE, SE30_VRAM_SIZE, /*writable*/ true);
@@ -522,7 +522,7 @@ const hw_profile_t machine_se30 = {
     .cdrom_id = 3,
 
     // Built-in slot-$E video card.  Exposed in the profile so the config
-    // dialog reads the VROM requirement from the card (it needs SE30.vrom);
+    // dialog reads the VROM requirement from the card (it needs builtin-se30-video-4f71ff1a.vrom);
     // this is the same table the substrate passes to nubus_init().
     .nubus_slots = se30_slots,
 

--- a/src/platform/headless/headless_main.c
+++ b/src/platform/headless/headless_main.c
@@ -161,8 +161,8 @@ static void print_usage(const char *program) {
     printf("  %s rom=plus.rom\n", program);
     printf("  %s rom=plus.rom hd=disk.img\n", program);
     printf("  %s rom=plus.rom fd=system.dsk script=boot.sh\n", program);
-    printf("  %s --daemon rom=SE30.rom\n", program);
-    printf("  %s --daemon --port=7000 rom=SE30.rom hd=disk.img\n", program);
+    printf("  %s --daemon rom=iix-iicx-se30-97221136.rom\n", program);
+    printf("  %s --daemon --port=7000 rom=iix-iicx-se30-97221136.rom hd=disk.img\n", program);
 }
 
 // Global script exit code (set by commands like screenshot match)
@@ -916,7 +916,7 @@ int main(int argc, char *argv[]) {
         system_set_pending_ram_kb(ram_kb);
 
     // Set the pending ROM path BEFORE system_create so SE/30 init can
-    // auto-discover a sibling SE30.vrom file during machine bring-up.
+    // auto-discover a sibling builtin-se30-video-4f71ff1a.vrom file during machine bring-up.
     rom_pending_set(rom_file);
 
     // Stage the user's video-card pick BEFORE system_create so nubus_init

--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -49,8 +49,8 @@ When properly configured, this directory should contain:
 tests/data/
 ├── README.md              ← You are here (this file is in the public repo)
 ├── roms/
-│   ├── Plus_v3.rom        # Macintosh Plus ROM (128 KB)
-│   └── IIcx.rom           # Macintosh IIcx ROM (optional)
+│   ├── plus-v3-4d1f8172.rom        # Macintosh Plus ROM (128 KB)
+│   └── iix-iicx-se30-97221136.rom           # Macintosh IIcx ROM (optional)
 ├── systems/
 │   ├── System_6_0_8.dsk   # System 6.0.8 boot disk (primary test target)
 │   └── ...                # Other system versions

--- a/tests/e2e/web2-specs/checkpoint-resume.spec.ts
+++ b/tests/e2e/web2-specs/checkpoint-resume.spec.ts
@@ -31,9 +31,9 @@ import { test, expect, type Page } from '@playwright/test';
 import * as path from 'node:path';
 import { gotoWeb2, stageOpfsFile } from '../helpers/web2-fs';
 
-const PLUS_ROM = path.resolve(__dirname, '../../data/roms/Plus_v3.rom');
-const SE30_ROM = path.resolve(__dirname, '../../data/roms/SE30.rom');
-const SE30_VROM = path.resolve(__dirname, '../../data/roms/SE30.vrom');
+const PLUS_ROM = path.resolve(__dirname, '../../data/roms/plus-v3-4d1f8172.rom');
+const SE30_ROM = path.resolve(__dirname, '../../data/roms/iix-iicx-se30-97221136.rom');
+const SE30_VROM = path.resolve(__dirname, '../../data/roms/builtin-se30-video-4f71ff1a.vrom');
 
 // Upload a ROM via the Welcome "Upload ROM..." button (the shipped path; the
 // persist bumps the image revision so the config slide re-scans).
@@ -164,7 +164,7 @@ test.describe('checkpoint save → reload → resume', () => {
 
     // The SE/30's onboard video card requires a vROM; stage it before the ROM
     // upload so the config slide's re-scan identifies both in one pass.
-    await stageOpfsFile(page, '/opfs/images/vrom/SE30.vrom', SE30_VROM);
+    await stageOpfsFile(page, '/opfs/images/vrom/builtin-se30-video-4f71ff1a.vrom', SE30_VROM);
     await uploadRom(page, SE30_ROM);
     await startMachine(page, 'se30');
 

--- a/tests/e2e/web2-specs/display-card-config.spec.ts
+++ b/tests/e2e/web2-specs/display-card-config.spec.ts
@@ -27,9 +27,9 @@ import { test, expect } from '@playwright/test';
 import * as path from 'node:path';
 import { gotoWeb2, stageOpfsFile } from '../helpers/web2-fs';
 
-const IICX_ROM = path.resolve(__dirname, '../../data/roms/IIcx.rom');
-const VROM_8_24 = path.resolve(__dirname, '../../data/roms/Apple-341-0868.vrom');
-const VROM_24AC = path.resolve(__dirname, '../../data/roms/display-card-24ac.vrom');
+const IICX_ROM = path.resolve(__dirname, '../../data/roms/iix-iicx-se30-97221136.rom');
+const VROM_8_24 = path.resolve(__dirname, '../../data/roms/mdc-8-24-revb-d1629664.vrom');
+const VROM_24AC = path.resolve(__dirname, '../../data/roms/display-card-24ac-d8daab87.vrom');
 
 test('New Machine dialog: pick the 24AC card by name and boot it', async ({ page }) => {
   test.setTimeout(120_000);
@@ -38,8 +38,8 @@ test('New Machine dialog: pick the 24AC card by name and boot it', async ({ page
   // Stage both IIcx video-card vROMs under their canonical names so the card
   // picker has a real choice (8•24 vs 24AC). Done before the ROM upload so the
   // upload's image-revision bump re-scans and identifies them in one pass.
-  await stageOpfsFile(page, '/opfs/images/vrom/Apple-341-0868.vrom', VROM_8_24);
-  await stageOpfsFile(page, '/opfs/images/vrom/display-card-24ac.vrom', VROM_24AC);
+  await stageOpfsFile(page, '/opfs/images/vrom/mdc-8-24-revb-d1629664.vrom', VROM_8_24);
+  await stageOpfsFile(page, '/opfs/images/vrom/display-card-24ac-d8daab87.vrom', VROM_24AC);
 
   // Upload the IIcx ROM via the Welcome "Upload ROM..." button. The persist
   // bumps the image revision, which re-scans the config slide (ROM + the two

--- a/tests/e2e/web2-specs/display-drop.spec.ts
+++ b/tests/e2e/web2-specs/display-drop.spec.ts
@@ -20,7 +20,7 @@ import * as path from 'node:path';
 import { gotoWeb2 } from '../helpers/web2-fs';
 
 const DATA = path.resolve(__dirname, '../../data');
-const PLUS_ROM = path.join(DATA, 'roms', 'Plus_v3.rom');
+const PLUS_ROM = path.join(DATA, 'roms', 'plus-v3-4d1f8172.rom');
 const SYSTEM_FD = path.join(DATA, 'systems', 'System_6_0_8.dsk');
 
 // Dispatch dragenter/dragover/drop onto the Display area with a real File in
@@ -90,7 +90,7 @@ test('drop workflow: ROM auto-boots, floppy auto-mounts, unknown file warns', as
   await gotoWeb2(page);
 
   // 1. ROM onto the Welcome display → default machine boots straight away.
-  await dropOnDisplay(page, 'Plus_v3.rom', PLUS_ROM);
+  await dropOnDisplay(page, 'plus-v3-4d1f8172.rom', PLUS_ROM);
   await expect(toast(page, 'Booted plus from uploaded ROM')).toBeVisible({ timeout: 60_000 });
   await expect(page.locator('.welcome-layer')).toHaveCount(0);
   await expect(page.locator('.gs-statusbar .sb-state .label')).toHaveText('Running');
@@ -116,7 +116,7 @@ test('checkpoint drop restores the saved machine state', async ({ page }) => {
 
   // Boot a machine via ROM drop, then pause it so the snapshot captures a
   // deterministic instruction count (a paused snapshot restores paused).
-  await dropOnDisplay(page, 'Plus_v3.rom', PLUS_ROM);
+  await dropOnDisplay(page, 'plus-v3-4d1f8172.rom', PLUS_ROM);
   await expect(toast(page, 'Booted plus from uploaded ROM')).toBeVisible({ timeout: 60_000 });
 
   await page.locator('button.ptab[data-tab="terminal"]').click();

--- a/tests/e2e/web2-specs/iicx-video-modes.spec.ts
+++ b/tests/e2e/web2-specs/iicx-video-modes.spec.ts
@@ -33,8 +33,8 @@ import * as path from 'node:path';
 import { gotoWeb2, stageOpfsFile } from '../helpers/web2-fs';
 
 const DATA = path.resolve(__dirname, '../../data');
-const IICX_ROM = path.join(DATA, 'roms', 'IIcx.rom');
-const JMFB_VROM = path.join(DATA, 'roms', 'Apple-341-0868.vrom');
+const IICX_ROM = path.join(DATA, 'roms', 'iix-iicx-se30-97221136.rom');
+const JMFB_VROM = path.join(DATA, 'roms', 'mdc-8-24-revb-d1629664.vrom');
 const FD_IMAGE = path.join(DATA, 'systems', 'System_7_0_1.image');
 
 interface VideoMode {
@@ -152,7 +152,7 @@ test('IIcx video modes: post-shader canvas matches per-mode baselines', async ({
   for (const mode of MODES) {
     if (first) {
       await gotoWeb2(page);
-      await stageOpfsFile(page, '/opfs/images/vrom/Apple-341-0868.vrom', JMFB_VROM);
+      await stageOpfsFile(page, '/opfs/images/vrom/mdc-8-24-revb-d1629664.vrom', JMFB_VROM);
       await stageOpfsFile(page, '/opfs/images/fd/System_7_0_1.image', FD_IMAGE);
       const [chooser] = await Promise.all([
         page.waitForEvent('filechooser'),

--- a/tests/e2e/web2-specs/iifx-aux3-realtime.spec.ts
+++ b/tests/e2e/web2-specs/iifx-aux3-realtime.spec.ts
@@ -31,8 +31,8 @@ import * as path from 'node:path';
 import { gotoWeb2, stageOpfsFile, stageOpfsFileStreaming } from '../helpers/web2-fs';
 
 const DATA = path.resolve(__dirname, '../../data');
-const IIFX_ROM = path.join(DATA, 'roms', '4147DD77-IIfx.rom');
-const JMFB_VROM = path.join(DATA, 'roms', '341-0868.vrom');
+const IIFX_ROM = path.join(DATA, 'roms', 'iifx-4147dd77.rom');
+const JMFB_VROM = path.join(DATA, 'roms', 'mdc-8-24-revb-d1629664.vrom');
 const AUX_HD = path.join(DATA, 'aux', 'aux_3.0.1', 'hd160-with-aux-301.img');
 // The 8bpp A/UX login framebuffer — same bytes as the integration
 // reference (tests/integration/iifx-aux3-boot-8bpp/aux-login-8bpp.png).
@@ -64,7 +64,7 @@ test('IIfx A/UX 3.0.1 free-runs under the real RAF scheduler to the login', asyn
   // worker-side copying, and the streaming upload path has its own e2e
   // (webkit-local/upload.spec.ts). Staged before the ROM upload so the config
   // slide's re-scan lists everything in one pass.
-  await stageOpfsFile(page, '/opfs/images/vrom/341-0868.vrom', JMFB_VROM);
+  await stageOpfsFile(page, '/opfs/images/vrom/mdc-8-24-revb-d1629664.vrom', JMFB_VROM);
   await stageOpfsFile(page, '/opfs/upload/login-ref.png', LOGIN_REF);
   await stageOpfsFileStreaming(page, '/opfs/images/hd/hd160-with-aux-301.img', AUX_HD);
 

--- a/tests/e2e/web2-specs/lisa-xenix-profile.spec.ts
+++ b/tests/e2e/web2-specs/lisa-xenix-profile.spec.ts
@@ -26,7 +26,7 @@ import { test, expect } from '@playwright/test';
 import * as path from 'node:path';
 import { gotoWeb2 } from '../helpers/web2-fs';
 
-const LISA_ROM = path.resolve(__dirname, '../../data/Lisa/roms/098917B2-LisaH.rom');
+const LISA_ROM = path.resolve(__dirname, '../../data/roms/lisa2-revh-098917b2.rom');
 const XENIX_HD = path.resolve(__dirname, '../../data/Lisa/Xenix-3.0/Xenix-3.0-ProFile.image');
 const XENIX_HD_NAME = 'Xenix-3.0-ProFile.image';
 

--- a/tests/e2e/web2-specs/perf-bench.spec.ts
+++ b/tests/e2e/web2-specs/perf-bench.spec.ts
@@ -30,7 +30,7 @@ import * as path from 'node:path';
 import { gotoWeb2 } from '../helpers/web2-fs';
 
 const DATA = path.resolve(__dirname, '../../data');
-const SE30_ROM = path.join(DATA, 'roms', 'SE30.rom');
+const SE30_ROM = path.join(DATA, 'roms', 'iix-iicx-se30-97221136.rom');
 
 const LABEL = process.env.PERF_LABEL ?? 'unlabeled';
 const WINDOWS = Number(process.env.PERF_WINDOWS ?? 3);

--- a/tests/e2e/web2-specs/scheduler-accelerated.spec.ts
+++ b/tests/e2e/web2-specs/scheduler-accelerated.spec.ts
@@ -27,7 +27,7 @@ import * as path from 'node:path';
 import { gotoWeb2 } from '../helpers/web2-fs';
 
 const DATA = path.resolve(__dirname, '../../data');
-const SE30_ROM = path.join(DATA, 'roms', 'SE30.rom');
+const SE30_ROM = path.join(DATA, 'roms', 'iix-iicx-se30-97221136.rom');
 
 // SE/30: 15.6672 MHz, authentic CPI 4.
 const SE30_HZ = 15_667_200;

--- a/tests/e2e/web2-specs/url-boot.spec.ts
+++ b/tests/e2e/web2-specs/url-boot.spec.ts
@@ -17,7 +17,7 @@ import { test, expect, type Page } from '@playwright/test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-const PLUS_ROM = path.resolve(__dirname, '../../data/roms/Plus_v3.rom');
+const PLUS_ROM = path.resolve(__dirname, '../../data/roms/plus-v3-4d1f8172.rom');
 
 // Serve the ROM bytes from disk for any request to the sentinel path the
 // URL params point at. Must be registered before goto so the in-page

--- a/tests/e2e/webkit-local/upload.spec.ts
+++ b/tests/e2e/webkit-local/upload.spec.ts
@@ -37,7 +37,7 @@ import * as path from 'node:path';
 
 // A real, in-catalog SE/30 onboard-video VROM (32 KB). Named with a space +
 // parentheses to match the reported "SE30 (1).vrom".
-const SE30_VROM = path.resolve(__dirname, '../../data/roms/SE30.vrom');
+const SE30_VROM = path.resolve(__dirname, '../../data/roms/builtin-se30-video-4f71ff1a.vrom');
 
 // Boot the app as a first-time visitor. Skips on engines without OPFS (Linux
 // WebKitGTK) — there the emulator can't boot at all, which is a different issue.

--- a/tests/integration/appletalk-afp/config.mk
+++ b/tests/integration/appletalk-afp/config.mk
@@ -12,7 +12,7 @@
 TEST_NAME := AppleTalk AFP Mount
 TEST_DESC := Chooser -> AppleShare -> discover host share -> connect as Guest -> mount volume on the desktop.
 
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom
 
 TEST_SETUP := unzip -o -q $(TEST_DATA)/systems/hd1.zip -d $(TEST_TMPDIR)
 

--- a/tests/integration/archive-fork-unpack/config.mk
+++ b/tests/integration/archive-fork-unpack/config.mk
@@ -8,4 +8,4 @@
 TEST_NAME := Archive fork-preserving unpack
 TEST_DESC := archive.extract a StuffIt fixture; verify AppleDouble "._<name>" sidecars carry the resource fork.
 
-TEST_ROM := roms/SE30.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom

--- a/tests/integration/boot-matrix/config.mk
+++ b/tests/integration/boot-matrix/config.mk
@@ -10,7 +10,7 @@ TEST_NAME := Boot Matrix
 TEST_DESC := Cold-boot a Plus across multiple System Software versions in one daemon run.
 
 # Macintosh Plus ROM (shared across the whole matrix)
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom
 
 # Start the daemon with a Plus profile at 1 MB so the first
 # `machine.boot` in test.script has a sensible baseline to re-instantiate

--- a/tests/integration/boot-matrix/test.script
+++ b/tests/integration/boot-matrix/test.script
@@ -104,8 +104,8 @@ assert ${scheduler.instr_count * 1000000000 / (scheduler.host_user_ns - t0) > 50
 # ====================================================================
 #
 # The SE/30 uses the Universal ROM (the same image shared with IIcx and
-# IIx; we keep the canonical filename IIcx.rom).  Switching ROMs is a
-# `rom.load` from the script — the daemon was started with Plus_v3.rom
+# IIx; we keep the canonical filename iix-iicx-se30-97221136.rom).  Switching ROMs is a
+# `rom.load` from the script — the daemon was started with plus-v3-4d1f8172.rom
 # from config.mk, but each iteration is free to swap ROMs before
 # running.  The Universal ROM also runs a ~13 s (guest time) boot-drive-
 # discovery wait at $40801610 before falling through to the actual boot;
@@ -116,7 +116,7 @@ assert ${scheduler.instr_count * 1000000000 / (scheduler.host_user_ns - t0) > 50
 
 # --- SE/30 + System Software 6.0.8 (800K) @ 4 MB RAM ----------------
 machine.boot "se30" 4096
-machine.rom.load "../../data/roms/IIcx.rom"
+machine.rom.load "../../data/roms/iix-iicx-se30-97221136.rom"
 machine.floppy.drive[0].insert "../../data/systems/SSW-6.08-800K/SSW 6.0.8-800k Disk1of4"
 t0 = ${scheduler.host_user_ns}
 scheduler.run 40000000
@@ -156,7 +156,7 @@ assert ${scheduler.instr_count * 1000000000 / (scheduler.host_user_ns - t0) > 10
 # took effect end-to-end).
 machine.nubus.video_sense = 0x6
 machine.boot "iicx" 4096
-machine.rom.load "../../data/roms/IIcx.rom"
+machine.rom.load "../../data/roms/iix-iicx-se30-97221136.rom"
 machine.floppy.drive[0].insert "../../data/systems/SSW-6.08-800K/SSW 6.0.8-800k Disk1of4"
 machine.rtc.pram.validate
 machine.rtc.pram.poke 0x46 0x002780a6a6000000:8
@@ -198,7 +198,7 @@ assert ${scheduler.instr_count * 1000000000 / (scheduler.host_user_ns - t0) > 50
 # because Disk Tools' INIT chain is heavier.
 machine.nubus.video_sense = 0x6
 machine.boot "iicx" 8192
-machine.rom.load "../../data/roms/IIcx.rom"
+machine.rom.load "../../data/roms/iix-iicx-se30-97221136.rom"
 machine.floppy.drive[0].insert "../../data/systems/SSW-7.0-800K/Disk Tools.image"
 machine.rtc.pram.validate
 machine.rtc.pram.poke 0x46 0x002781a6a6000000:8

--- a/tests/integration/checkpoint/config.mk
+++ b/tests/integration/checkpoint/config.mk
@@ -6,7 +6,7 @@ TEST_NAME := Checkpoint Save/Load
 TEST_DESC := Tests save-state and load-state across different boot configurations
 
 # Required disk images (paths relative to tests/data/)
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom
 
 # This test uses a custom runner script instead of the standard single-invocation pattern
 # The runner script handles the two-step checkpoint test

--- a/tests/integration/checkpoint2/config.mk
+++ b/tests/integration/checkpoint2/config.mk
@@ -7,7 +7,7 @@ TEST_NAME := Checkpoint Save/Load v2
 TEST_DESC := Tests save-state and load-state with persistent test artifacts
 
 # Required disk images (paths relative to tests/data/)
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom
 
 # This test uses a custom runner script that operates on static script files
 # and uses a persistent test-results directory instead of /tmp

--- a/tests/integration/core-layering/config.mk
+++ b/tests/integration/core-layering/config.mk
@@ -4,5 +4,5 @@
 # ROM is required by the harness but unused.
 TEST_NAME := Core Layering Check
 TEST_DESC := src/core/ must not #include any src/machines/ implementation header
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom
 TEST_RUNNER := run.sh

--- a/tests/integration/debug/config.mk
+++ b/tests/integration/debug/config.mk
@@ -5,7 +5,7 @@ TEST_NAME := Debug Tooling
 TEST_DESC := Tests debug shell commands (find str/bytes) from PR1 of debug-tooling proposal
 
 # Plus ROM — small, deterministic, always available.
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom
 
 # Custom runner: we capture the emulator's stdout and grep for expected
 # lines so the test verifies actual behavior, not just "didn't crash".

--- a/tests/integration/hd-create/config.mk
+++ b/tests/integration/hd-create/config.mk
@@ -5,4 +5,4 @@ TEST_NAME := HD Create
 TEST_DESC := Tests hd create with model names, human sizes, and hd models listing
 
 # Universal ROM shared by SE/30, IIcx, IIx (checksum 0x97221136)
-TEST_ROM := roms/SE30.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom

--- a/tests/integration/iici-boot-chime/config.mk
+++ b/tests/integration/iici-boot-chime/config.mk
@@ -10,5 +10,5 @@
 TEST_NAME := IIci boot chime — golden WAV capture
 TEST_DESC := machine.sound.capture/match: ASC wavetable chime on the RBV machine (channel-A mix)
 
-TEST_ROM := roms/368CADFE-IIci.rom
+TEST_ROM := roms/iici-368cadfe.rom
 TEST_ARGS := model=iici ram=8192

--- a/tests/integration/iici-boot/config.mk
+++ b/tests/integration/iici-boot/config.mk
@@ -6,7 +6,7 @@ TEST_NAME := IIci Floppy Boot
 TEST_DESC := Boots the Macintosh IIci (RBV built-in video) from System 7.0.1 HD floppy and verifies the Finder desktop
 
 # Dedicated 512 KB Macintosh IIci ("Aurora") ROM, checksum 0x368CADFE.
-TEST_ROM := roms/368CADFE-IIci.rom
+TEST_ROM := roms/iici-368cadfe.rom
 
 # Boot from the 1.44MB HD MFM floppy (System 7.0.1), the same image used by
 # se30-floppy-hd and iifx-boot.  RAM is pinned at 8 MB (the IIci profile

--- a/tests/integration/iicx-24ac-restart/config.mk
+++ b/tests/integration/iicx-24ac-restart/config.mk
@@ -23,7 +23,7 @@
 TEST_NAME := IIcx Display Card 24AC — Finder Restart
 TEST_DESC := Boot IIcx + 24AC from the 32-bit SCSI cdev image, pick Special > Restart, and confirm it reboots back to the Finder desktop
 
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # The harness creates the IIcx with 8 MB; the script re-boots with the 24AC
 # card selected (video_card can't be passed as an arg) and attaches the SCSI HD.

--- a/tests/integration/iicx-24ac-sysinfo/config.mk
+++ b/tests/integration/iicx-24ac-sysinfo/config.mk
@@ -18,7 +18,7 @@
 TEST_NAME := IIcx Display Card 24AC — floppy insert + System Info Display benchmark
 TEST_DESC := Boot IIcx + 24AC to the colour Finder, insert "Utilities Disk 2", launch System Info, select only Test Display, and Run the Display benchmark (PRAM seeded so no System Differences dialog)
 
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # The harness creates the IIcx with 8 MB; the script re-boots with the 24AC
 # card selected (video_card can't be passed as an arg) and attaches the SCSI HD.

--- a/tests/integration/iicx-24ac/config.mk
+++ b/tests/integration/iicx-24ac/config.mk
@@ -15,7 +15,7 @@
 TEST_NAME := IIcx Display Card 24AC — 32-bit SCSI cdev boot
 TEST_DESC := Boot IIcx + 24AC from the 32-bit System 7.1 SCSI cdev image to an 8-bpp colour Finder desktop
 
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # The harness creates the IIcx with 8 MB; the script re-boots with the 24AC
 # card selected (video_card can't be passed as an arg) and attaches the SCSI HD.

--- a/tests/integration/iicx-824gc-16bpp/config.mk
+++ b/tests/integration/iicx-824gc-16bpp/config.mk
@@ -7,6 +7,6 @@
 TEST_NAME := IIcx Display Card 8•24 GC — 16-bpp via VidComm (exact FB words)
 TEST_DESC := VidComm switch to 16 bpp + copy/xor/blend cores, byte-exact
 
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 TEST_ARGS := model=iicx ram=8192

--- a/tests/integration/iicx-824gc-accel/config.mk
+++ b/tests/integration/iicx-824gc-accel/config.mk
@@ -19,7 +19,7 @@
 TEST_NAME := IIcx Display Card 8•24 GC — accelerator ON (real .GraphAccel bring-up)
 TEST_DESC := Boot IIcx + 8•24 GC with the accelerator enabled; bring-up clean (gc.on, error 0, RPCs), desktop renders, no dialog
 
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # The harness creates the IIcx with 8 MB; the script re-boots with the 8•24 GC
 # card selected (video_card can't be passed as an arg) and attaches the SCSI HD.

--- a/tests/integration/iicx-824gc-accel8/config.mk
+++ b/tests/integration/iicx-824gc-accel8/config.mk
@@ -12,6 +12,6 @@
 TEST_NAME := IIcx Display Card 8•24 GC — accelerator ON at 8 bpp
 TEST_DESC := Boot IIcx + 8•24 GC at 8 bpp with the accelerator drawing; colour desktop pixel-exact
 
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 TEST_ARGS := model=iicx ram=8192

--- a/tests/integration/iicx-824gc-adb-mouse/config.mk
+++ b/tests/integration/iicx-824gc-adb-mouse/config.mk
@@ -16,6 +16,6 @@
 TEST_NAME := IIcx Display Card 8•24 GC — ADB mouse deltas move the cursor
 TEST_DESC := ADB delta injection (web2 route) updates Mouse/RawMouse via the slot VBL cursor task
 
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 TEST_ARGS := model=iicx ram=8192

--- a/tests/integration/iicx-824gc-arith8/config.mk
+++ b/tests/integration/iicx-824gc-arith8/config.mk
@@ -10,6 +10,6 @@
 TEST_NAME := IIcx Display Card 8•24 GC — 8-bpp arithmetic modes + RGBPat (exact FB bytes)
 TEST_DESC := Arithmetic transfer modes ($20-$27) + MakeRGBPat dither, poke-driven, byte-exact
 
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 TEST_ARGS := model=iicx ram=8192

--- a/tests/integration/iicx-824gc-beep/config.mk
+++ b/tests/integration/iicx-824gc-beep/config.mk
@@ -21,7 +21,7 @@
 TEST_NAME := IIcx 8•24 GC — Control Panel volume beep (ASC wavetable path)
 TEST_DESC := Boot to Finder, open Control Panel via Apple menu, drag Speaker Volume; golden-WAV match of the Sound Manager beep
 
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # The harness creates the IIcx with 8 MB; the script re-boots with the 8•24 GC
 # card selected (video_card can't be passed as an arg) and attaches the SCSI HD.

--- a/tests/integration/iicx-824gc-decline/config.mk
+++ b/tests/integration/iicx-824gc-decline/config.mk
@@ -12,6 +12,6 @@
 TEST_NAME := IIcx Display Card 8•24 GC — force_decline differential oracle
 TEST_DESC := Same boot as iicx-824gc-accel but every drawing func declines; the ROM path must render the identical pixels
 
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 TEST_ARGS := model=iicx ram=8192

--- a/tests/integration/iicx-824gc-decline8/config.mk
+++ b/tests/integration/iicx-824gc-decline8/config.mk
@@ -9,6 +9,6 @@
 TEST_NAME := IIcx Display Card 8•24 GC — 8 bpp force_decline differential oracle
 TEST_DESC := Same 8-bpp boot as iicx-824gc-accel8 but every drawing func declines; the ROM path must render identical pixels
 
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 TEST_ARGS := model=iicx ram=8192

--- a/tests/integration/iicx-824gc-sysinfo/config.mk
+++ b/tests/integration/iicx-824gc-sysinfo/config.mk
@@ -22,7 +22,7 @@
 TEST_NAME := IIcx Display Card 8•24 GC — System 7.1 System Info Display benchmark (accel ON)
 TEST_DESC := Boot IIcx + 8•24 GC to the System 7.1 colour Finder, insert "Utilities Disk 2", launch System Info, select only Test Display, and Run the Display benchmark — accelerator on, pixel-exact
 
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # The harness creates the IIcx with 8 MB; the script re-boots with the 8•24 GC
 # card selected (video_card can't be passed as an arg) and attaches the SCSI HD.

--- a/tests/integration/iicx-824gc/config.mk
+++ b/tests/integration/iicx-824gc/config.mk
@@ -14,7 +14,7 @@
 TEST_NAME := IIcx Display Card 8•24 GC — card model + accelerator CB bring-up
 TEST_DESC := Detect the 8•24 GC card (v1.1 decl ROM, lane-0) + drive the HLE CB bring-up protocol
 
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # The harness creates the IIcx with 8 MB; the script re-boots with the 8•24 GC
 # card selected (video_card can't be passed as an arg).

--- a/tests/integration/iicx-boot-chime/config.mk
+++ b/tests/integration/iicx-boot-chime/config.mk
@@ -7,5 +7,5 @@
 TEST_NAME := IIcx boot chime — golden WAV capture
 TEST_DESC := machine.sound.capture/match: ASC wavetable chime through the producer path (IIcx channel-A mix)
 
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 TEST_ARGS := model=iicx

--- a/tests/integration/iicx-display-card-24ac/config.mk
+++ b/tests/integration/iicx-display-card-24ac/config.mk
@@ -17,9 +17,9 @@
 TEST_NAME := IIcx Display Card 24AC
 TEST_DESC := Display Card 24AC: engine decode + engine-vs-fallback oracle + object model + 8bpp colour desktop.
 
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # 8 MB RAM matches the iicx-video-modes budget so the boot-ROM slot scan /
-# PrimaryInit timing transfers directly.  The display-card-24ac.vrom is
+# PrimaryInit timing transfers directly.  The display-card-24ac-d8daab87.vrom is
 # found next to the ROM via the shared declrom loader's rom-dir search.
 TEST_ARGS := model=iicx ram=8192 fd=$(TEST_DATA)/systems/System_7_0_1.image

--- a/tests/integration/iicx-display-card-24ac/test.script
+++ b/tests/integration/iicx-display-card-24ac/test.script
@@ -3,7 +3,7 @@
 # See proposal-nubus-card-display-card-24ac.md.  The card is a framebuffer +
 # CLUT + VBL display card (Phase 1) plus a hardware QuickDraw fill/raster
 # accelerator (Phase 2).  This test exercises both halves on the IIcx with
-# the genuine display-card-24ac.vrom, plus the object-model surface
+# the genuine display-card-24ac-d8daab87.vrom, plus the object-model surface
 # (proposal §3.8) and the 8-bpp colour desktop (proposal §2 exit criterion).
 #
 # Slot-space layout (slot $9 -> base 0xF9000000), from the dossier hardware

--- a/tests/integration/iicx-dual-display/config.mk
+++ b/tests/integration/iicx-dual-display/config.mk
@@ -9,7 +9,7 @@
 TEST_NAME := IIcx dual display
 TEST_DESC := Boot the IIcx with two video cards (JMFB in $9 + 8•24 GC staged into $A) and pin the dual-card contract
 
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # The harness boots the IIcx once; the script stages socket $A and re-boots.
 TEST_ARGS := model=iicx ram=8192

--- a/tests/integration/iicx-ext-floppy/config.mk
+++ b/tests/integration/iicx-ext-floppy/config.mk
@@ -16,7 +16,7 @@ TEST_NAME := IIcx External Floppy Insert (System 7.1)
 TEST_DESC := Inserting a floppy into the IIcx external drive (FD1) under System 7.1 mounts it on the desktop (regression guard for the old Finder error-type-41 bomb)
 
 # Universal ROM shared by SE/30, IIcx, IIx (checksum 0x97221136)
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # 8 MB RAM, matching the boot-matrix IIcx + System Software rows and the
 # sibling iicx-keyboard test.  Floppies are inserted in-script.

--- a/tests/integration/iicx-format-hd/config.mk
+++ b/tests/integration/iicx-format-hd/config.mk
@@ -1,7 +1,7 @@
 # Integration test configuration: IIcx + 8•24 GC — format a blank HD under System 6.0.8
 #
 # Boots a Macintosh IIcx with the Apple Macintosh Display Card 8•24 (JMFB,
-# mdc_8_24 — loads Apple-341-0868.vrom next to the ROM) from the SSW 6.0.8
+# mdc_8_24 — loads mdc-8-24-revb-d1629664.vrom next to the ROM) from the SSW 6.0.8
 # 800K boot floppy (Disk2of4, volume "Utilities"), launches Apple HD SC Setup
 # v2.0.3 off that floppy, and formats a freshly-created blank HD20SC SCSI disk
 # at ID 0 — all driven by mouse clicks, matched pixel-exact at each milestone.
@@ -18,7 +18,7 @@
 TEST_NAME := IIcx Format Blank HD (8•24, System 6.0.8)
 TEST_DESC := Boot IIcx + 8•24 GC from SSW 6.0.8 floppy, run Apple HD SC Setup, format a blank HD20SC
 
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # The harness creates the IIcx with 8 MB; the script re-boots with the 8•24
 # card selected (video_card can't be passed as an arg), attaches the blank HD,

--- a/tests/integration/iicx-format-hd/test.script
+++ b/tests/integration/iicx-format-hd/test.script
@@ -17,8 +17,8 @@
 storage.hd_create ${WORK_DIR}/blank.img HD20SC
 
 # Select the 8•24 GC + 13" RGB 640x480 sense, boot the IIcx with 8 MB, and
-# reload the ROM so the card's declaration ROM (Apple-341-0868.vrom, found
-# next to IIcx.rom) binds.  video_card can't be passed as a boot arg.
+# reload the ROM so the card's declaration ROM (mdc-8-24-revb-d1629664.vrom, found
+# next to iix-iicx-se30-97221136.rom) binds.  video_card can't be passed as a boot arg.
 machine.nubus.video_card = "mdc_8_24"
 machine.nubus.video_sense = 0x6
 machine.boot "iicx" 8192

--- a/tests/integration/iicx-keyboard/config.mk
+++ b/tests/integration/iicx-keyboard/config.mk
@@ -13,7 +13,7 @@ TEST_NAME := IIcx Keyboard (System 7.1 Find dialog)
 TEST_DESC := IIcx ADB keyboard under System 7.1: types "macintosh" into Finder's Find dialog and verifies every key lands
 
 # Universal ROM shared by SE/30, IIcx, IIx (checksum 0x97221136)
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # 8 MB RAM matches the boot-matrix IIcx + System Software row.  The floppy is
 # inserted in-script (machine.boot discards the daemon's initial drive state),

--- a/tests/integration/iicx-mactest/config.mk
+++ b/tests/integration/iicx-mactest/config.mk
@@ -10,7 +10,7 @@ TEST_NAME := IIcx MacTest Boot
 TEST_DESC := Disables ADB Communication tests via Options > Test Selections, then runs the IIcx MacTest floppy suite
 
 # Universal ROM shared by SE/30, IIcx, IIx (checksum 0x97221136)
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # MacTest IIcx/IIci floppy disk image.
 # Pin RAM at 4 MB to match the SE/30 baseline so MacTest's RAM-test reports

--- a/tests/integration/iicx-marathon-music/config.mk
+++ b/tests/integration/iicx-marathon-music/config.mk
@@ -24,5 +24,5 @@
 TEST_NAME := IIcx 8•24 GC — Marathon in-game background music (QuickTime MIDI)
 TEST_DESC := Run through the Marathon gameplay hand-off and assert the QuickTime background music is audible
 
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 TEST_ARGS := model=iicx ram=8192

--- a/tests/integration/iicx-marathon/config.mk
+++ b/tests/integration/iicx-marathon/config.mk
@@ -21,7 +21,7 @@
 TEST_NAME := IIcx Display Card 8•24 GC — Marathon boot + new game at 8 bpp
 TEST_DESC := Boot IIcx + 8•24 GC at 8 bpp, launch Marathon, set Preferences to High-Res/100%/256/Normal, OK, Begin New Game through the Arrival cut scene into gameplay; pixel-exact
 
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # The harness creates the IIcx with 8 MB; the script re-boots with the 8•24 GC
 # card selected (video_card can't be passed as an arg) and attaches the SCSI HD.

--- a/tests/integration/iicx-video-modes/config.mk
+++ b/tests/integration/iicx-video-modes/config.mk
@@ -11,7 +11,7 @@
 TEST_NAME := IIcx Video Modes
 TEST_DESC := Cold-boot Finder-at-N-bpp via PRAM seeding + resolution sweep on the JMFB.
 
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # 8 MB RAM lets the JMFB driver complete PrimaryInit cleanly and
 # matches the iicx-floppy budget so the Finder boot timing transfers

--- a/tests/integration/iifx-24ac/config.mk
+++ b/tests/integration/iifx-24ac/config.mk
@@ -14,9 +14,9 @@
 TEST_NAME := IIfx Display Card 24AC boot
 TEST_DESC := Boot the IIfx with the 24AC selected (computed compatibility) and verify the card seats and the boot screen shows
 
-# Dedicated IIfx ROM; the 24AC vROM (display-card-24ac.vrom) is found next
+# Dedicated IIfx ROM; the 24AC vROM (display-card-24ac-d8daab87.vrom) is found next
 # to it by canonical catalog name.
-TEST_ROM := roms/4147DD77-IIfx.rom
+TEST_ROM := roms/iifx-4147dd77.rom
 
 # The harness boots the IIfx once; the script re-boots with the 24AC
 # selected (the ROM-only phase needs no disk).

--- a/tests/integration/iifx-824gc/config.mk
+++ b/tests/integration/iifx-824gc/config.mk
@@ -21,7 +21,7 @@
 TEST_NAME := IIfx Display Card 8•24 GC — System 7 Finder
 TEST_DESC := Boot the IIfx with the 8•24 GC (computed compatibility) from the System 7.0.1 floppy to a pixel-exact Finder desktop
 
-TEST_ROM := roms/4147DD77-IIfx.rom
+TEST_ROM := roms/iifx-4147dd77.rom
 
 # Same floppy + RAM as iifx-boot; video_card= stages the pick before
 # machine creation (the headless twin of web2's pre-boot

--- a/tests/integration/iifx-aux3-boot-8bpp/config.mk
+++ b/tests/integration/iifx-aux3-boot-8bpp/config.mk
@@ -25,8 +25,8 @@
 TEST_NAME := IIfx A/UX 3.0.1 HD Boot at 8 bpp (reaches graphical login)
 TEST_DESC := Boot IIfx (16 MB, JMFB at 13" RGB 8 bpp) from the A/UX 3.0.1 HD image; expect the graphical login window, pixel-exact.
 
-# IIfx ROM (checksum 0x4147DD77).  JMFB declrom (Apple-341-0868.vrom) is
+# IIfx ROM (checksum 0x4147DD77).  JMFB declrom (mdc-8-24-revb-d1629664.vrom) is
 # auto-discovered from the same directory as the ROM file.
-TEST_ROM := roms/4147DD77-IIfx.rom
+TEST_ROM := roms/iifx-4147dd77.rom
 
 TEST_ARGS := model=iifx ram=16384

--- a/tests/integration/iifx-aux3-boot/config.mk
+++ b/tests/integration/iifx-aux3-boot/config.mk
@@ -13,10 +13,10 @@
 TEST_NAME := IIfx A/UX 3.0.1 HD Boot (reaches login)
 TEST_DESC := Boot IIfx with 16 MB RAM from the A/UX 3.0.1 HD image; expect the A/UX text `login:` prompt.
 
-# IIfx ROM (checksum 0x4147DD77).  JMFB declrom (Apple-341-0868.vrom) is
+# IIfx ROM (checksum 0x4147DD77).  JMFB declrom (mdc-8-24-revb-d1629664.vrom) is
 # auto-discovered from the same directory as the ROM file; the content is
-# identical to tests/data/roms/341-0868.vrom.
-TEST_ROM := roms/4147DD77-IIfx.rom
+# identical to tests/data/roms/mdc-8-24-revb-d1629664.vrom.
+TEST_ROM := roms/iifx-4147dd77.rom
 
 # Copy the HD image into TEST_TMPDIR so its .delta/.journal are wiped with
 # the tempdir on exit; the source image is left untouched between runs.

--- a/tests/integration/iifx-aux3-x11/config.mk
+++ b/tests/integration/iifx-aux3-x11/config.mk
@@ -17,9 +17,9 @@
 TEST_NAME := IIfx A/UX 3.0.1 X11 Session
 TEST_DESC := Boot IIfx from the A/UX 3.0.1 HD image, choose an X11 session type at the login window, and log in as root to the X11 desktop.
 
-# IIfx ROM (checksum 0x4147DD77).  JMFB declrom (Apple-341-0868.vrom) is
+# IIfx ROM (checksum 0x4147DD77).  JMFB declrom (mdc-8-24-revb-d1629664.vrom) is
 # auto-discovered from the same directory as the ROM file.
-TEST_ROM := roms/4147DD77-IIfx.rom
+TEST_ROM := roms/iifx-4147dd77.rom
 
 # Copy the HD image into TEST_TMPDIR so its .delta/.journal are wiped with
 # the tempdir on exit; the source image is left untouched between runs.

--- a/tests/integration/iifx-boot-chime/config.mk
+++ b/tests/integration/iifx-boot-chime/config.mk
@@ -11,5 +11,5 @@
 TEST_NAME := IIfx boot chime — golden WAV capture
 TEST_DESC := machine.sound.capture/match: ASC wavetable chime on the OSS machine (channel-A mix)
 
-TEST_ROM := roms/4147DD77-IIfx.rom
+TEST_ROM := roms/iifx-4147dd77.rom
 TEST_ARGS := model=iifx ram=8192

--- a/tests/integration/iifx-boot/config.mk
+++ b/tests/integration/iifx-boot/config.mk
@@ -7,7 +7,7 @@
 TEST_NAME := IIfx Floppy Boot to Finder
 TEST_DESC := Boots Macintosh IIfx from System 7.0.1 floppy and verifies the Finder desktop
 
-TEST_ROM := roms/4147DD77-IIfx.rom
+TEST_ROM := roms/iifx-4147dd77.rom
 
 # NOTE: ram=8192 currently regresses the boot (stalls in POST at $40843F96
 # while probing the SCC IOP).  ram=16384 boots cleanly through to Finder.

--- a/tests/integration/iifx-mactest/config.mk
+++ b/tests/integration/iifx-mactest/config.mk
@@ -16,7 +16,7 @@
 TEST_NAME := IIfx MacTest Boot (8bpp)
 TEST_DESC := Boots Macintosh IIfx from the MacTest floppy at 8-bit colour and verifies the hardware-identification panel
 
-TEST_ROM := roms/4147DD77-IIfx.rom
+TEST_ROM := roms/iifx-4147dd77.rom
 
 # MacTest 1.0 1.44MB HD MFM floppy image.
 # RAM is pinned at 16 MB to match the iifx-boot baseline: ram=8192 currently

--- a/tests/integration/iifx-marathon/config.mk
+++ b/tests/integration/iifx-marathon/config.mk
@@ -11,7 +11,7 @@
 TEST_NAME := IIfx Display Card 8•24 GC — Marathon boot + new game at 8 bpp
 TEST_DESC := Boot IIfx + 8•24 GC at 8 bpp, launch Marathon, set Preferences to High-Res/100%/256/Normal, OK, Begin New Game through the Arrival cut scene into gameplay; pixel-exact
 
-TEST_ROM := roms/4147DD77-IIfx.rom
+TEST_ROM := roms/iifx-4147dd77.rom
 
 # The harness creates the IIfx with 16 MB; the script re-boots with the
 # 8•24 GC card selected and attaches the SCSI HD.

--- a/tests/integration/iisi-boot-chime/config.mk
+++ b/tests/integration/iisi-boot-chime/config.mk
@@ -7,5 +7,5 @@
 TEST_NAME := IIsi boot chime — golden WAV capture
 TEST_DESC := machine.sound.capture/match: ASC wavetable chime on the V8 machine (channel-A mix)
 
-TEST_ROM := roms/36B7FB6C-IIsi.rom
+TEST_ROM := roms/iisi-36b7fb6c.rom
 TEST_ARGS := model=iisi ram=17408

--- a/tests/integration/iisi-boot/config.mk
+++ b/tests/integration/iisi-boot/config.mk
@@ -10,7 +10,7 @@ TEST_NAME := IIsi Floppy Boot
 TEST_DESC := Boots the Macintosh IIsi (Egret + V8 built-in video at physical 0) from System 7.0.1 floppy and verifies the Finder desktop
 
 # Dedicated 512 KB Macintosh IIsi ("Erickson") ROM, checksum 0x36B7FB6C.
-TEST_ROM := roms/36B7FB6C-IIsi.rom
+TEST_ROM := roms/iisi-36b7fb6c.rom
 
 # RAM pinned at 17 MB = 1 MB soldered Bank A ($00000000, holds the video frame
 # buffer at its bottom) + 16 MB Bank B ($04000000, system "low memory"), the

--- a/tests/integration/iix-824gc/config.mk
+++ b/tests/integration/iix-824gc/config.mk
@@ -10,9 +10,9 @@
 TEST_NAME := IIx Display Card 8•24 GC boot
 TEST_DESC := Boot the IIx with the 8•24 GC selected (computed compatibility) and verify the card seats and paints
 
-# Universal IIx/IIcx/SE/30 ROM; the 8•24 GC vROM (Apple-341-0266.vrom) is
+# Universal IIx/IIcx/SE/30 ROM; the 8•24 GC vROM (824gc-v1.1-revb-d722b053.vrom) is
 # found next to it by canonical catalog name.
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # The harness boots the IIx once; the script re-boots with the 8•24 GC
 # selected (video_card can't be passed as a startup arg).

--- a/tests/integration/iix-boot/config.mk
+++ b/tests/integration/iix-boot/config.mk
@@ -5,6 +5,6 @@
 TEST_NAME := IIx Boot
 TEST_DESC := Boots IIx with Universal ROM and verifies machine-ID identification
 
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 TEST_ARGS := model=iix ram=8192

--- a/tests/integration/iix-floppy/config.mk
+++ b/tests/integration/iix-floppy/config.mk
@@ -10,6 +10,6 @@
 TEST_NAME := IIx System 7.0.1 Floppy Boot
 TEST_DESC := Boots IIx from the System 7.0.1 floppy and verifies no crash
 
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 TEST_ARGS := model=iix ram=8192 fd=$(TEST_DATA)/systems/System_7_0_1.image

--- a/tests/integration/image-export-raw/config.mk
+++ b/tests/integration/image-export-raw/config.mk
@@ -6,4 +6,4 @@
 TEST_NAME := storage.export_raw
 TEST_DESC := Export a disk image to a flat raw file and re-mount it via the VFS
 
-TEST_ROM := roms/SE30.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom

--- a/tests/integration/image-hfs-traverse/config.mk
+++ b/tests/integration/image-hfs-traverse/config.mk
@@ -5,4 +5,4 @@
 TEST_NAME := Image HFS traverse
 TEST_DESC := Traverse a System 6 HFS floppy via VFS descent; verify cp, EROFS, EBUSY
 
-TEST_ROM := roms/SE30.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom

--- a/tests/integration/image-partmap/config.mk
+++ b/tests/integration/image-partmap/config.mk
@@ -7,4 +7,4 @@ TEST_NAME := Image partmap
 TEST_DESC := Exercises `image partmap` and `image probe` against an APM-formatted A/UX disk image
 
 # Universal ROM shared by SE/30, IIcx, IIx
-TEST_ROM := roms/SE30.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom

--- a/tests/integration/image-ufs-traverse/config.mk
+++ b/tests/integration/image-ufs-traverse/config.mk
@@ -8,4 +8,4 @@ TEST_NAME := Image UFS traverse
 TEST_DESC := Descends into the A/UX 3.0.1 UFS root partition and copies out /etc
 
 # Universal ROM shared by SE/30, IIcx, IIx
-TEST_ROM := roms/SE30.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom

--- a/tests/integration/lisa-los-boot/config.mk
+++ b/tests/integration/lisa-los-boot/config.mk
@@ -6,7 +6,7 @@ TEST_NAME := Apple Lisa 2 LOS 3.1 boot
 TEST_DESC := Boots the Lisa 2 from the Lisa Office System 3.1 install floppy to the Install/Repair/Restore menu
 
 # Interleaved rev-H Lisa 2 boot ROM (341-0175-H / 341-0176-H), 16 KB, checksum 0x098917B2.
-TEST_ROM := Lisa/roms/098917B2-LisaH.rom
+TEST_ROM := roms/lisa2-revh-098917b2.rom
 
 # Lisa 2, 2 MB.  Booting the Office System exercises the whole stack: the boot
 # ROM sizes/maps RAM and loads the OS off the Sony 400K floppy; the OS mounts the

--- a/tests/integration/lisa-los-install/config.mk
+++ b/tests/integration/lisa-los-install/config.mk
@@ -7,7 +7,7 @@ TEST_NAME := Apple Lisa 2 LOS 3.1 mouse-driven Install
 TEST_DESC := Warps the cursor to the Install button and clicks it; verifies the installer responds (reaches its disk-selection screen)
 
 # Interleaved rev-H Lisa 2 boot ROM (341-0175-H / 341-0176-H), 16 KB, checksum 0x098917B2.
-TEST_ROM := Lisa/roms/098917B2-LisaH.rom
+TEST_ROM := roms/lisa2-revh-098917b2.rom
 
 # Lisa 2, 2 MB.  Same boot as lisa-los-boot; this test adds the mouse interaction.
 # The cursor is positioned by the "global" warp: the COPS reads the OS's live

--- a/tests/integration/lisa-los-profile/config.mk
+++ b/tests/integration/lisa-los-profile/config.mk
@@ -35,6 +35,6 @@
 TEST_NAME := Apple Lisa 2 LOS 3.1 ProFile install
 TEST_DESC := Full LOS 3.1 install onto the ProFile, then reboot off it and cleanly power off
 
-TEST_ROM := Lisa/roms/098917B2-LisaH.rom
+TEST_ROM := roms/lisa2-revh-098917b2.rom
 TEST_ARGS := model=lisa ram=2048 fd=$(TEST_DATA)/Lisa/LisaOfficeSystem-3.1/LOS-3.1-1.image
 TEST_SETUP := python3 lisa-profile-boot/seed_pram.py "$(WORK_DIR)/profile.pram"

--- a/tests/integration/lisa-profile-boot/config.mk
+++ b/tests/integration/lisa-profile-boot/config.mk
@@ -30,6 +30,6 @@
 TEST_NAME := Apple Lisa 2 boot LOS from the ProFile
 TEST_DESC := Cold-boots the installed ProFile via its on-disk PRAM snapshot (no floppy); catches a non-clean-shutdown image
 
-TEST_ROM := Lisa/roms/098917B2-LisaH.rom
+TEST_ROM := roms/lisa2-revh-098917b2.rom
 TEST_ARGS := model=lisa ram=2048
 TEST_SETUP := cp "$(TEST_DATA)/Lisa/LisaOfficeSystem-3.1/LOS-3.1-ProFile.image" "$(WORK_DIR)/profile.image" && python3 lisa-profile-boot/seed_pram.py "$(WORK_DIR)/profile.pram" --coldboot

--- a/tests/integration/lisa-profile/config.mk
+++ b/tests/integration/lisa-profile/config.mk
@@ -8,7 +8,7 @@ TEST_NAME := Apple Lisa 2 ProFile hard disk
 TEST_DESC := Reads the ProFile controller's device-info block via the boot ROM's PROREAD driver
 
 # Interleaved rev-H Lisa 2 boot ROM (341-0175-H / 341-0176-H), 16 KB, checksum 0x098917B2.
-TEST_ROM := Lisa/roms/098917B2-LisaH.rom
+TEST_ROM := roms/lisa2-revh-098917b2.rom
 
 # Lisa 2, 1 MB.  No floppy: the test drives the ProFile directly via PROREAD.
 TEST_ARGS := model=lisa ram=1024

--- a/tests/integration/lisa-xenix-boot/config.mk
+++ b/tests/integration/lisa-xenix-boot/config.mk
@@ -24,7 +24,7 @@
 TEST_NAME := Apple Lisa 2 boot Xenix from the ProFile
 TEST_DESC := Boots the installed Xenix 3.0 ProFile to its multi-user startup prompt
 
-TEST_ROM := Lisa/roms/098917B2-LisaH.rom
+TEST_ROM := roms/lisa2-revh-098917b2.rom
 TEST_ARGS := model=lisa ram=2048 fd=$(TEST_DATA)/Lisa/Xenix-3.0/Xenix-3.0-Boot-XProFile.dc42
 
 # Copy the installed image to a writable scratch path so the staged input is never

--- a/tests/integration/lisa-xenix-hdinit/config.mk
+++ b/tests/integration/lisa-xenix-hdinit/config.mk
@@ -23,7 +23,7 @@
 TEST_NAME := Apple Lisa 2 SCO Xenix 3.0 hdinit
 TEST_DESC := Boot Xenix and run hdinit to initialize the ProFile (mkfs + fsck + boot block)
 
-TEST_ROM := Lisa/roms/098917B2-LisaH.rom
+TEST_ROM := roms/lisa2-revh-098917b2.rom
 
 # Lisa 2, 2 MB.  Boot from the Xenix "Boot XProFile Patch" floppy (the plain Boot
 # floppy's pf driver cannot drive an external ProFile).

--- a/tests/integration/lisa-xenix-install/config.mk
+++ b/tests/integration/lisa-xenix-install/config.mk
@@ -24,6 +24,6 @@
 TEST_NAME := Apple Lisa 2 SCO Xenix 3.0 full install
 TEST_DESC := Full Xenix 3.0 OS install onto the ProFile (hdinit, reboot, firsttime, 7 floppies), then save the cleanly-shut-down image
 
-TEST_ROM := Lisa/roms/098917B2-LisaH.rom
+TEST_ROM := roms/lisa2-revh-098917b2.rom
 
 TEST_ARGS := model=lisa ram=2048 fd=$(TEST_DATA)/Lisa/Xenix-3.0/Xenix-3.0-Boot-XProFile.dc42

--- a/tests/integration/lisa-xenix-nofloppy/config.mk
+++ b/tests/integration/lisa-xenix-nofloppy/config.mk
@@ -28,6 +28,6 @@
 TEST_NAME := Apple Lisa 2 Xenix ProFile no-floppy boot
 TEST_DESC := Boots the installed Xenix 3.0 ProFile to its multi-user prompt with no floppy, via the ROM STARTUP FROM picker
 
-TEST_ROM := Lisa/roms/098917B2-LisaH.rom
+TEST_ROM := roms/lisa2-revh-098917b2.rom
 TEST_ARGS := model=lisa ram=2048
 TEST_SETUP := cp "$(TEST_DATA)/Lisa/Xenix-3.0/Xenix-3.0-ProFile.image" "$(WORK_DIR)/profile.image"

--- a/tests/integration/machine-capabilities/config.mk
+++ b/tests/integration/machine-capabilities/config.mk
@@ -8,5 +8,5 @@ TEST_DESC := machine.profile().capabilities mmu.kind per model + VROM-by-card
 
 # Any ROM works — machine.profile() is a static registry lookup and does
 # not boot the machine; Plus is the smallest.
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom
 TEST_RUNNER := run.sh

--- a/tests/integration/machine-lifecycle/config.mk
+++ b/tests/integration/machine-lifecycle/config.mk
@@ -5,7 +5,7 @@ TEST_NAME := Machine Lifecycle (M1)
 TEST_DESC := Validates system_create/system_destroy lifecycle and checkpoint round-trip via machine_plus callbacks
 
 # Required ROM image (path relative to tests/data/)
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom
 
 # No extra disk images required; uses TEST_RUNNER for multi-step execution
 TEST_RUNNER := run.sh

--- a/tests/integration/machine-profile-schema/config.mk
+++ b/tests/integration/machine-profile-schema/config.mk
@@ -8,5 +8,5 @@ TEST_NAME := Machine Profile Schema Snapshot
 TEST_DESC := machine.profile() JSON shape pinned per model (added/removed/retyped field => fail)
 
 # Any ROM works — machine.profile() is a static registry lookup, no boot.
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom
 TEST_RUNNER := run.sh

--- a/tests/integration/nubus-staged-config/config.mk
+++ b/tests/integration/nubus-staged-config/config.mk
@@ -10,6 +10,6 @@
 TEST_NAME := NuBus per-slot staged config
 TEST_DESC := slot[N].card_id / video_mode staging, wildcard-alias equivalence, consume-at-boot
 
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 TEST_ARGS := model=iicx ram=8192

--- a/tests/integration/object-debug/config.mk
+++ b/tests/integration/object-debug/config.mk
@@ -6,4 +6,4 @@
 TEST_NAME := Object-model debug consolidation
 TEST_DESC := debug.breakpoints/.logpoints indexed children with sparse stable indices
 
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom

--- a/tests/integration/object-eval/config.mk
+++ b/tests/integration/object-eval/config.mk
@@ -6,4 +6,4 @@
 TEST_NAME := Object-model eval (Plus)
 TEST_DESC := Smoke test for `eval` shell command — cpu/memory/machine paths
 
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom

--- a/tests/integration/object-expr/config.mk
+++ b/tests/integration/object-expr/config.mk
@@ -4,4 +4,4 @@
 TEST_NAME := Object-model expressions (Plus)
 TEST_DESC := $(...) substitution and predicate assert in the legacy shell
 
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom

--- a/tests/integration/object-floppy/config.mk
+++ b/tests/integration/object-floppy/config.mk
@@ -6,5 +6,5 @@
 TEST_NAME := Object-model floppy class
 TEST_DESC := floppy.drives[0|1] indexed children + eject method
 
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom
 TEST_ARGS := fd0=$(TEST_DATA)/systems/System_6_0_8.dsk

--- a/tests/integration/object-logpoint/config.mk
+++ b/tests/integration/object-logpoint/config.mk
@@ -5,4 +5,4 @@
 TEST_NAME := Object-model logpoint interpolation
 TEST_DESC := ${...} interpolation drives logpoint message formatting
 
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom

--- a/tests/integration/object-rtc/config.mk
+++ b/tests/integration/object-rtc/config.mk
@@ -6,4 +6,4 @@
 TEST_NAME := Object-model RTC class
 TEST_DESC := rtc.time / rtc.pram peek+poke+snapshot
 
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom

--- a/tests/integration/object-scc/config.mk
+++ b/tests/integration/object-scc/config.mk
@@ -6,4 +6,4 @@
 TEST_NAME := Object-model SCC class
 TEST_DESC := scc.loopback / scc.reset / scc.{a,b}.* expose the SCC peripheral
 
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom

--- a/tests/integration/object-scsi/config.mk
+++ b/tests/integration/object-scsi/config.mk
@@ -4,6 +4,6 @@
 TEST_NAME := Object-model SCSI class
 TEST_DESC := scsi.bus.phase + scsi.devices indexed children + scsi.loopback
 
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom
 TEST_SETUP := unzip -o -q $(TEST_DATA)/systems/hd1.zip -d $(TEST_TMPDIR)
 TEST_ARGS := hd=$(TEST_TMPDIR)/hd1.img

--- a/tests/integration/object-sound/config.mk
+++ b/tests/integration/object-sound/config.mk
@@ -5,4 +5,4 @@
 TEST_NAME := Object-model sound class
 TEST_DESC := sound.enabled / .volume / .sample_rate / .mute() — Plus PWM module
 
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom

--- a/tests/integration/object-storage/config.mk
+++ b/tests/integration/object-storage/config.mk
@@ -5,6 +5,6 @@
 TEST_NAME := Object-model storage class
 TEST_DESC := storage.images indexed children — filename / path / type / writable
 
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom
 TEST_SETUP := unzip -o -q $(TEST_DATA)/systems/hd1.zip -d $(TEST_TMPDIR)
 TEST_ARGS := hd=$(TEST_TMPDIR)/hd1.img fd0=$(TEST_DATA)/systems/System_6_0_8.dsk

--- a/tests/integration/object-storage/test.script
+++ b/tests/integration/object-storage/test.script
@@ -25,6 +25,6 @@ storage.images[1].filename
 # storage.import — copy a small file to a chosen destination via the
 # legacy `cp` route, then verify storage.import without dst_path
 # falls back to the content-hash naming under /opfs/images/.
-echo ${storage.import("../../data/roms/Plus_v3.rom", "/tmp/imported_rom.bin")}
+echo ${storage.import("../../data/roms/plus-v3-4d1f8172.rom", "/tmp/imported_rom.bin")}
 
 quit

--- a/tests/integration/object-toplevel/config.mk
+++ b/tests/integration/object-toplevel/config.mk
@@ -6,4 +6,4 @@
 TEST_NAME := Object-model M8 top-level (appletalk + mouse)
 TEST_DESC := appletalk.shares/.printer + mouse.* methods
 
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom

--- a/tests/integration/object-via/config.mk
+++ b/tests/integration/object-via/config.mk
@@ -8,4 +8,4 @@ TEST_NAME := Object-model VIA classes
 TEST_DESC := via1 / via2 status registers + port_a / port_b children
 
 # Universal ROM shared by SE/30, IIcx, IIx (checksum 0x97221136)
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom

--- a/tests/integration/plus-boot-beep/config.mk
+++ b/tests/integration/plus-boot-beep/config.mk
@@ -13,4 +13,4 @@
 TEST_NAME := Plus boot beep — golden WAV capture
 TEST_DESC := machine.sound.capture/match: deterministic Plus PWM audio through the generalized audio path
 
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom

--- a/tests/integration/plus-floppy-blank/config.mk
+++ b/tests/integration/plus-floppy-blank/config.mk
@@ -12,7 +12,7 @@
 TEST_NAME := Plus Blank Floppy
 TEST_DESC := Create a blank floppy, mount it as the 2nd drive under System 6, hit the initialize-disk dialog, eject from Finder.
 
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom
 
 # Boot from System 6.0.8 in the internal drive; the blank floppy is created
 # by the script into WORK_DIR and inserted into the external drive.

--- a/tests/integration/plus-mactest/config.mk
+++ b/tests/integration/plus-mactest/config.mk
@@ -5,7 +5,7 @@ TEST_NAME := Plus MacTest
 TEST_DESC := Boots Plus with MacTest floppy, deselects unsupported tests, runs suite, verifies pass
 
 # Macintosh Plus ROM
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom
 
 # MacTest floppy disk image (pre-extracted from MacTest_Disk.image_.sit_.hqx)
 TEST_ARGS := fd=$(TEST_DATA)/apps/MacTest-Plus.image

--- a/tests/integration/plus-musicworks/config.mk
+++ b/tests/integration/plus-musicworks/config.mk
@@ -13,5 +13,5 @@
 TEST_NAME := Plus MusicWorks — Brandenburg No. 3 playback
 TEST_DESC := Boot MFS floppy to Finder, open Samples/Brandenburg No. 3 in MusicWorks, PLAY; golden-WAV match of the PWM music
 
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom
 TEST_ARGS := fd=$(TEST_DATA)/apps/MusicWorks-0.42.image

--- a/tests/integration/re-disasm/config.mk
+++ b/tests/integration/re-disasm/config.mk
@@ -7,5 +7,5 @@
 
 TEST_NAME := dump --disasm-code (System 6 Finder)
 TEST_DESC := Snapshot CODE 1 + jump-table disasm and compare to checked-in golden
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom
 TEST_RUNNER := run.sh

--- a/tests/integration/re-extract/config.mk
+++ b/tests/integration/re-extract/config.mk
@@ -6,5 +6,5 @@
 
 TEST_NAME := dump end-to-end (AUX 3.0.1 HFS Finder)
 TEST_DESC := Extract the AUX hd image's MacOS-partition Finder; verify deterministic per-resource output
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom
 TEST_RUNNER := run.sh

--- a/tests/integration/re-manifest/config.mk
+++ b/tests/integration/re-manifest/config.mk
@@ -3,5 +3,5 @@
 
 TEST_NAME := dump manifest + decoders + flags
 TEST_DESC := Validate manifest schema, decoded JSON, and the --no-X flags on System 6 Finder
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom
 TEST_RUNNER := run.sh

--- a/tests/integration/rom-identify/config.mk
+++ b/tests/integration/rom-identify/config.mk
@@ -8,4 +8,4 @@
 TEST_NAME := ROM identify and machine profile probes
 TEST_DESC := rom.identify map shape, machine.profile static lookup, machine.boot validation
 
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom

--- a/tests/integration/rom-identify/test.script
+++ b/tests/integration/rom-identify/test.script
@@ -1,18 +1,18 @@
 # rom.identify and machine.profile probe surface.
 #
-# Headless boots Plus from Plus_v3.rom (config.mk's TEST_ROM); we then
+# Headless boots Plus from plus-v3-4d1f8172.rom (config.mk's TEST_ROM); we then
 # probe the same file plus the SE/30 ROM by relative path to exercise the
 # new map shape, and call machine.profile() for both registered models to
 # pin the static configuration shape.  The cross-check here is what
 # protects against the drift documented in proposal §1.1.
 
 # rom.identify on the loaded Plus ROM.  Output is a JSON-encoded V_STRING.
-echo ${machine.rom.identify("../../data/roms/Plus_v3.rom")}
+echo ${machine.rom.identify("../../data/roms/plus-v3-4d1f8172.rom")}
 
 # Universal ROM: must list se30 / iicx / iix as compatible.  Headless ran
 # its boot pass against Plus, so this is just a path probe — no machine
 # state is touched.
-echo ${machine.rom.identify("../../data/roms/SE30.rom")}
+echo ${machine.rom.identify("../../data/roms/iix-iicx-se30-97221136.rom")}
 
 # Unrecognised file: probing /dev/null/nonexistent must yield V_ERROR.
 # The shell's truthiness rule treats errors as falsy.

--- a/tests/integration/rom-naming/config.mk
+++ b/tests/integration/rom-naming/config.mk
@@ -1,0 +1,17 @@
+# Integration test: canonical ROM/vROM filename conformance (proposal-test-rom-naming.md §4.3).
+#
+# The enforcement that makes the reorganization stick.  Enumerates every file
+# in tests/data/roms and, via machine.(v)rom.identify, asserts:
+#   1. the file is RECOGNISED (no unknown blobs may live in the directory);
+#   2. its basename EQUALS the catalog's canonical_name (no drift);
+#   3. no two files share a checksum/CRC (kills duplicate blobs forever).
+#
+# Uses a run.sh runner because the object-model shell has no directory
+# enumeration — the runner lists the dir in bash and drives one headless
+# identify pass over all files.  TEST_ROM is just the harness's boot ROM.
+
+TEST_NAME := ROM/vROM canonical filename conformance
+TEST_DESC := every tests/data/roms file is recognised, canonically named, and checksum-unique
+
+TEST_ROM := roms/plus-v3-4d1f8172.rom
+TEST_RUNNER := run.sh

--- a/tests/integration/rom-naming/run.sh
+++ b/tests/integration/rom-naming/run.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Canonical ROM/vROM filename conformance (proposal-test-rom-naming.md §4.3).
+#
+# Enumerate every file in $TEST_DATA/roms and drive a single headless
+# identify pass over all of them, then assert:
+#   1. every file is RECOGNISED by machine.rom.identify / machine.vrom.identify;
+#   2. each file's basename == the catalog's reported canonical_name;
+#   3. no two files share a checksum (CPU ROM) or Format-Block CRC (vROM).
+#
+# The identify surface is picked by extension (.rom → rom, .vrom → vrom).
+set -euo pipefail
+
+ROMS_DIR="$TEST_DATA/roms"
+[ -d "$ROMS_DIR" ] || { echo "FAIL: $ROMS_DIR does not exist"; exit 1; }
+
+# Build the headless script: for each file emit a marker line naming the file,
+# then echo its identify JSON.  The shell prints values in an unquoted display
+# form, but the fields we key on (recognised / canonical_name / checksum / crc)
+# are comma-free, so they extract cleanly regardless of the free-text `name`.
+SCRIPT="$WORK_DIR/identify.script"
+: > "$SCRIPT"
+count=0
+while IFS= read -r -d '' f; do
+    base="$(basename "$f")"
+    case "$base" in
+        *.rom)  obj="machine.rom.identify"  ;;
+        *.vrom) obj="machine.vrom.identify" ;;
+        *)      echo "FAIL: unexpected non-ROM file in roms/: $base"; exit 1 ;;
+    esac
+    printf 'echo GSFILE %s\n' "$base" >> "$SCRIPT"
+    printf 'echo ${%s("%s")}\n' "$obj" "$f" >> "$SCRIPT"
+    count=$((count + 1))
+done < <(find "$ROMS_DIR" -maxdepth 1 -type f -print0 | sort -z)
+echo "quit" >> "$SCRIPT"
+
+[ "$count" -gt 0 ] || { echo "FAIL: no files found in $ROMS_DIR"; exit 1; }
+echo "rom-naming: identifying $count file(s) in $ROMS_DIR"
+
+OUT="$WORK_DIR/identify.out"
+GS_STORAGE_CACHE="$STORAGE_CACHE" "$HEADLESS_BIN" \
+    rom="$ROM_PATH" --no-prompt --speed=max "script=$SCRIPT" > "$OUT" 2>/dev/null
+
+python3 - "$OUT" "$count" <<'PY'
+import re, sys
+
+out_path, expected = sys.argv[1], int(sys.argv[2])
+lines = open(out_path, encoding="utf-8", errors="replace").read().splitlines()
+
+def field(js, key):
+    m = re.search(r'(?:^|[,{])' + re.escape(key) + r':([^,}]*)', js)
+    return m.group(1) if m else None
+
+records = []          # (basename, json)
+pending = None
+for ln in lines:
+    m = re.search(r'GSFILE (\S+)', ln)
+    if m:
+        pending = m.group(1)
+        continue
+    if pending is not None and '{recognised:' in ln:
+        js = ln[ln.index('{recognised:'):]
+        records.append((pending, js))
+        pending = None
+
+fail = []
+if len(records) != expected:
+    fail.append(f"parsed {len(records)} identify results but expected {expected} "
+                f"(a file may have produced an error instead of a result)")
+
+seen_ids = {}
+for base, js in records:
+    if field(js, "recognised") != "true":
+        fail.append(f"{base}: NOT recognised (unknown blobs may not live in roms/) -> {js}")
+        continue
+    canon = field(js, "canonical_name")
+    if canon != base:
+        fail.append(f"{base}: filename != canonical_name (reported {canon!r})")
+    # checksum for CPU ROMs, crc for vROMs — either way a content identity.
+    ident = field(js, "checksum") or field(js, "crc")
+    if ident:
+        ident = ident.lower()
+        if ident in seen_ids:
+            fail.append(f"duplicate content id {ident}: {base} and {seen_ids[ident]}")
+        else:
+            seen_ids[ident] = base
+
+if fail:
+    print("=== rom-naming conformance FAILURES ===")
+    for f in fail:
+        print("  - " + f)
+    sys.exit(1)
+
+print(f"rom-naming: {len(records)} files OK — all recognised, canonically named, "
+      f"{len(seen_ids)} unique content ids, no duplicates")
+PY

--- a/tests/integration/rom-naming/run.sh
+++ b/tests/integration/rom-naming/run.sh
@@ -25,7 +25,10 @@ while IFS= read -r -d '' f; do
     case "$base" in
         *.rom)  obj="machine.rom.identify"  ;;
         *.vrom) obj="machine.vrom.identify" ;;
-        *)      echo "FAIL: unexpected non-ROM file in roms/: $base"; exit 1 ;;
+        # The generated manifest (roms/README.md, proposal §4.4) and any other
+        # docs legitimately live here — they are not ROM blobs, so skip them.
+        README.md|*.md) continue ;;
+        *) echo "FAIL: unexpected non-ROM/doc file in roms/: $base"; exit 1 ;;
     esac
     printf 'echo GSFILE %s\n' "$base" >> "$SCRIPT"
     printf 'echo ${%s("%s")}\n' "$obj" "$f" >> "$SCRIPT"

--- a/tests/integration/rom-naming/test.script
+++ b/tests/integration/rom-naming/test.script
@@ -1,0 +1,5 @@
+# See run.sh — this test uses a custom runner (TEST_RUNNER := run.sh) because
+# the conformance check must enumerate tests/data/roms, which the object-model
+# shell cannot do.  The Makefile requires a test.script to exist, so this file
+# is intentionally a no-op placeholder.
+quit

--- a/tests/integration/scsi/config.mk
+++ b/tests/integration/scsi/config.mk
@@ -6,7 +6,7 @@ TEST_NAME := SCSI Hard Disk Boot
 TEST_DESC := Verifies booting from a SCSI hard disk image (hd1.zip)
 
 # Required disk images (paths relative to tests/data/)
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom
 
 # Setup command: unzip hd1.zip to a temp directory before running
 # $(TEST_DATA) and $(TEST_TMPDIR) are expanded by the parent Makefile

--- a/tests/integration/se30-aux-3/config.mk
+++ b/tests/integration/se30-aux-3/config.mk
@@ -10,7 +10,7 @@ TEST_NAME := SE/30 A/UX 3.0.1 Boot (retail SE)
 TEST_DESC := Boot SE/30 from retail A/UX 3.0.1 SE floppy + CD; mount root from CD-ROM
 
 # Universal ROM shared by SE/30, IIcx, IIx (checksum 0x97221136)
-TEST_ROM := roms/SE30.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # Always start clean: copy the boot floppy (DiskCopy 4.2, 800 KB) into
 # TEST_TMPDIR so its .delta/.journal are wiped with the tempdir on exit;

--- a/tests/integration/se30-aux3-boot/config.mk
+++ b/tests/integration/se30-aux3-boot/config.mk
@@ -5,7 +5,7 @@ TEST_NAME := SE/30 A/UX 3.0.1 HD Boot
 TEST_DESC := Boot SE/30 with 16 MB RAM from a pre-installed A/UX 3.0.1 HD image
 
 # Universal ROM shared by SE/30, IIcx, IIx (checksum 0x97221136)
-TEST_ROM := roms/SE30.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # Copy the HD image into TEST_TMPDIR so its .delta/.journal are wiped with
 # the tempdir on exit; the source image is left untouched between runs.

--- a/tests/integration/se30-boot-chime/config.mk
+++ b/tests/integration/se30-boot-chime/config.mk
@@ -12,5 +12,5 @@
 TEST_NAME := SE/30 boot chime — golden WAV capture
 TEST_DESC := machine.sound.capture/match: ASC wavetable chime through the producer path (SE/30 sum mix)
 
-TEST_ROM := roms/SE30.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 TEST_ARGS := model=se30

--- a/tests/integration/se30-boot/config.mk
+++ b/tests/integration/se30-boot/config.mk
@@ -5,7 +5,7 @@ TEST_NAME := SE/30 Boot
 TEST_DESC := Boots SE/30 with Universal ROM to the floppy icon screen and verifies display
 
 # Universal ROM shared by SE/30, IIcx, IIx (checksum 0x97221136)
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # No extra disk images; boot to floppy icon (no bootable disk)
 TEST_ARGS :=

--- a/tests/integration/se30-cdrom/config.mk
+++ b/tests/integration/se30-cdrom/config.mk
@@ -6,7 +6,7 @@ TEST_NAME := SE/30 CD-ROM
 TEST_DESC := Boots SE/30 with CD-ROM on SCSI bus, verifies Finder desktop and cdrom shell commands
 
 # Universal ROM shared by SE/30, IIcx, IIx (checksum 0x97221136)
-TEST_ROM := roms/SE30.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # Boot from 1.44MB HD MFM floppy (System 7.0.1) with CD-ROM on SCSI ID 3
 TEST_ARGS := ram=8192 fd=$(TEST_DATA)/systems/System_7_0_1.image cdrom=$(TEST_DATA)/aux/aux_3.0.1/APPLE_AUX_3-0-1_RETAIL.iso

--- a/tests/integration/se30-floppy-hd/config.mk
+++ b/tests/integration/se30-floppy-hd/config.mk
@@ -5,7 +5,7 @@ TEST_NAME := SE/30 HD Floppy Boot
 TEST_DESC := Boots SE/30 with Universal ROM from 1.44MB HD floppy and verifies Finder desktop
 
 # Universal ROM shared by SE/30, IIcx, IIx (checksum 0x97221136)
-TEST_ROM := roms/SE30.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # Boot from 1.44MB HD MFM floppy (System 7.0.1)
 TEST_ARGS := ram=8192 fd=$(TEST_DATA)/systems/System_7_0_1.image

--- a/tests/integration/se30-floppy/config.mk
+++ b/tests/integration/se30-floppy/config.mk
@@ -5,7 +5,7 @@ TEST_NAME := SE/30 Floppy Boot
 TEST_DESC := Boots SE/30 with Universal ROM from System 7.1 floppy and verifies display
 
 # Universal ROM shared by SE/30, IIcx, IIx (checksum 0x97221136)
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # Boot from System 7.1 floppy disk.  Pin RAM at 4 MB to match the existing
 # screenshot baseline; SE/30's profile default is 8 MB (proposal §3.1) and

--- a/tests/integration/se30-format-hd/config.mk
+++ b/tests/integration/se30-format-hd/config.mk
@@ -6,7 +6,7 @@ TEST_NAME := SE/30 Format Blank HD
 TEST_DESC := Creates blank 80MB image via hd create, boots 7.0.1 floppy, opens HD SC Setup
 
 # SE/30 Universal ROM
-TEST_ROM := roms/SE30.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # Remove stale delta/journal files so the floppy boots from a clean base image
 TEST_SETUP := rm -f $(TEST_DATA)/systems/System_7_0_1.image.delta $(TEST_DATA)/systems/System_7_0_1.image.journal

--- a/tests/integration/se30-mactest/config.mk
+++ b/tests/integration/se30-mactest/config.mk
@@ -5,7 +5,7 @@ TEST_NAME := SE/30 MacTest Boot
 TEST_DESC := Boots SE/30 with MacTest SE/30 floppy, dismisses splash, verifies test UI
 
 # Universal ROM shared by SE/30, IIcx, IIx (checksum 0x97221136)
-TEST_ROM := roms/SE30.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # MacTest SE/30 floppy disk image (800K DiskCopy)
 # Boot from drive 0 (IWM SELECT=0).  MacTest's floppy test (TEST_PERFO) ejects

--- a/tests/integration/se30-scsi/config.mk
+++ b/tests/integration/se30-scsi/config.mk
@@ -6,7 +6,7 @@ TEST_NAME := SE/30 SCSI Hard Disk Boot
 TEST_DESC := Verifies SE/30 booting from a SCSI hard disk image (hd1.zip)
 
 # Required disk images (paths relative to tests/data/)
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 # Setup command: unzip hd1.zip to a temp directory before running
 # $(TEST_DATA) and $(TEST_TMPDIR) are expanded by the parent Makefile

--- a/tests/integration/shell-class/config.mk
+++ b/tests/integration/shell-class/config.mk
@@ -8,4 +8,4 @@
 TEST_NAME := Shell class surface
 TEST_DESC := shell.{run,complete,expand,alias_set,alias_unset,vars,aliases,prompt,running} via gs_eval
 
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom

--- a/tests/integration/shell-commands/config.mk
+++ b/tests/integration/shell-commands/config.mk
@@ -5,4 +5,4 @@ TEST_NAME := Shell Commands
 TEST_DESC := Tests new debug shell commands (aliases, help, register commands, status)
 
 # Universal ROM shared by SE/30, IIcx, IIx (checksum 0x97221136)
-TEST_ROM := roms/SE30.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom

--- a/tests/integration/storage-guards/config.mk
+++ b/tests/integration/storage-guards/config.mk
@@ -8,5 +8,5 @@
 TEST_NAME := storage.rm/mv guards
 TEST_DESC := Protected paths, self-move, and existing-destination refusals
 
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom
 TEST_RUNNER := run.sh

--- a/tests/integration/vfs-rsrc/config.mk
+++ b/tests/integration/vfs-rsrc/config.mk
@@ -5,4 +5,4 @@
 
 TEST_NAME := VFS resource-fork tree
 TEST_DESC := Walk /rsrc/<TYPE>/<id> and .info sidecars on a System 6 floppy
-TEST_ROM := roms/Plus_v3.rom
+TEST_ROM := roms/plus-v3-4d1f8172.rom

--- a/tests/integration/vrom-identify/config.mk
+++ b/tests/integration/vrom-identify/config.mk
@@ -11,6 +11,6 @@
 TEST_NAME := vrom.identify probe surface
 TEST_DESC := vrom.identify Format-Block CRC identity + card_id/compatible contract + catalog/registry drift guard
 
-TEST_ROM := roms/IIcx.rom
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
 
 TEST_ARGS := model=iicx ram=8192

--- a/tests/integration/vrom-identify/test.script
+++ b/tests/integration/vrom-identify/test.script
@@ -11,27 +11,27 @@
 
 # --- Part 1: the {card_id, compatible, crc} contract (stateless probe). ---
 # Output is a JSON-encoded V_STRING; echo for visibility, then exact-match.
-echo ${machine.vrom.identify("../../data/roms/Apple-341-0868.vrom")}
-echo ${machine.vrom.identify("../../data/roms/SE30.vrom")}
-echo ${machine.vrom.identify("../../data/roms/display-card-24ac.vrom")}
+echo ${machine.vrom.identify("../../data/roms/mdc-8-24-revb-d1629664.vrom")}
+echo ${machine.vrom.identify("../../data/roms/builtin-se30-video-4f71ff1a.vrom")}
+echo ${machine.vrom.identify("../../data/roms/display-card-24ac-d8daab87.vrom")}
 
 # Macintosh Display Card 8•24 → JMFB card "mdc_8_24", CRC $D1629664.
-assert ${machine.vrom.identify("../../data/roms/Apple-341-0868.vrom") == "{\"recognised\":true,\"canonical_name\":\"Apple-341-0868.vrom\",\"card_id\":\"mdc_8_24\",\"compatible\":[\"mdc_8_24\"],\"size\":32768,\"crc\":\"0xd1629664\"}"} "8•24 vROM identity"
+assert ${machine.vrom.identify("../../data/roms/mdc-8-24-revb-d1629664.vrom") == "{\"recognised\":true,\"canonical_name\":\"mdc-8-24-revb-d1629664.vrom\",\"card_id\":\"mdc_8_24\",\"compatible\":[\"mdc_8_24\"],\"size\":32768,\"crc\":\"0xd1629664\"}"} "8•24 vROM identity"
 
 # SE/30 onboard video (byteLanes $0F, 4-lane) → builtin card, CRC $4F71FF1A.
-assert ${machine.vrom.identify("../../data/roms/SE30.vrom") == "{\"recognised\":true,\"canonical_name\":\"SE30.vrom\",\"card_id\":\"builtin_se30_video\",\"compatible\":[\"builtin_se30_video\"],\"size\":32768,\"crc\":\"0x4f71ff1a\"}"} "SE/30 onboard-video vROM identity"
+assert ${machine.vrom.identify("../../data/roms/builtin-se30-video-4f71ff1a.vrom") == "{\"recognised\":true,\"canonical_name\":\"builtin-se30-video-4f71ff1a.vrom\",\"card_id\":\"builtin_se30_video\",\"compatible\":[\"builtin_se30_video\"],\"size\":32768,\"crc\":\"0x4f71ff1a\"}"} "SE/30 onboard-video vROM identity"
 
 # Apple Macintosh Display Card 24AC → "display_card_24ac", CRC $D8DAAB87.
-assert ${machine.vrom.identify("../../data/roms/display-card-24ac.vrom") == "{\"recognised\":true,\"canonical_name\":\"display-card-24ac.vrom\",\"card_id\":\"display_card_24ac\",\"compatible\":[\"display_card_24ac\"],\"size\":32768,\"crc\":\"0xd8daab87\"}"} "24AC vROM identity"
+assert ${machine.vrom.identify("../../data/roms/display-card-24ac-d8daab87.vrom") == "{\"recognised\":true,\"canonical_name\":\"display-card-24ac-d8daab87.vrom\",\"card_id\":\"display_card_24ac\",\"compatible\":[\"display_card_24ac\"],\"size\":32768,\"crc\":\"0xd8daab87\"}"} "24AC vROM identity"
 
 # Apple Macintosh Display Card 8•24 GC ("Dolphin") → "824gc".  Three genuine
 # declaration ROMs (byteLanes $E1); v1.1 is a 64 KB chip, v1.0 / alpha 32 KB.
-assert ${machine.vrom.identify("../../data/roms/Apple-341-0266.vrom") == "{\"recognised\":true,\"canonical_name\":\"Apple-341-0266.vrom\",\"card_id\":\"824gc\",\"compatible\":[\"824gc\"],\"size\":65536,\"crc\":\"0xd722b053\"}"} "8•24 GC v1.1 vROM identity"
-assert ${machine.vrom.identify("../../data/roms/341-0812-02_1.0.vrom") == "{\"recognised\":true,\"canonical_name\":\"341-0812-02_1.0.vrom\",\"card_id\":\"824gc\",\"compatible\":[\"824gc\"],\"size\":32768,\"crc\":\"0x9e9857e8\"}"} "8•24 GC v1.0 vROM identity"
-assert ${machine.vrom.identify("../../data/roms/Dolphin_1.0A16.vrom") == "{\"recognised\":true,\"canonical_name\":\"Dolphin_1.0A16.vrom\",\"card_id\":\"824gc\",\"compatible\":[\"824gc\"],\"size\":32768,\"crc\":\"0x4740028d\"}"} "8•24 GC alpha vROM identity"
+assert ${machine.vrom.identify("../../data/roms/824gc-v1.1-revb-d722b053.vrom") == "{\"recognised\":true,\"canonical_name\":\"824gc-v1.1-revb-d722b053.vrom\",\"card_id\":\"824gc\",\"compatible\":[\"824gc\"],\"size\":65536,\"crc\":\"0xd722b053\"}"} "8•24 GC v1.1 vROM identity"
+assert ${machine.vrom.identify("../../data/roms/824gc-v1.0-reva-9e9857e8.vrom") == "{\"recognised\":true,\"canonical_name\":\"824gc-v1.0-reva-9e9857e8.vrom\",\"card_id\":\"824gc\",\"compatible\":[\"824gc\"],\"size\":32768,\"crc\":\"0x9e9857e8\"}"} "8•24 GC v1.0 vROM identity"
+assert ${machine.vrom.identify("../../data/roms/824gc-v1.0a16-4740028d.vrom") == "{\"recognised\":true,\"canonical_name\":\"824gc-v1.0a16-4740028d.vrom\",\"card_id\":\"824gc\",\"compatible\":[\"824gc\"],\"size\":32768,\"crc\":\"0x4740028d\"}"} "8•24 GC alpha vROM identity"
 
 # A main ROM is the wrong size for a vROM → recognised:false (no false match).
-assert ${machine.vrom.identify("../../data/roms/Plus_v3.rom") == "{\"recognised\":false}"} "non-vROM file must be unrecognised"
+assert ${machine.vrom.identify("../../data/roms/plus-v3-4d1f8172.rom") == "{\"recognised\":false}"} "non-vROM file must be unrecognised"
 
 # Unreadable path → V_ERROR (the shell's truthiness rule treats it as falsy).
 assert ${!machine.vrom.identify("/dev/null/nonexistent")} "unreadable path must yield V_ERROR"

--- a/tests/integration/xl-boot/config.mk
+++ b/tests/integration/xl-boot/config.mk
@@ -10,7 +10,7 @@ TEST_DESC := Boots the Macintosh XL via MacWorks XL (loader disk, then scripted 
 
 # Interleaved Macintosh XL "3A" boot ROM (341-0346-A / 341-0347-A), 16 KB,
 # checksum 0x094C82F0.
-TEST_ROM := Lisa/roms/094C82F0-MacXL.rom
+TEST_ROM := roms/macxl-3a-094c82f0.rom
 
 # Boot from the MacWorks XL loader disk.  RAM is pinned at 1 MB (the macxl
 # profile default) so the 608x431 framebuffer sits at $F8000 and the rendered

--- a/tests/integration/xl-no-media/config.mk
+++ b/tests/integration/xl-no-media/config.mk
@@ -11,7 +11,7 @@ TEST_DESC := Boots the Macintosh XL with no floppy and no ProFile; the boot ROM 
 
 # Interleaved Macintosh XL "3A" boot ROM (341-0346-A / 341-0347-A), 16 KB,
 # checksum 0x094C82F0.
-TEST_ROM := Lisa/roms/094C82F0-MacXL.rom
+TEST_ROM := roms/macxl-3a-094c82f0.rom
 
 # Macintosh XL, 1 MB (the macxl profile default, so the 608x431 framebuffer sits
 # at $F8000 and the rendered prompt is reproducible).  No fd= and no profile=


### PR DESCRIPTION
Implements `local/gs-docs/proposals/proposal-test-rom-naming.md`: one canonical filename grammar for CPU ROMs and NuBus declaration ROMs (vROMs), derived from — and now enforced against — the in-code catalogs.

## ⚠️ Coordinated with a gs-test-data flag-day
The matching rename **already landed on `pappadf/gs-test-data` `main`** (commit `2469697`, `git mv` — history preserved, content byte-identical). Because `scripts/fetch-test-data.sh` only ever clones gs-test-data's default branch, the two repos were flipped together:
- `main` here is **red until this PR merges** (it references old names but fetches the renamed data).
- Merging this PR restores green. Revertible via `git revert 2469697` on gs-test-data if needed.

## Canonical grammar
- CPU ROMs: `<targets>[-<rev>]-<checksum8>.rom`
- vROMs: `<card-id>[-<rev>]-<crc8>.vrom`
- One flat `roms/` directory (Lisa/XL folded in); two duplicate blobs dropped (`IIcx.rom`≡`SE30.rom`, `341-0868.vrom`≡`Apple-341-0868.vrom`).
- Universal ROM → `iix-iicx-se30-97221136.rom`.

## Code (catalogs = enforced single source of truth)
- `rom.h`/`rom.c`: `canonical_name` column on `rom_info_t` (ROM_TABLE + Lisa table); `machine.rom.identify` reports it, mirroring `machine.vrom.identify`.
- `vrom.c`: `VROM_CATALOG` rows renamed (no aliases — both repos flip together).
- `builtin_se30_video.c`: SE/30 vROM filename now derived from `vrom_catalog_name()` instead of a hardcoded `"SE30.vrom"` (jmfb & other cards already load via catalog-driven `declrom_load_vrom_card`).

## Enforcement + tooling
- `tests/integration/rom-naming`: strict conformance test — every file in `tests/data/roms` must be recognised, carry its catalog canonical name, and have a unique checksum/CRC (kills duplicates and drift permanently).
- `scripts/rom-manifest.sh`: regenerates gs-test-data's `roms/README.md` manifest from `machine.(v)rom.identify` + curated notes.

## Reference updates
~150 sites: integration `config.mk`/`test.script`, e2e specs, web2 fixtures, docs, `.agents/skills`, `Makefile`, `USAGE.md`, and the `fetch-test-data.sh` availability probe. Checksum string assertions (e.g. `rom.checksum == "4D1F8172"`) intentionally unchanged.

## Verified locally
`rom-naming`, `rom-identify`, `vrom-identify`, `iix-boot`, `se30-boot`, `iicx-824gc`, `iicx-display-card-24ac`, `boot-matrix`, `lisa-los-boot`, `iifx-boot-chime`, `iisi-boot-chime`, `iicx-24ac`, and 29 web2 unit/lint tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)