### PR TITLE
rom/vrom: content-addressed provisioning — core never fabricates or interprets a path

### DIFF
--- a/app/web2/src/bus/emulator.ts
+++ b/app/web2/src/bus/emulator.ts
@@ -420,7 +420,8 @@ export async function initEmulator(config: MachineConfig): Promise<void> {
   // Select the NuBus video card before boot. Without this the slot falls back
   // to its default card (e.g. the IIcx's "mdc_8_24"), so an uploaded 24AC vROM
   // would boot an 8•24 instead. The id comes from the dialog's probe of the
-  // chosen card; the card factory then finds its vROM on disk by canonical name.
+  // chosen card; the card factory content-matches its vROM among the offered
+  // files (the explicit vrom.load above being the preferred pick).
   if (config.videoCard) {
     await gsEval('machine.nubus.video_card', [config.videoCard]);
   }

--- a/app/web2/src/bus/upload.ts
+++ b/app/web2/src/bus/upload.ts
@@ -365,7 +365,7 @@ async function persist(
   originalName: string,
   descriptor: MediaTypeDescriptor,
   info:
-    | { persistDir?: string; checksum?: string; canonicalName?: string; [k: string]: unknown }
+    | { persistDir?: string; checksum?: string; cardId?: string; [k: string]: unknown }
     | undefined,
 ): Promise<string | null> {
   const finalName = descriptor.nameFn ? descriptor.nameFn(originalName, info) : originalName;
@@ -377,16 +377,23 @@ async function persist(
     return null;
   }
   await discardStaging(sourcePath);
+  // Offer a freshly stored vROM to the core's content-addressed registry.
+  // The startup enumeration ran once at page load, so without this an
+  // "(auto)" boot after a mid-session upload would not see the file until
+  // the next reload.
+  if (descriptor.id === 'vrom') {
+    await gsEval('machine.vrom.offer', [finalPath]);
+  }
   // Notify inventory watchers (e.g. WelcomeConfigSlide's dropdown
   // refresh effect) that the OPFS image catalog has changed.
   bumpImagesRevision();
-  // When the file was recognised and stored under a canonical name (VROM →
-  // its declaration-ROM canonical filename), surface that in the toast — it
-  // tells the user we actually identified the file, not just "it landed in
-  // OPFS". The card's human name is shown later in the config dialog (sourced
-  // from machine.profile), so we don't duplicate that knowledge here.
-  const canonical = info?.canonicalName as string | undefined;
-  const shown = canonical && canonical !== originalName ? canonical : originalName;
+  // When the file was recognised as a vROM, surface the card it provides in
+  // the toast — it tells the user we actually identified the file, not just
+  // "it landed in OPFS". The card's human display name is shown later in the
+  // config dialog (sourced from machine.profile), so we don't duplicate that
+  // knowledge here; the id is the identification signal.
+  const cardId = info?.cardId as string | undefined;
+  const shown = cardId ? `${originalName} (Video ROM for '${cardId}')` : originalName;
   showNotification(`${shown} uploaded`, 'info');
   return finalPath;
 }

--- a/app/web2/src/components/display/WelcomeConfigSlide.svelte
+++ b/app/web2/src/components/display/WelcomeConfigSlide.svelte
@@ -72,10 +72,11 @@
   }
 
   // One identified VROM in OPFS: which card it provides (probed via
-  // vrom.identify) so the dialog can speak in cards, not filenames.
+  // vrom.identify) so the dialog can speak in cards, not filenames. Any
+  // human-readable label comes from the card id via machine.profile
+  // (cardOptions) — the on-disk name is a content hash and never shown.
   interface VromEntry {
     path: string;
-    name: string; // canonical filename
     cardId: string; // nubus card-kind id this blob provides
     compatible: string[]; // card ids this vROM can drive (usually [cardId])
   }
@@ -152,9 +153,10 @@
   // VROM row/handling is driven by the *selected card* (the SE/30-vs-IIci
   // asymmetry): a card declares requires_vrom, not the machine.
   let needsVrom = $derived(selectedCard?.requires_vrom === true);
-  // The vROM file handed to the core for the selected card. The card factory
-  // finds its vROM on disk by canonical name, so this mainly feeds the SE/30
-  // builtin's pending-path and gates "is this card installable".
+  // The vROM file handed to the core for the selected card (an explicit
+  // machine.vrom.load — the preferred offer); it also gates "is this card
+  // installable". Without it the card factory falls back to whatever the
+  // platform offered from the OPFS store (content-matched).
   let resolvedVrom = $derived(needsVrom ? (vromsByCardId[cardId]?.[0] ?? null) : null);
   // Model expects a video card but none is installable (every candidate card
   // needs a vROM and none is present). Drives the "upload a Video ROM" hint.
@@ -236,14 +238,12 @@
     try {
       const parsed = JSON.parse(r) as {
         recognised?: boolean;
-        canonical_name?: string;
         card_id?: string;
         compatible?: string[];
       };
       if (!parsed.recognised || !parsed.card_id) return null;
       return {
         path,
-        name: parsed.canonical_name ?? path.split('/').pop() ?? path,
         cardId: parsed.card_id,
         compatible: Array.isArray(parsed.compatible) ? parsed.compatible : [parsed.card_id],
       };
@@ -448,8 +448,9 @@
       return;
     }
     const selected = romsForCurrentModel.find((r) => r.path === romPath) ?? romsForCurrentModel[0];
-    // The chosen card auto-resolves its vROM (probed by card id); the card
-    // factory then finds it on disk by canonical name. '(auto)' = no vROM.
+    // The chosen card auto-resolves its vROM (probed by card id); '(auto)'
+    // means no explicit pick — the card factory content-matches among the
+    // files the platform offered from the OPFS store.
     const vromPath = resolvedVrom ? resolvedVrom.path : '(auto)';
     const floppyPaths = floppies.map((f) =>
       f === NONE_SENTINEL || !f ? '' : `/opfs/images/fd/${f}`,

--- a/app/web2/src/lib/media.ts
+++ b/app/web2/src/lib/media.ts
@@ -50,7 +50,6 @@ interface RomIdentifyResult {
 // human-readable card name is owned by the card kind (machine.profile), not here.
 interface VromIdentifyResult {
   recognised: boolean;
-  canonical_name?: string;
   card_id?: string;
   compatible?: string[];
   size?: number;
@@ -98,7 +97,6 @@ export const MEDIA_TYPES: Record<MediaTypeId, MediaTypeDescriptor> = {
         return {
           valid: true,
           info: {
-            canonicalName: parsed.canonical_name,
             cardId: parsed.card_id,
             compatible: parsed.compatible,
             checksum: parsed.crc,
@@ -108,13 +106,14 @@ export const MEDIA_TYPES: Record<MediaTypeId, MediaTypeDescriptor> = {
         return { valid: false };
       }
     },
-    // VROMs are stored under the canonical filename the core's card
-    // factories look up (e.g. JMFB hardcodes "mdc-8-24-revb-d1629664.vrom" in
-    // jmfb.c). The C-side `machine.vrom.identify` derives the canonical name
-    // from the file's content hash; the UI doesn't carry any ROM
-    // knowledge of its own.
+    // VROMs are stored by content hash (the declaration ROM's Format-Block
+    // CRC), mirroring how CPU ROMs are stored by checksum. Discovery is
+    // content-based (the core's offer registry), so the on-disk name never
+    // matters — and the UI carries no naming grammar of its own. The
+    // identify payload's crc is "0x"-prefixed; strip it for the filename.
     nameFn(originalName, info) {
-      return (info?.canonicalName as string) || originalName;
+      const crc = info?.checksum as string | undefined;
+      return crc ? crc.replace(/^0x/, '') : originalName;
     },
   },
 

--- a/app/web2/tests/unit/media.test.ts
+++ b/app/web2/tests/unit/media.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { MEDIA_TYPES, type GsEval } from '@/lib/media';
+import { VROMS_DIR } from '@/lib/opfsPaths';
+
+// The OPFS store is content-addressed for both media types
+// (proposal-content-addressed-rom-provisioning.md §3.6a): CPU ROMs are stored
+// by checksum, vROMs by the declaration ROM's Format-Block CRC. Discovery is
+// content-based (the core's offer registry), so the on-disk name never
+// matters — but the stable hash name is what keeps re-uploads idempotent.
+
+// gsEval stub returning a fixed vrom.identify payload (the post-proposal
+// shape: content facts only, no canonical_name).
+const vromIdentify: GsEval = async (evalPath: string, args?: unknown[]) => {
+  expect(evalPath).toBe('machine.vrom.identify');
+  expect(args).toEqual(['/opfs/upload/my_weird.bin']);
+  return JSON.stringify({
+    recognised: true,
+    card_id: 'mdc_8_24',
+    compatible: ['mdc_8_24'],
+    size: 32768,
+    crc: '0xd1629664',
+  });
+};
+
+describe('vrom media descriptor', () => {
+  it('validate() maps the identify payload to cardId/compatible/checksum', async () => {
+    const result = await MEDIA_TYPES.vrom.validate('/opfs/upload/my_weird.bin', vromIdentify);
+    expect(result.valid).toBe(true);
+    expect(result.info?.cardId).toBe('mdc_8_24');
+    expect(result.info?.compatible).toEqual(['mdc_8_24']);
+    expect(result.info?.checksum).toBe('0xd1629664');
+  });
+
+  it('validate() rejects unrecognised files', async () => {
+    const unrecognised: GsEval = async () => JSON.stringify({ recognised: false, size: 32768 });
+    const result = await MEDIA_TYPES.vrom.validate('/opfs/upload/junk.bin', unrecognised);
+    expect(result.valid).toBe(false);
+  });
+
+  it('nameFn stores an uploaded vROM under its content hash (CRC, no 0x)', async () => {
+    const result = await MEDIA_TYPES.vrom.validate('/opfs/upload/my_weird.bin', vromIdentify);
+    const name = MEDIA_TYPES.vrom.nameFn!('my_weird.bin', result.info);
+    expect(name).toBe('d1629664');
+    // The persisted path is content-addressed — the user's upload name is
+    // discarded, exactly like the CPU-ROM store.
+    expect(`${MEDIA_TYPES.vrom.persistDir}/${name}`).toBe(`${VROMS_DIR}/d1629664`);
+  });
+
+  it('nameFn falls back to the original name without identify info', () => {
+    expect(MEDIA_TYPES.vrom.nameFn!('fallback.vrom', undefined)).toBe('fallback.vrom');
+  });
+});

--- a/scripts/rom-manifest.sh
+++ b/scripts/rom-manifest.sh
@@ -2,12 +2,14 @@
 #
 # rom-manifest.sh - Generate the human-readable roms/ manifest for gs-test-data.
 #
-# Machine-derives every fact it can (canonical name, size, checksum/CRC, kind,
-# compatible models / card id, family name) by running gs-headless
-# machine.(v)rom.identify over each file, then merges a small curated notes
-# table (provenance, Apple part numbers, Rev A/B, "16bpp requires this ROM")
-# that identify cannot know.  This is the tool from proposal-test-rom-naming.md
-# §4.4 — the manifest is regenerated, never hand-edited.
+# Machine-derives every fact it can (size, checksum/CRC, kind, compatible
+# models / card id, family name) by running gs-headless
+# machine.(v)rom.identify over each file, computes each file's canonical name
+# by applying the tooling grammar (scripts/rom_naming.py) to its content id,
+# then merges a small curated notes table (provenance, Apple part numbers,
+# Rev A/B, "16bpp requires this ROM") that identify cannot know.  This is the
+# tool from proposal-test-rom-naming.md §4.4 — the manifest is regenerated,
+# never hand-edited.
 #
 # Usage:
 #   scripts/rom-manifest.sh [ROMS_DIR] [OUT_FILE]
@@ -51,21 +53,24 @@ OUT="$WORK/identify.out"
 GS_STORAGE_CACHE="$WORK/cache" "$HEADLESS_BIN" \
     rom="$BOOT_ROM" --no-prompt --speed=max "script=$SCRIPT" > "$OUT" 2>/dev/null
 
-python3 - "$OUT" "$OUT_FILE" <<'PY'
+python3 - "$OUT" "$OUT_FILE" "$SCRIPT_DIR" <<'PY'
 import re, sys, os
 
-out_path, dest = sys.argv[1], sys.argv[2]
+out_path, dest, script_dir = sys.argv[1], sys.argv[2], sys.argv[3]
+sys.path.insert(0, script_dir)
+from rom_naming import canonical_name  # the tooling naming grammar
+
 lines = open(out_path, encoding="utf-8", errors="replace").read().splitlines()
 
 def field(js, key):
-    # Comma-free scalar fields (checksum, crc, canonical_name, card_id, size,
-    # recognised). NOT for `name` / `compatible`, which can contain commas.
+    # Comma-free scalar fields (checksum, crc, card_id, size, recognised).
+    # NOT for `name` / `compatible`, which can contain commas.
     m = re.search(r'(?:^|[,{])' + re.escape(key) + r':([^,}]*)', js)
     return m.group(1) if m else None
 
 def rom_name(js):
-    # rom.identify key order: ...,name:<free text>,canonical_name:...
-    m = re.search(r'(?:^|,)name:(.*?),canonical_name:', js)
+    # rom.identify key order: ...,name:<free text>,size:...
+    m = re.search(r'(?:^|,)name:(.*?),size:', js)
     return m.group(1) if m else ""
 
 def compatible(js):
@@ -135,9 +140,9 @@ out.append("|---|---|---|---|---|")
 cpu = [(b, j) for b, j in rows if b.endswith(".rom")]
 vro = [(b, j) for b, j in rows if b.endswith(".vrom")]
 for base, js in sorted(cpu):
-    canon = field(js, "canonical_name") or base
-    size  = human_kb(field(js, "size") or "0")
     chk   = field(js, "checksum") or ""
+    canon = canonical_name(chk) or base
+    size  = human_kb(field(js, "size") or "0")
     name  = rom_name(js)
     comp  = compatible(js)
     note  = NOTES.get(base, "")
@@ -149,9 +154,9 @@ out.append("")
 out.append("| Canonical file | Size | CRC | Card id | Notes |")
 out.append("|---|---|---|---|---|")
 for base, js in sorted(vro):
-    canon = field(js, "canonical_name") or base
-    size  = human_kb(field(js, "size") or "0")
     crc   = field(js, "crc") or ""
+    canon = canonical_name(crc) or base
+    size  = human_kb(field(js, "size") or "0")
     card  = field(js, "card_id") or ""
     note  = NOTES.get(base, "")
     out.append(f"| `{canon}` | {size} | `{crc}` | `{card}` | {note} |")

--- a/scripts/rom_naming.py
+++ b/scripts/rom_naming.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# rom_naming.py - Canonical fixture-filename grammar for the gs-test-data repo.
+#
+# The emulator core identifies every ROM/vROM purely by content (checksum /
+# NuBus Format-Block CRC) and knows no filenames.  Fixture files in
+# gs-test-data's roms/ directory, however, are browsed by humans, so they
+# keep the legible canonical grammar from proposal-test-rom-naming.md:
+#
+#   <targets>[-<rev>]-<checksum8>.rom       e.g. iix-iicx-se30-97221136.rom
+#   <card-id, _ -> ->[-<rev>]-<crc8>.vrom   e.g. mdc-8-24-revb-d1629664.vrom
+#
+# The <targets>/<rev> parts are human facts (marketing revs, Apple part
+# generations) that cannot be derived from the bytes, so the grammar reduces
+# to a pure content-identity -> name table.  This module is the single owner
+# of that mapping (proposal-content-addressed-rom-provisioning.md section 3.6b);
+# its only consumers are scripts/rom-manifest.sh and the rom-naming
+# conformance test.  The emulator never sees it.
+
+# Content identity (8 lowercase hex digits: the stored checksum for CPU ROMs,
+# the Format-Block CRC for vROMs) -> canonical basename.
+CANONICAL_NAMES = {
+    # --- CPU ROMs (*.rom), keyed by stored checksum -------------------------
+    "4d1f8172": "plus-v3-4d1f8172.rom",  # Macintosh Plus Rev 3 ("Loud Harmonicas")
+    "97221136": "iix-iicx-se30-97221136.rom",  # Universal 256 KB IIx/IIcx/SE-30 ROM
+    "4147dd77": "iifx-4147dd77.rom",  # Macintosh IIfx
+    "368cadfe": "iici-368cadfe.rom",  # Macintosh IIci ("Aurora")
+    "36b7fb6c": "iisi-36b7fb6c.rom",  # Macintosh IIsi ("Erickson")
+    "098917b2": "lisa2-revh-098917b2.rom",  # Apple Lisa 2 boot ROM rev H (computed checksum)
+    "094c82f0": "macxl-3a-094c82f0.rom",  # Macintosh XL boot ROM "3A" (computed checksum)
+    # --- Declaration ROMs / vROMs (*.vrom), keyed by Format-Block CRC -------
+    "d1629664": "mdc-8-24-revb-d1629664.vrom",  # Display Card 8-24 (JMFB), part 341-0868 Rev B
+    "4f71ff1a": "builtin-se30-video-4f71ff1a.vrom",  # SE/30 onboard video
+    "d8daab87": "display-card-24ac-d8daab87.vrom",  # Display Card 24AC
+    "d722b053": "824gc-v1.1-revb-d722b053.vrom",  # 8-24 GC v1.1, part 341-0266 (16bpp default)
+    "9e9857e8": "824gc-v1.0-reva-9e9857e8.vrom",  # 8-24 GC v1.0 shipping, part 341-0812-02
+    "4740028d": "824gc-v1.0a16-4740028d.vrom",  # 8-24 GC 1.00a16 alpha ("Dolphin")
+}
+
+
+def canonical_name(content_id):
+    """Map a content identity to its canonical fixture basename, or None.
+
+    Accepts the identity in any of the forms the identify surfaces emit:
+    "0xd1629664", "d1629664", or "D1629664".
+    """
+    if not content_id:
+        return None
+    ident = content_id.strip().lower()
+    if ident.startswith("0x"):
+        ident = ident[2:]
+    return CANONICAL_NAMES.get(ident)

--- a/src/core/memory/rom.c
+++ b/src/core/memory/rom.c
@@ -47,18 +47,16 @@ static const char *const MACXL_COMPATIBLE[] = {"macxl", NULL};
 // Dedicated 512 KB Macintosh IIsi ("Erickson") ROM — not the universal ROM.
 static const char *const IISI_COMPATIBLE[] = {"iisi", NULL};
 
-// Master ROM signature table.
+// Master ROM signature table.  Content facts only — the canonical fixture
+// filenames live in tooling (scripts/rom_naming.py), not here.
 static const rom_info_t ROM_TABLE[] = {
-    // Only Rev 3 ("Loud Harmonicas") ships in tests/data; Rev 1/2 are catalogued
-    // for identify but have no canonical file (NULL — the conformance test never
-    // sees them on disk).
-    {"Macintosh Plus (Rev 1, Lonely Hearts)",   PLUS_COMPATIBLE,      0x4D1EEEE1, 128 * 1024, NULL                        },
-    {"Macintosh Plus (Rev 2, Lonely Heifers)",  PLUS_COMPATIBLE,      0x4D1EEAE1, 128 * 1024, NULL                        },
-    {"Macintosh Plus (Rev 3, Loud Harmonicas)", PLUS_COMPATIBLE,      0x4D1F8172, 128 * 1024, "plus-v3-4d1f8172.rom"      },
-    {"Universal IIx/IIcx/SE/30 ROM",            UNIVERSAL_COMPATIBLE, 0x97221136, 256 * 1024, "iix-iicx-se30-97221136.rom"},
-    {"Macintosh IIfx ROM",                      IIFX_COMPATIBLE,      0x4147DD77, 512 * 1024, "iifx-4147dd77.rom"         },
-    {"Macintosh IIci ROM",                      IICI_COMPATIBLE,      0x368CADFE, 512 * 1024, "iici-368cadfe.rom"         },
-    {"Macintosh IIsi ROM",                      IISI_COMPATIBLE,      0x36B7FB6C, 512 * 1024, "iisi-36b7fb6c.rom"         },
+    {"Macintosh Plus (Rev 1, Lonely Hearts)",   PLUS_COMPATIBLE,      0x4D1EEEE1, 128 * 1024},
+    {"Macintosh Plus (Rev 2, Lonely Heifers)",  PLUS_COMPATIBLE,      0x4D1EEAE1, 128 * 1024},
+    {"Macintosh Plus (Rev 3, Loud Harmonicas)", PLUS_COMPATIBLE,      0x4D1F8172, 128 * 1024},
+    {"Universal IIx/IIcx/SE/30 ROM",            UNIVERSAL_COMPATIBLE, 0x97221136, 256 * 1024},
+    {"Macintosh IIfx ROM",                      IIFX_COMPATIBLE,      0x4147DD77, 512 * 1024},
+    {"Macintosh IIci ROM",                      IICI_COMPATIBLE,      0x368CADFE, 512 * 1024},
+    {"Macintosh IIsi ROM",                      IISI_COMPATIBLE,      0x36B7FB6C, 512 * 1024},
 };
 
 #define ROM_TABLE_COUNT (sizeof(ROM_TABLE) / sizeof(ROM_TABLE[0]))
@@ -82,8 +80,8 @@ typedef struct lisa_rom_sig {
 } lisa_rom_sig_t;
 
 static const lisa_rom_sig_t LISA_ROM_TABLE[] = {
-    {{"Apple Lisa 2 Boot ROM (rev H)", LISA_COMPATIBLE, 0x098917B2, LISA_ROM_SIZE, "lisa2-revh-098917b2.rom"}, 0x0248},
-    {{"Macintosh XL Boot ROM (\"3A\")", MACXL_COMPATIBLE, 0x094C82F0, LISA_ROM_SIZE, "macxl-3a-094c82f0.rom"}, 0x0341},
+    {{"Apple Lisa 2 Boot ROM (rev H)", LISA_COMPATIBLE, 0x098917B2, LISA_ROM_SIZE},   0x0248},
+    {{"Macintosh XL Boot ROM (\"3A\")", MACXL_COMPATIBLE, 0x094C82F0, LISA_ROM_SIZE}, 0x0341},
 };
 
 #define LISA_ROM_TABLE_COUNT (sizeof(LISA_ROM_TABLE) / sizeof(LISA_ROM_TABLE[0]))
@@ -535,12 +533,12 @@ static value_t rom_method_reload(struct object *self, const member_t *m, int arg
 }
 
 // rom.identify(path) → JSON-encoded info map describing the ROM file:
-//   { recognised, compatible, checksum, name, canonical_name, size }
-// recognised==false implies compatible==[], name=="", canonical_name=="" but
-// the checksum and size are still populated from the file.  canonical_name is
-// the enforced on-disk filename (proposal-test-rom-naming.md), empty for ROMs
-// that are recognised but don't ship in tests/data.  Returns V_ERROR if the
-// path can not be opened (caller treats that as "no info, skip this entry").
+//   { recognised, compatible, checksum, name, size }
+// recognised==false implies compatible==[], name=="" but the checksum and
+// size are still populated from the file.  Content facts only — canonical
+// fixture naming is a tooling concern (scripts/rom_naming.py).  Returns
+// V_ERROR if the path can not be opened (caller treats that as "no info,
+// skip this entry").
 static value_t rom_method_identify(struct object *self, const member_t *m, int argc, const value_t *argv) {
     (void)self;
     (void)m;
@@ -569,12 +567,6 @@ static value_t rom_method_identify(struct object *self, const member_t *m, int a
     json_str(b, hex);
     json_key(b, "name");
     json_str(b, fi.info ? fi.info->family_name : "");
-    // Canonical on-disk filename (proposal-test-rom-naming.md). Present and
-    // non-empty only for recognised ROMs that actually ship in tests/data;
-    // empty otherwise. The rom-naming conformance test asserts every file's
-    // basename equals this. Mirrors vrom.identify's canonical_name.
-    json_key(b, "canonical_name");
-    json_str(b, (fi.info && fi.info->canonical_name) ? fi.info->canonical_name : "");
     json_key(b, "size");
     json_int(b, (int64_t)fi.size);
     json_close_obj(b);

--- a/src/core/memory/rom.h
+++ b/src/core/memory/rom.h
@@ -28,11 +28,9 @@ typedef struct rom_info {
     const char *const *compatible; // NULL-terminated list of compatible model_ids
     uint32_t checksum; // Stored checksum (first 4 bytes, big-endian)
     uint32_t rom_size; // Expected file size in bytes
-    // Canonical on-disk filename in tests/data/roms, derived from this row per
-    // proposal-test-rom-naming.md (<targets>[-<rev>]-<checksum8>.rom). The
-    // load-bearing single source of truth for what the file MUST be named;
-    // rom.identify reports it and the rom-naming conformance test enforces it.
-    const char *canonical_name;
+    // Note: canonical fixture filenames are a tooling concern (scripts/
+    // rom_naming.py maps content identity → name for the gs-test-data repo);
+    // core reasons only in content identities and never knows a filename.
 } rom_info_t;
 
 // Look up a ROM by its stored checksum.

--- a/src/core/memory/vrom.c
+++ b/src/core/memory/vrom.c
@@ -2,16 +2,19 @@
 // Copyright (c) pappadf
 
 // vrom.c
-// VROM file handling and the vrom.* object-model surface.
+// VROM content identification, the pre-boot offer registry, and the vrom.*
+// object-model surface.
 //
-// VROM is a 32 KB blob the SE/30 needs alongside the main ROM. Because the
-// main ROM is only loaded after machine creation and the VROM has to be
-// available during machine init, the design is: vrom.load(path) just
-// records a pending path; se30 init reads pending_path() and loads bytes
-// directly into video RAM.
+// A vROM is a NuBus declaration-ROM chip image (32 KB, or 64 KB for some
+// revisions) identified purely by its Format-Block CRC.  The platform offers
+// candidate files (vrom_offer) before machine.boot; the card factories match
+// among the offers by content (vrom_offer_find via declrom_load_vrom_card).
+// Core never fabricates a path and never interprets a filename — a path is
+// only ever an opaque handle used to open the file.
 
 #include "vrom.h"
 
+#include "log.h"
 #include "machine_profile.h"
 #include "object.h"
 #include "value.h"
@@ -20,6 +23,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+
+LOG_USE_CATEGORY_NAME("vrom");
 
 // ============================================================================
 // File-level helpers
@@ -41,8 +46,253 @@ bool vrom_probe_file(const char *path, size_t *out_size) {
     return size == VROM_EXPECTED_SIZE;
 }
 
+// NuBus declaration-ROM Format Block CRC.  Every declaration ROM — the
+// genuine cards and the "fake" SE/30 onboard-video ROM alike — carries a
+// 20-byte Format Block at the top of the dense chip image; its 4-byte CRC
+// (preceded by the `$5A932BC7` TestPattern) is the intrinsic, Slot-Manager-
+// validated checksum.  See docs/core/peripherals/nubus_vrom.md §2.  We read
+// it as identity, the direct analog of rom.c keying on the main ROM's
+// checksum word — no emulator-invented hash.  Field offsets from EOF of the
+// dense chip (high address = end), per §2 / §12:
+//   buf[size-1]        ByteLanes
+//   buf[size-2]        Reserved
+//   buf[size-6..size-3] TestPattern (big-endian $5A 93 2B C7)
+//   buf[size-12..size-9] CRC (big-endian)
+#define VROM_TESTPATTERN_OFF 6 // bytes from EOF to the first TestPattern byte
+#define VROM_CRC_OFF         12 // bytes from EOF to the first (MSB) CRC byte
+
+static uint32_t vrom_be32(const uint8_t *p) {
+    return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) | ((uint32_t)p[2] << 8) | (uint32_t)p[3];
+}
+
+// Catalog of known VROM blobs.  Maps the declaration ROM's Format-Block CRC
+// to the nubus card-kind id the blob provides — content→hardware facts only,
+// no filenames (canonical fixture naming is a tooling concern; see
+// scripts/rom_naming.py).  The id is the machine-readable link a UI uses to
+// pick the card (machine.nubus.video_card); the human label is owned by the
+// card kind (nubus_card_find(id)->display_name) so it never drifts.  The
+// `preferred` bit marks the default revision when one card has several ROMs.
+// Adding a new VROM = one row here.  Keyed exactly like rom.c's ROM_TABLE
+// {checksum -> ...}.
+struct vrom_known {
+    uint32_t crc;
+    size_t chip_size; // dense chip image size on disk
+    const char *card_id;
+    bool preferred; // default pick among several revisions of one card
+};
+static const struct vrom_known VROM_CATALOG[] = {
+    // Macintosh Display Card 8•24 (ROM rev 341-0868, "Rev B"). Drives the JMFB
+    // NuBus card (id "mdc_8_24") on IIcx / IIx / IIfx; loaded by jmfb.c.
+    {0xD1629664u, 0x08000, "mdc_8_24",           true },
+    // SE/30 onboard video declaration ROM (byteLanes $0F, 4-lane); loaded
+    // by builtin_se30_video.c (id "builtin_se30_video").
+    {0x4F71FF1Au, 0x08000, "builtin_se30_video", true },
+    // Apple Macintosh Display Card 24AC (id "display_card_24ac").
+    {0xD8DAAB87u, 0x08000, "display_card_24ac",  true },
+    // Apple Macintosh Display Card 8•24 GC ("Dolphin", id "824gc"): the
+    // accelerated card.  Its declaration ROMs are byteLanes $E1 (byte lane 0);
+    // v1.1 is a 64 KB chip, v1.0 / the alpha are 32 KB.  All three carry the
+    // same $5A932BC7 TestPattern, so they identify by Format-Block CRC.
+    {0xD722B053u, 0x10000, "824gc",              true }, // part 341-0266, v1.1 (default; 16bpp)
+    {0x9E9857E8u, 0x08000, "824gc",              false}, // part 341-0812-02, v1.0 (shipping)
+    {0x4740028Du, 0x08000, "824gc",              false}, // "Dolphin" 1.00a16 alpha
+};
+
+#define VROM_CATALOG_COUNT (sizeof(VROM_CATALOG) / sizeof(VROM_CATALOG[0]))
+
+// Content-identification core shared by vrom.identify, the offer registry,
+// and the card factories' loader (declrom_load_vrom_card).  Reads the file's
+// trailing Format Block, gates on the $5A932BC7 TestPattern, and looks the
+// CRC up in the catalog.  Result codes let vrom.identify keep its
+// error/unrecognised distinction.
+enum vrom_id_result {
+    VROM_ID_UNREADABLE, // stat/open/read failed
+    VROM_ID_WRONG_SIZE, // exists, but not a chip-sized blob
+    VROM_ID_UNKNOWN, // right size; *out_crc valid; not a catalog entry (or no TestPattern)
+    VROM_ID_KNOWN, // recognised: *out filled from the catalog row
+};
+static enum vrom_id_result vrom_identify_core(const char *path, vrom_id_t *out, size_t *out_size, uint32_t *out_crc) {
+    size_t size = 0;
+    vrom_probe_file(path, &size); // fills *size regardless of the 32 KB gate
+    if (out_size)
+        *out_size = size;
+    // vrom_probe_file leaves size == 0 only when stat failed (missing /
+    // unreadable).
+    if (size == 0)
+        return VROM_ID_UNREADABLE;
+    // Declaration-ROM chips come in two sizes: 32 KB (SE/30, JMFB, 24AC, the
+    // 8•24 GC v1.0 / alpha) and 64 KB (the 8•24 GC v1.1).  The Format Block +
+    // CRC live in the trailing bytes either way, so accept both.
+    if (size != VROM_EXPECTED_SIZE && size != 2u * VROM_EXPECTED_SIZE)
+        return VROM_ID_WRONG_SIZE;
+
+    FILE *f = fopen(path, "rb");
+    if (!f)
+        return VROM_ID_UNREADABLE;
+    // Only the trailing Format Block matters for identity.
+    uint8_t tail[VROM_CRC_OFF];
+    if (fseek(f, (long)(size - sizeof(tail)), SEEK_SET) != 0 || fread(tail, 1, sizeof(tail), f) != sizeof(tail)) {
+        fclose(f);
+        return VROM_ID_UNREADABLE;
+    }
+    fclose(f);
+
+    // Gate on the TestPattern: a right-sized blob without `$5A932BC7` in the
+    // Format Block is not a declaration ROM (don't trust a stray CRC match).
+    const uint8_t *tp = tail + sizeof(tail) - VROM_TESTPATTERN_OFF;
+    bool is_declrom = tp[0] == 0x5Au && tp[1] == 0x93u && tp[2] == 0x2Bu && tp[3] == 0xC7u;
+    uint32_t crc = vrom_be32(tail);
+    if (out_crc)
+        *out_crc = crc;
+    if (!is_declrom)
+        return VROM_ID_UNKNOWN;
+    for (size_t i = 0; i < VROM_CATALOG_COUNT; i++) {
+        if (VROM_CATALOG[i].crc == crc) {
+            if (out) {
+                out->crc = crc;
+                out->chip_size = size;
+                out->card_id = VROM_CATALOG[i].card_id;
+            }
+            return VROM_ID_KNOWN;
+        }
+    }
+    return VROM_ID_UNKNOWN;
+}
+
+bool vrom_identify_card(const char *path, vrom_id_t *out) {
+    if (!path || !*path)
+        return false;
+    return vrom_identify_core(path, out, NULL, NULL) == VROM_ID_KNOWN;
+}
+
 // ============================================================================
-// Pending-path tracking
+// Offer registry
+// ============================================================================
+
+// One registered candidate: a recognised file the platform offered, keyed by
+// its content identity.  The direct analog of the old single pending-path
+// static, generalised to N entries.
+struct vrom_offer_entry {
+    uint32_t crc; // content identity (registry key)
+    size_t chip_size; // actual file size (32 KB or 64 KB)
+    const char *card_id; // catalog card-kind id (static storage)
+    char *path; // opaque locator (owned)
+    bool explicit_pick; // set by vrom.load — wins the pick order
+};
+
+static struct vrom_offer_entry *s_offers = NULL;
+static size_t s_offer_count = 0;
+static size_t s_offer_cap = 0;
+
+// Register one candidate.  `explicit_pick` marks the vrom.load offer, which
+// takes priority in vrom_offer_find (at most one entry carries the flag).
+static void vrom_offer_add(const char *path, bool explicit_pick) {
+    if (!path || !*path)
+        return;
+    vrom_id_t id;
+    if (!vrom_identify_card(path, &id)) {
+        // Not a recognised declaration ROM — drop it quietly (the platform
+        // offers whole directories; strays are expected, not errors).
+        LOG(2, "vrom_offer: '%s' is not a recognised declaration ROM — ignored", path);
+        return;
+    }
+    // Idempotent by content: one entry per CRC.  A re-offer refreshes the
+    // path (the newest locator for these bytes) and may promote to explicit.
+    struct vrom_offer_entry *e = NULL;
+    for (size_t i = 0; i < s_offer_count; i++) {
+        if (s_offers[i].crc == id.crc) {
+            e = &s_offers[i];
+            break;
+        }
+    }
+    if (!e) {
+        if (s_offer_count == s_offer_cap) {
+            size_t cap = s_offer_cap ? s_offer_cap * 2 : 8;
+            struct vrom_offer_entry *grown = realloc(s_offers, cap * sizeof(*grown));
+            if (!grown)
+                return;
+            s_offers = grown;
+            s_offer_cap = cap;
+        }
+        e = &s_offers[s_offer_count];
+        memset(e, 0, sizeof(*e));
+        s_offer_count++;
+    }
+    char *dup = strdup(path);
+    if (!dup) {
+        // Fresh entry with no path is useless — roll the append back.
+        if (!e->path)
+            s_offer_count--;
+        return;
+    }
+    free(e->path);
+    e->path = dup;
+    e->crc = id.crc;
+    e->chip_size = id.chip_size;
+    e->card_id = id.card_id;
+    if (explicit_pick) {
+        // Only one explicit pick at a time — latest vrom.load wins.
+        for (size_t i = 0; i < s_offer_count; i++)
+            s_offers[i].explicit_pick = false;
+        e->explicit_pick = true;
+    }
+    LOG(2, "vrom_offer: '%s' provides card '%s' (crc 0x%08x)%s", path, e->card_id, e->crc,
+        explicit_pick ? " [explicit]" : "");
+}
+
+void vrom_offer(const char *path) {
+    vrom_offer_add(path, false);
+}
+
+void vrom_offer_clear(void) {
+    for (size_t i = 0; i < s_offer_count; i++)
+        free(s_offers[i].path);
+    free(s_offers);
+    s_offers = NULL;
+    s_offer_count = 0;
+    s_offer_cap = 0;
+}
+
+const char *vrom_offer_find(const char *card_id, int idx, size_t *out_chip_size) {
+    if (!card_id)
+        return NULL;
+    // Pick order: the explicit vrom.load offer first, then catalog rows with
+    // the `preferred` bit, then the remaining catalog rows in order.  All
+    // content-based — no filename ever enters the comparison.
+    // Pass 0: the explicit pick (at most one entry carries the flag).
+    for (size_t i = 0; i < s_offer_count; i++) {
+        if (!s_offers[i].explicit_pick || strcmp(s_offers[i].card_id, card_id) != 0)
+            continue;
+        if (idx-- == 0) {
+            if (out_chip_size)
+                *out_chip_size = s_offers[i].chip_size;
+            return s_offers[i].path;
+        }
+    }
+    // Passes 1..2: catalog order, preferred rows first.  One offer per CRC
+    // (registry invariant), so each row yields at most one candidate.
+    for (int want_preferred = 1; want_preferred >= 0; want_preferred--) {
+        for (size_t r = 0; r < VROM_CATALOG_COUNT; r++) {
+            if (VROM_CATALOG[r].preferred != (bool)want_preferred)
+                continue;
+            if (strcmp(VROM_CATALOG[r].card_id, card_id) != 0)
+                continue;
+            for (size_t i = 0; i < s_offer_count; i++) {
+                if (s_offers[i].crc != VROM_CATALOG[r].crc || s_offers[i].explicit_pick)
+                    continue; // explicit entry was already yielded in pass 0
+                if (idx-- == 0) {
+                    if (out_chip_size)
+                        *out_chip_size = s_offers[i].chip_size;
+                    return s_offers[i].path;
+                }
+            }
+        }
+    }
+    return NULL;
+}
+
+// ============================================================================
+// Explicit pick (vrom.load)
 // ============================================================================
 
 static char *s_pending_vrom_path = NULL;
@@ -57,8 +307,10 @@ int vrom_set_path(const char *path) {
         return -1;
     free(s_pending_vrom_path);
     s_pending_vrom_path = dup;
-    // Note: no log line here on success — the path is just stashed for later
-    // consumption by machine init; the user gets `true` back from vrom.load().
+    // vrom.load is sugar for "offer + preferred pick": register the file so
+    // the next machine init matches it by content.  An unrecognised file is
+    // recorded for the vrom.path echo but never matched (offer drops it).
+    vrom_offer_add(path, true);
     return 0;
 }
 
@@ -103,158 +355,36 @@ static value_t vrom_method_load(struct object *self, const member_t *m, int argc
     return val_bool(true);
 }
 
-// NuBus declaration-ROM Format Block CRC.  Every declaration ROM — the
-// genuine cards and the "fake" SE/30 onboard-video ROM alike — carries a
-// 20-byte Format Block at the top of the dense chip image; its 4-byte CRC
-// (preceded by the `$5A932BC7` TestPattern) is the intrinsic, Slot-Manager-
-// validated checksum.  See docs/core/peripherals/nubus_vrom.md §2.  We read
-// it as identity, the direct analog of rom.c keying on the main ROM's
-// checksum word — no emulator-invented hash.  Field offsets from EOF of the
-// dense chip (high address = end), per §2 / §12:
-//   buf[size-1]        ByteLanes
-//   buf[size-2]        Reserved
-//   buf[size-6..size-3] TestPattern (big-endian $5A 93 2B C7)
-//   buf[size-12..size-9] CRC (big-endian)
-#define VROM_TESTPATTERN_OFF 6 // bytes from EOF to the first TestPattern byte
-#define VROM_CRC_OFF         12 // bytes from EOF to the first (MSB) CRC byte
-
-static uint32_t vrom_be32(const uint8_t *p) {
-    return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) | ((uint32_t)p[2] << 8) | (uint32_t)p[3];
+// vrom.offer(path) — platform/UI hook into the offer registry, e.g. web2's
+// upload ingest offering a freshly stored file so an "(auto)" boot sees it
+// without a page reload.  Returns true iff the file was recognised and
+// registered; false is "not a vROM", not an error.
+static value_t vrom_method_offer(struct object *self, const member_t *m, int argc, const value_t *argv) {
+    (void)self;
+    (void)m;
+    (void)argc;
+    vrom_id_t id;
+    bool recognised = vrom_identify_card(argv[0].s, &id);
+    if (recognised)
+        vrom_offer(argv[0].s);
+    return val_bool(recognised);
 }
 
-// Catalog of known VROM blobs.  Maps the declaration ROM's Format-Block CRC
-// to the canonical on-disk filename the C-side card factories search for
-// (declrom_load_vrom_card / builtin_se30_video both take the filename from
-// vrom_catalog_name — no card hardcodes it) and the nubus card-kind id the
-// blob provides.  The id is the machine-readable link a UI uses to pick the
-// card (machine.nubus.video_card); the human label is owned by the card kind
-// (nubus_card_find(id)->display_name) so it never drifts.  Adding a new VROM
-// = one row here.  Keyed exactly like rom.c's ROM_TABLE {checksum -> ...}.
-struct vrom_known {
-    uint32_t crc;
-    size_t chip_size; // dense chip image size on disk
-    const char *canonical_name;
-    const char *card_id;
-};
-// Canonical filenames follow proposal-test-rom-naming.md:
-// <card-id>[-<rev>]-<crc8>.vrom, card-id with `_`→`-`. Apple part numbers
-// (341-0868, 341-0266, …) live in the manifest / these comments, not the
-// filename — they identify the chip, not the card. The rom-naming conformance
-// test asserts every tests/data/roms/*.vrom basename equals its row here.
-static const struct vrom_known VROM_CATALOG[] = {
-    // Macintosh Display Card 8•24 (ROM rev 341-0868, "Rev B"). Drives the JMFB
-    // NuBus card (id "mdc_8_24") on IIcx / IIx / IIfx; loaded by jmfb.c.
-    {0xD1629664u, 0x08000, "mdc-8-24-revb-d1629664.vrom",      "mdc_8_24"          },
-    // SE/30 onboard video declaration ROM (byteLanes $0F, 4-lane); loaded
-    // by builtin_se30_video.c (id "builtin_se30_video").
-    {0x4F71FF1Au, 0x08000, "builtin-se30-video-4f71ff1a.vrom", "builtin_se30_video"},
-    // Apple Macintosh Display Card 24AC (id "display_card_24ac").
-    {0xD8DAAB87u, 0x08000, "display-card-24ac-d8daab87.vrom",  "display_card_24ac" },
-    // Apple Macintosh Display Card 8•24 GC ("Dolphin", id "824gc"): the
-    // accelerated card.  Its declaration ROMs are byteLanes $E1 (byte lane 0);
-    // v1.1 is a 64 KB chip, v1.0 / the alpha are 32 KB.  All three carry the
-    // same $5A932BC7 TestPattern, so they identify by Format-Block CRC.
-    {0xD722B053u, 0x10000, "824gc-v1.1-revb-d722b053.vrom",    "824gc"             }, // part 341-0266, v1.1 (default; 16bpp)
-    {0x9E9857E8u, 0x08000, "824gc-v1.0-reva-9e9857e8.vrom",    "824gc"             }, // part 341-0812-02, v1.0 (shipping)
-    {0x4740028Du, 0x08000, "824gc-v1.0a16-4740028d.vrom",      "824gc"             }, // "Dolphin" 1.00a16 alpha
-};
-
-// Content-identification core shared by vrom.identify and the card factories'
-// loader (declrom_load_vrom_card).  Reads the file's trailing Format Block,
-// gates on the $5A932BC7 TestPattern, and looks the CRC up in the catalog.
-// Result codes let vrom.identify keep its error/unrecognised distinction.
-enum vrom_id_result {
-    VROM_ID_UNREADABLE, // stat/open/read failed
-    VROM_ID_WRONG_SIZE, // exists, but not a chip-sized blob
-    VROM_ID_UNKNOWN, // right size; *out_crc valid; not a catalog entry (or no TestPattern)
-    VROM_ID_KNOWN, // recognised: *out filled from the catalog row
-};
-static enum vrom_id_result vrom_identify_core(const char *path, vrom_id_t *out, size_t *out_size, uint32_t *out_crc) {
-    size_t size = 0;
-    vrom_probe_file(path, &size); // fills *size regardless of SE/30's 32 KB gate
-    if (out_size)
-        *out_size = size;
-    // vrom_probe_file leaves size == 0 only when stat failed (missing /
-    // unreadable).
-    if (size == 0)
-        return VROM_ID_UNREADABLE;
-    // Declaration-ROM chips come in two sizes: 32 KB (SE/30, JMFB, 24AC, the
-    // 8•24 GC v1.0 / alpha) and 64 KB (the 8•24 GC v1.1).  The Format Block +
-    // CRC live in the trailing bytes either way, so accept both.
-    if (size != VROM_EXPECTED_SIZE && size != 2u * VROM_EXPECTED_SIZE)
-        return VROM_ID_WRONG_SIZE;
-
-    FILE *f = fopen(path, "rb");
-    if (!f)
-        return VROM_ID_UNREADABLE;
-    // Only the trailing Format Block matters for identity.
-    uint8_t tail[VROM_CRC_OFF];
-    if (fseek(f, (long)(size - sizeof(tail)), SEEK_SET) != 0 || fread(tail, 1, sizeof(tail), f) != sizeof(tail)) {
-        fclose(f);
-        return VROM_ID_UNREADABLE;
-    }
-    fclose(f);
-
-    // Gate on the TestPattern: a right-sized blob without `$5A932BC7` in the
-    // Format Block is not a declaration ROM (don't trust a stray CRC match).
-    const uint8_t *tp = tail + sizeof(tail) - VROM_TESTPATTERN_OFF;
-    bool is_declrom = tp[0] == 0x5Au && tp[1] == 0x93u && tp[2] == 0x2Bu && tp[3] == 0xC7u;
-    uint32_t crc = vrom_be32(tail);
-    if (out_crc)
-        *out_crc = crc;
-    if (!is_declrom)
-        return VROM_ID_UNKNOWN;
-    for (size_t i = 0; i < sizeof(VROM_CATALOG) / sizeof(VROM_CATALOG[0]); i++) {
-        if (VROM_CATALOG[i].crc == crc) {
-            if (out) {
-                out->crc = crc;
-                out->chip_size = size;
-                out->canonical_name = VROM_CATALOG[i].canonical_name;
-                out->card_id = VROM_CATALOG[i].card_id;
-            }
-            return VROM_ID_KNOWN;
-        }
-    }
-    return VROM_ID_UNKNOWN;
-}
-
-bool vrom_identify_card(const char *path, vrom_id_t *out) {
-    if (!path || !*path)
-        return false;
-    return vrom_identify_core(path, out, NULL, NULL) == VROM_ID_KNOWN;
-}
-
-const char *vrom_catalog_name(const char *card_id, int idx, size_t *out_chip_size) {
-    if (!card_id)
-        return NULL;
-    for (size_t i = 0; i < sizeof(VROM_CATALOG) / sizeof(VROM_CATALOG[0]); i++) {
-        if (strcmp(VROM_CATALOG[i].card_id, card_id) != 0)
-            continue;
-        if (idx-- > 0)
-            continue;
-        if (out_chip_size)
-            *out_chip_size = VROM_CATALOG[i].chip_size;
-        return VROM_CATALOG[i].canonical_name;
-    }
-    return NULL;
-}
-
-// vrom.identify(path) — returns a JSON map describing the file, keyed off
-// the declaration ROM's Format-Block CRC:
+// vrom.identify(path) — returns a JSON map of content facts describing the
+// file, keyed off the declaration ROM's Format-Block CRC:
 //   {
 //     "recognised":     bool,
-//     "canonical_name": "display-card-24ac-d8daab87.vrom",     // present when recognised
-//     "card_id":        "display_card_24ac",          // nubus card-kind id
-//     "compatible":     ["display_card_24ac"],         // card ids this blob can drive
+//     "card_id":        "display_card_24ac",     // nubus card-kind id
+//     "compatible":     ["display_card_24ac"],   // card ids this blob can drive
 //     "size":           32768,
 //     "crc":            "0xd8daab87"
 //   }
 // `compatible` mirrors rom.identify's `compatible:[model_ids]` shape (a list,
-// usually length 1).  JS callers use canonical_name to persist the file under
-// a stable, human-meaningful name, and card_id / compatible to pick the card;
-// the human-readable name comes from machine.profile, not here.  (The card
-// factories load by CONTENT — declrom_load_vrom_card — so the canonical name
-// is a convention, not a requirement.)
+// usually length 1).  JS callers use crc to persist the file under a stable
+// content-addressed name, and card_id / compatible to pick the card; the
+// human-readable name comes from machine.profile, not here.  (The card
+// factories load by CONTENT — declrom_load_vrom_card — so the on-disk name
+// never matters.)
 static value_t vrom_method_identify(struct object *self, const member_t *m, int argc, const value_t *argv) {
     (void)self;
     (void)m;
@@ -274,9 +404,9 @@ static value_t vrom_method_identify(struct object *self, const member_t *m, int 
     case VROM_ID_KNOWN: {
         char out[256];
         snprintf(out, sizeof(out),
-                 "{\"recognised\":true,\"canonical_name\":\"%s\",\"card_id\":\"%s\",\"compatible\":[\"%s\"],"
+                 "{\"recognised\":true,\"card_id\":\"%s\",\"compatible\":[\"%s\"],"
                  "\"size\":%zu,\"crc\":\"0x%08x\"}",
-                 id.canonical_name, id.card_id, id.card_id, size, crc);
+                 id.card_id, id.card_id, size, crc);
         return val_str(out);
     }
     case VROM_ID_UNKNOWN:
@@ -313,11 +443,15 @@ static const member_t vrom_members[] = {
      .attr = {.type = V_UINT, .get = vrom_attr_size, .set = NULL}},
     {.kind = M_METHOD,
      .name = "load",
-     .doc = "Set the VROM path; consumed at the next machine init",
+     .doc = "Offer the VROM at path and make it the preferred pick at the next machine init",
      .method = {.args = vrom_path_arg, .nargs = 1, .result = V_BOOL, .fn = vrom_method_load}},
     {.kind = M_METHOD,
+     .name = "offer",
+     .doc = "Offer a candidate VROM file; true iff recognised and registered",
+     .method = {.args = vrom_path_arg, .nargs = 1, .result = V_BOOL, .fn = vrom_method_offer}},
+    {.kind = M_METHOD,
      .name = "identify",
-     .doc = "JSON map: {recognised, canonical_name?, card_id?, compatible?, size, crc}.",
+     .doc = "JSON map: {recognised, card_id?, compatible?, size, crc}.",
      .method = {.args = vrom_path_arg, .nargs = 1, .result = V_STRING, .fn = vrom_method_identify}},
 };
 
@@ -351,4 +485,5 @@ void vrom_delete(void) {
         s_vrom_object = NULL;
     }
     vrom_pending_clear();
+    vrom_offer_clear();
 }

--- a/src/core/memory/vrom.h
+++ b/src/core/memory/vrom.h
@@ -2,10 +2,13 @@
 // Copyright (c) pappadf
 
 // vrom.h
-// VROM handling for machines with discrete VROM (currently SE/30 only).
-// The user picks the path via vrom.load(path); the actual blit into video
-// memory happens during machine init (machines/se30.c::se30_load_vrom),
-// which calls vrom_pending_path() to retrieve the path.
+// VROM (NuBus declaration-ROM) handling: content identification plus the
+// pre-boot offer registry.  A path is a HANDLE, not a fact: core may open a
+// path it was handed and identify the bytes, but it never fabricates a path
+// or interprets a filename.  The platform — which owns the filesystem —
+// enumerates candidate files and *offers* them via vrom_offer(); the card
+// factories then match, by content, among the offered candidates
+// (declrom_load_vrom_card).  See proposal-content-addressed-rom-provisioning.md.
 
 #ifndef VROM_H
 #define VROM_H
@@ -17,18 +20,18 @@
 struct class_desc;
 struct object;
 
-// VROM is a fixed 32 KB image for the SE/30. A file passes the probe if
-// it has the right size; we do not validate content beyond that.
+// The common declaration-ROM chip size (32 KB); some revisions are 64 KB
+// (2 * VROM_EXPECTED_SIZE) — vrom_identify_card accepts both.
 #define VROM_EXPECTED_SIZE (32 * 1024)
 
-// True if a file at `path` is the right size to be a VROM image. *out_size
+// True if a file at `path` is the common 32 KB chip size. *out_size
 // (if non-NULL) gets the file size regardless of validity.
 bool vrom_probe_file(const char *path, size_t *out_size);
 
 // === Content-based identification (the declaration-ROM catalog) ============
 //
 // Identity is the NuBus Format-Block CRC of the chip image — the same key
-// vrom.identify exposes to the UI.  Filenames are only ever hints; these
+// vrom.identify exposes to the UI.  Filenames are never inspected; these
 // helpers let the card factories load whatever file actually provides their
 // card, wherever the user put it (see declrom_load_vrom_card).
 
@@ -36,7 +39,6 @@ bool vrom_probe_file(const char *path, size_t *out_size);
 typedef struct {
     uint32_t crc; // Format-Block CRC (big-endian, as stored)
     size_t chip_size; // dense chip image size (32 KB or 64 KB today)
-    const char *canonical_name; // catalog filename (static storage)
     const char *card_id; // nubus card-kind id the blob provides (static)
 } vrom_id_t;
 
@@ -45,27 +47,48 @@ typedef struct {
 // *out.  False for anything else (missing, wrong size, unknown CRC).
 bool vrom_identify_card(const char *path, vrom_id_t *out);
 
-// Enumerate the catalog's canonical filenames for a card id: returns the
-// idx'th matching row's canonical_name (and its chip size via *out_chip_size,
-// optional), or NULL when exhausted.  idx counts matches, not catalog rows.
-const char *vrom_catalog_name(const char *card_id, int idx, size_t *out_chip_size);
+// === The offer registry =====================================================
+//
+// The platform hands core candidate vROM files before machine.boot.  Core
+// opens each, identifies it by content, and remembers recognised ones keyed
+// by their content identity (Format-Block CRC).  It NEVER enumerates a
+// directory or builds a path.  `path` is opaque: used to open the file and
+// stored for round-trip reporting.  Unrecognised offers are dropped (with a
+// debug log), not errors.  Offers persist across machine.boot; the registry
+// is process-lifetime state torn down by vrom_offer_clear()/vrom_delete().
 
-// Set the pending VROM path. Takes effect at the next machine init.
-// Returns 0 on success, -1 on OOM.
+// Add one candidate (idempotent by content).
+void vrom_offer(const char *path);
+
+// Drop every registered offer (teardown).
+void vrom_offer_clear(void);
+
+// Enumerate the offered candidates that provide the card `card_id`, in pick
+// order: the explicit vrom.load offer first, then catalog `preferred` rows,
+// then remaining catalog order.  Returns the idx'th candidate's path
+// (borrowed; valid until the registry changes) and its chip size via
+// *out_chip_size (optional), or NULL when exhausted.
+const char *vrom_offer_find(const char *card_id, int idx, size_t *out_chip_size);
+
+// Set the explicit vROM pick (vrom.load): an offer that is also the
+// *preferred* candidate for whichever card its content provides.  Also
+// recorded verbatim for the vrom.path attribute.  Returns 0 on success,
+// -1 on an empty path / OOM.
 int vrom_set_path(const char *path);
 
-// Path most recently set by vrom_set_path(), or NULL if none.
-// Consumed by se30_load_vrom() during SE/30 machine init.
+// Path most recently set by vrom_set_path(), or NULL if none.  Echo-back
+// for the vrom.path / vrom.loaded attributes only — discovery goes through
+// the offer registry.
 const char *vrom_pending_path(void);
 
-// Clear the pending path (called from system_destroy).
+// Clear the explicit pick (called from vrom_delete).
 void vrom_pending_clear(void);
 
 // === Lifecycle =============================================================
 //
 // vrom_init() creates the singleton `vrom` object node and attaches it under
-// the root; vrom_delete() detaches/frees it and clears the pending path.
-// Both are idempotent. Called from system_create / system_destroy.
+// the root; vrom_delete() detaches/frees it and clears the pending path and
+// the offer registry.  Both are idempotent.
 extern const struct class_desc vrom_class;
 
 void vrom_init(void);

--- a/src/core/peripherals/nubus/cards/display_card_824gc.c
+++ b/src/core/peripherals/nubus/cards/display_card_824gc.c
@@ -1102,8 +1102,8 @@ static int card_init(nubus_card_t *card, config_t *cfg, checkpoint_t *cp) {
     }
 
     if (!load_vrom(p))
-        LOG(0, "no 8•24 GC declaration ROM found (machine.vrom.load a GC vROM, "
-               "or place one under /opfs/images/vrom/ or tests/data/roms/); "
+        LOG(0, "no 8•24 GC declaration ROM offered (machine.vrom.load a GC vROM, "
+               "or make one available where the platform offers vROM files); "
                "declaration ROM is zero-filled");
 
     card->declrom = p->vrom;

--- a/src/core/peripherals/nubus/declrom.c
+++ b/src/core/peripherals/nubus/declrom.c
@@ -13,8 +13,7 @@
 #include "declrom.h"
 #include "card.h"
 #include "log.h"
-#include "rom.h" // rom_pending_path() — sibling-vrom search
-#include "vrom.h" // content identification (Format-Block CRC catalog)
+#include "vrom.h" // content identification + the platform-fed offer registry
 
 #include <stdint.h>
 #include <stdio.h>
@@ -184,7 +183,7 @@ static bool read_chip_exact(const char *path, uint8_t *buf, size_t chip_size) {
 // for a 64 KB one (the 8•24 GC v1.0 in the v1.1-sized window) occupies the
 // top half; the leading bytes stay zero, below the ROM's declared length.
 static bool load_chip_into_bus(const char *path, size_t chip_size, uint8_t *bus_buf, size_t bus_size) {
-    if (chip_size == 0 || bus_size < chip_size * 4)
+    if (chip_size == 0 || bus_size < chip_size)
         return false;
     uint8_t *chip = calloc(1, chip_size);
     if (!chip)
@@ -197,10 +196,15 @@ static bool load_chip_into_bus(const char *path, size_t chip_size, uint8_t *bus_
     // 4-lane layouts both the spec and these files place it at the highest
     // active-lane address — the chip's final byte).
     uint8_t byte_lanes = chip[chip_size - 1];
-    size_t footprint = chip_size * 4; // single-lane expansion (the common case)
-    bool ok = declrom_layout_chip(chip, chip_size, bus_buf + (bus_size - footprint), footprint, byte_lanes);
+    // A single-lane chip sparse-expands to 4× its size in bus space; a 4-lane
+    // ($0F) chip is flat-copied and occupies exactly chip_size bytes (the
+    // SE/30 onboard-video ROM, whose window equals the chip size).
+    size_t footprint = (byte_lanes == 0x0Fu) ? chip_size : chip_size * 4;
+    bool ok = bus_size >= footprint &&
+              declrom_layout_chip(chip, chip_size, bus_buf + (bus_size - footprint), footprint, byte_lanes);
     if (!ok)
-        LOG(0, "declrom_load_vrom_card: '%s' has unsupported byteLanes $%02x", path, byte_lanes);
+        LOG(0, "declrom_load_vrom_card: '%s' has unsupported byteLanes $%02x (or exceeds the bus window)", path,
+            byte_lanes);
     free(chip);
     return ok;
 }
@@ -211,78 +215,20 @@ bool declrom_load_vrom_card(const char *card_id, uint8_t *bus_buf, size_t bus_si
     if (!card_id || !bus_buf || bus_size == 0)
         return false;
 
-    // 0. The explicitly loaded vROM (machine.vrom.load <path> — how the web
-    //    UI hands over an uploaded file).  Content-verified: the file must
-    //    identify (Format-Block CRC) to THIS card; the filename is irrelevant.
-    const char *pending = vrom_pending_path();
-    vrom_id_t id;
-    if (pending && vrom_identify_card(pending, &id)) {
-        if (strcmp(id.card_id, card_id) == 0) {
-            if (load_chip_into_bus(pending, id.chip_size, bus_buf, bus_size)) {
-                if (out_path)
-                    *out_path = strdup(pending);
-                return true;
-            }
-        } else {
-            LOG(2, "vrom.load path '%s' provides card '%s', not '%s' — searching instead", pending, id.card_id,
-                card_id);
-        }
-    }
-
-    // 1..4. Search the standard locations for EVERY catalog filename that
-    //    provides this card (a card can have several ROM revisions, with
-    //    different chip sizes — e.g. the 8•24 GC's v1.1/v1.0/alpha), still
-    //    content-verifying each hit before loading it.
-    char path[1024];
+    // Walk the offer registry's candidates for this card in pick order
+    // (explicit vrom.load first, then catalog-preferred, then catalog order —
+    // see vrom_offer_find).  Every candidate was already content-identified
+    // at offer time; the first one that lays out cleanly wins.  Core never
+    // builds a path here — the platform offered every one of these.
+    size_t chip_size = 0;
     for (int n = 0;; n++) {
-        const char *filename = vrom_catalog_name(card_id, n, NULL);
-        if (!filename)
+        const char *path = vrom_offer_find(card_id, n, &chip_size);
+        if (!path)
             break;
-
-        // 1. Next to the pending CPU ROM — the directory the integration-test
-        //    harness cds into, where sibling vrom files live.
-        char *found_path = NULL;
-        const char *rom_path = rom_pending_path();
-        if (rom_path) {
-            const char *slash = strrchr(rom_path, '/');
-            if (slash) {
-                size_t dir_len = (size_t)(slash - rom_path + 1);
-                if (dir_len + strlen(filename) + 1 <= sizeof(path)) {
-                    memcpy(path, rom_path, dir_len);
-                    strcpy(path + dir_len, filename);
-                    if (vrom_identify_card(path, &id) && strcmp(id.card_id, card_id) == 0)
-                        found_path = strdup(path);
-                }
-            }
-        }
-
-        // 2..4. Standard search prefixes, in priority order.
-        static const char *const prefixes[] = {
-            "/opfs/images/vrom/",
-            "tests/data/roms/",
-            "",
-            NULL,
-        };
-        for (const char *const *pre = prefixes; !found_path && *pre; pre++) {
-            if (strlen(*pre) + strlen(filename) + 1 > sizeof(path))
-                continue;
-            strcpy(path, *pre);
-            strcat(path, filename);
-            if (vrom_identify_card(path, &id) && strcmp(id.card_id, card_id) == 0)
-                found_path = strdup(path);
-        }
-
-        if (found_path) {
-            // id was filled by the successful identify; its chip_size is the
-            // actual file size.
-            if (load_chip_into_bus(found_path, id.chip_size, bus_buf, bus_size)) {
-                if (out_path)
-                    *out_path = found_path;
-                else
-                    free(found_path);
-                return true;
-            }
-            free(found_path);
+        if (load_chip_into_bus(path, chip_size, bus_buf, bus_size)) {
+            if (out_path)
+                *out_path = strdup(path);
+            return true;
         }
     }
     return false;

--- a/src/core/peripherals/nubus/declrom.h
+++ b/src/core/peripherals/nubus/declrom.h
@@ -83,22 +83,19 @@ void declrom_expand_lane3(const uint8_t *chip, size_t chip_size, uint8_t *bus_bu
 bool declrom_layout_chip(const uint8_t *chip, size_t chip_size, uint8_t *bus_buf, size_t bus_size, uint8_t byte_lanes);
 
 // Find the declaration-ROM chip image that provides the card `card_id` —
-// by CONTENT (the vrom.c Format-Block-CRC catalog), never by a hardcoded
-// filename — read it, and lay it out into the TAIL of `bus_buf` (bus_size
-// bytes) per its byteLanes byte (see declrom_layout_chip; the Format Block
-// always ends at the slot top, so a smaller ROM revision occupies the top of
-// a window sized for the largest one).  Tries, in order:
-//   0. the explicit `machine.vrom.load <path>` pending path (how the web UI
-//      hands over an uploaded file, whatever it is named), if it identifies
-//      to this card;
-//   1. each catalog canonical filename for this card, in each of:
-//      the pending CPU ROM's directory (where the integration-test harness
-//      keeps sibling vrom files), `/opfs/images/vrom/`, `tests/data/roms/`,
-//      and the current working directory — every hit content-verified before
-//      it is accepted.
+// by CONTENT (the vrom.c Format-Block-CRC catalog), never by a filename —
+// read it, and lay it out into the TAIL of `bus_buf` (bus_size bytes) per
+// its byteLanes byte (see declrom_layout_chip; the Format Block always ends
+// at the slot top, so a smaller ROM revision occupies the top of a window
+// sized for the largest one).  Candidates come exclusively from the offer
+// registry the platform populated before boot (vrom_offer / vrom.load — see
+// vrom.h): they are tried in pick order (explicit vrom.load first, then the
+// catalog's preferred revision, then catalog order).  Core never fabricates
+// a search path.
 // On success returns true and stores a freshly-strdup'd copy of the path it
 // loaded from in *out_path (caller frees); on miss returns false and leaves
-// *out_path NULL.  Shared by every real-ROM display card (JMFB, 24AC, 8•24 GC).
+// *out_path NULL.  Shared by every card with a real ROM file (JMFB, 24AC,
+// 8•24 GC, SE/30 built-in video).
 bool declrom_load_vrom_card(const char *card_id, uint8_t *bus_buf, size_t bus_size, char **out_path);
 
 #endif // NUBUS_DECLROM_H

--- a/src/machines/glue/builtin_se30_video.c
+++ b/src/machines/glue/builtin_se30_video.c
@@ -8,7 +8,8 @@
 //
 // What the card owns:
 //   * 64 KB VRAM at $FEE00000
-//   * 32 KB declaration ROM at $FEFF8000 (real builtin-se30-video-4f71ff1a.vrom if available,
+//   * 32 KB declaration ROM at $FEFF8000 (the real SE/30 onboard-video vROM
+//     when one was offered — found by content via declrom_load_vrom_card —
 //     synthesised fallback otherwise; the byte-banged synth is the same
 //     220-line sequence se30.c used to carry inline)
 //   * the display_t exposed via system_display() — 512×342×1bpp, with
@@ -18,13 +19,11 @@
 #include "builtin_se30_video.h"
 #include "card.h"
 #include "checkpoint.h"
+#include "declrom.h"
 #include "display.h"
 #include "log.h"
-#include "memory.h"
-#include "rom.h"
 #include "system.h"
 #include "system_config.h"
-#include "vrom.h"
 
 #include <stdint.h>
 #include <stdio.h>
@@ -50,7 +49,7 @@ typedef struct {
 // === VROM loading / synth (moved verbatim from se30.c) ======================
 
 // Build a minimal fallback NuBus declaration ROM (8 KB at the top of the
-// 32 KB buffer) when the real builtin-se30-video-4f71ff1a.vrom is not available.  The byte
+// 32 KB buffer) when no real onboard-video vROM was offered.  The byte
 // sequence below is taken verbatim from the legacy se30_build_vrom_fallback
 // in src/machines/se30.c — see that history for rationale.
 static void synthesise_vrom_fallback(uint8_t *rom) {
@@ -200,70 +199,19 @@ static void synthesise_vrom_fallback(uint8_t *rom) {
     top[0x1FF7] = (uint8_t)(crc);
 }
 
-// Try to load the VROM bytes from a single path.  Returns true on success.
-static bool try_load_vrom(const char *path, uint8_t *vrom_buf) {
-    FILE *f = fopen(path, "rb");
-    if (!f)
-        return false;
-    size_t n = fread(vrom_buf, 1, SE30_VROM_SIZE, f);
-    fclose(f);
-    if (n == SE30_VROM_SIZE) {
-        LOG(1, "Loaded real VROM from %s (%zu bytes)", path, n);
-        return true;
-    }
-    return false;
-}
-
-// Try the explicit pending path, then well-known search paths, then the
-// directory holding the loaded ROM.  Stores the path used in *out_path
-// (caller takes ownership) on success.
-static bool load_real_vrom(config_t *cfg, uint8_t *vrom_buf, char **out_path) {
+// Load the real onboard-video declaration ROM through the shared content-
+// driven loader (the offer registry the platform populated — no search, no
+// filenames).  The SE/30's chip is byteLanes $0F (4-lane, flat copy), so it
+// fills the whole 32 KB window.  Stores the path used in *out_path (caller
+// takes ownership) on success.
+static bool load_real_vrom(uint8_t *vrom_buf, char **out_path) {
     *out_path = NULL;
-    const char *explicit_path = vrom_pending_path();
-    if (explicit_path) {
-        if (try_load_vrom(explicit_path, vrom_buf)) {
-            *out_path = strdup(explicit_path);
-            return true;
-        }
-        LOG(0, "VROM file %s not found or wrong size", explicit_path);
+    if (!declrom_load_vrom_card(builtin_se30_video_kind.id, vrom_buf, SE30_VROM_SIZE, out_path)) {
+        LOG(0, "No SE/30 onboard-video vROM offered — falling back to the synthesised declaration ROM");
+        return false;
     }
-    // Canonical filename is owned by the vROM catalog (single source of truth —
-    // proposal-test-rom-naming.md), never hardcoded here. Search the standard
-    // prefixes, then the directory holding the loaded ROM.
-    const char *fname = vrom_catalog_name("builtin_se30_video", 0, NULL);
-    if (!fname)
-        fname = "builtin-se30-video-4f71ff1a.vrom"; // defensive; the catalog row must exist
-    static const char *const prefixes[] = {"/opfs/images/vrom/", "tests/data/roms/", "", NULL};
-    char vrom_path[512];
-    for (const char *const *pre = prefixes; *pre; pre++) {
-        if (strlen(*pre) + strlen(fname) + 1 > sizeof(vrom_path))
-            continue;
-        strcpy(vrom_path, *pre);
-        strcat(vrom_path, fname);
-        if (try_load_vrom(vrom_path, vrom_buf)) {
-            *out_path = strdup(vrom_path);
-            return true;
-        }
-    }
-    const char *rom_path = rom_pending_path();
-    if (!rom_path)
-        rom_path = memory_rom_filename(cfg->mem_map);
-    if (rom_path) {
-        const char *slash = strrchr(rom_path, '/');
-        if (slash) {
-            size_t dir_len = (size_t)(slash - rom_path + 1);
-            if (dir_len + strlen(fname) + 1 <= sizeof(vrom_path)) {
-                memcpy(vrom_path, rom_path, dir_len);
-                strcpy(vrom_path + dir_len, fname);
-                if (try_load_vrom(vrom_path, vrom_buf)) {
-                    *out_path = strdup(vrom_path);
-                    return true;
-                }
-            }
-        }
-    }
-    LOG(0, "FATAL: Real VROM (%s) not found.", fname);
-    return false;
+    LOG(1, "Loaded real VROM from %s", *out_path);
+    return true;
 }
 
 // === Card vtable ============================================================
@@ -281,11 +229,12 @@ static int card_init(nubus_card_t *card, config_t *cfg, checkpoint_t *cp) {
         free(p);
         return -1;
     }
-    if (!load_real_vrom(cfg, p->vrom, &p->vrom_path)) {
+    (void)cfg;
+    if (!load_real_vrom(p->vrom, &p->vrom_path)) {
         if (!cp) {
             // Real VROM was the long-standing requirement on cold boot;
             // fall back to the synthesised image so the SE/30 keeps booting
-            // even when builtin-se30-video-4f71ff1a.vrom is absent in CI environments.
+            // even when no onboard-video vROM was offered (CI environments).
             synthesise_vrom_fallback(p->vrom);
         }
         // Restoring from a checkpoint?  The VROM contents will be overwritten
@@ -367,8 +316,8 @@ const nubus_card_kind_t builtin_se30_video_kind = {
     .id = "builtin_se30_video",
     .display_name = "Macintosh SE/30 Built-in Video",
     .attach = CARD_ATTACH_BUILTIN, // motherboard circuitry — never socketed
-    // The SE/30 carries no video declaration ROM in main ROM; it needs the
-    // separate builtin-se30-video-4f71ff1a.vrom file (the dialog's VROM picker drives this).
+    // The SE/30 carries no video declaration ROM in main ROM; it needs a
+    // separate onboard-video vROM file (the dialog's VROM picker drives this).
     .requires_vrom = true,
     .monitors = builtin_se30_monitors,
     .factory = factory,

--- a/src/machines/glue/se30.c
+++ b/src/machines/glue/se30.c
@@ -406,9 +406,10 @@ static void se30_post_nubus(config_t *cfg) {
     se30->vram = builtin_se30_video_vram(se30->video_card);
     se30->vrom = builtin_se30_video_vrom(se30->video_card);
     if (!se30->vram || !se30->vrom) {
-        fprintf(stderr, "Error: SE/30 Video ROM (builtin-se30-video-4f71ff1a.vrom) not found.\n"
+        fprintf(stderr, "Error: SE/30 Video ROM not found.\n"
                         "The SE/30 emulator requires a real VROM file for proper operation.\n"
-                        "Place builtin-se30-video-4f71ff1a.vrom next to the ROM file or in tests/data/roms/.\n");
+                        "Load one with machine.vrom.load, or make it available where the platform\n"
+                        "offers vROM files (e.g. next to the ROM file).\n");
         exit(1);
     }
     memory_map_host_region(cfg->mem_map, "se30_vram", se30->vram, SE30_VRAM_BASE, SE30_VRAM_SIZE, /*writable*/ true);
@@ -522,8 +523,9 @@ const hw_profile_t machine_se30 = {
     .cdrom_id = 3,
 
     // Built-in slot-$E video card.  Exposed in the profile so the config
-    // dialog reads the VROM requirement from the card (it needs builtin-se30-video-4f71ff1a.vrom);
-    // this is the same table the substrate passes to nubus_init().
+    // dialog reads the VROM requirement from the card (it needs the SE/30
+    // onboard-video vROM); this is the same table the substrate passes to
+    // nubus_init().
     .nubus_slots = se30_slots,
 
     .substrate = &glue_substrate, // shared GLUE-family substrate

--- a/src/platform/headless/headless_main.c
+++ b/src/platform/headless/headless_main.c
@@ -21,8 +21,10 @@
 #include "shell.h"
 #include "shell_var.h"
 #include "system.h"
+#include "vrom.h"
 
 #include <arpa/inet.h>
+#include <dirent.h>
 #include <errno.h>
 #include <getopt.h>
 #include <netinet/in.h>
@@ -619,6 +621,44 @@ int shell_poll(void) {
     return 1;
 }
 
+// Offer every *.vrom file in the ROM file's directory to the core's
+// content-addressed vROM registry.  The platform owns the filesystem: it
+// enumerates candidates and offers their paths; core identifies each by
+// content and never fabricates a path itself.  This is what makes sibling
+// vROM files (e.g. the integration harness's tests/data/roms, reached via
+// the absolute rom= path) discoverable without core knowing any directory.
+static void offer_sibling_vroms(const char *rom_path) {
+    const char *slash = strrchr(rom_path, '/');
+    char dir[1024];
+    if (slash) {
+        size_t dir_len = (size_t)(slash - rom_path);
+        if (dir_len == 0)
+            dir_len = 1; // ROM at filesystem root → "/"
+        if (dir_len >= sizeof(dir))
+            return;
+        memcpy(dir, rom_path, dir_len);
+        dir[dir_len] = '\0';
+    } else {
+        strcpy(dir, "."); // bare filename → the current directory
+    }
+    DIR *d = opendir(dir);
+    if (!d)
+        return;
+    struct dirent *entry;
+    char path[1200];
+    while ((entry = readdir(d)) != NULL) {
+        const char *name = entry->d_name;
+        size_t len = strlen(name);
+        // Only *.vrom candidates — the offer itself content-verifies them.
+        if (len < 6 || strcmp(name + len - 5, ".vrom") != 0)
+            continue;
+        if (snprintf(path, sizeof(path), "%s/%s", dir, name) >= (int)sizeof(path))
+            continue;
+        vrom_offer(path);
+    }
+    closedir(d);
+}
+
 int main(int argc, char *argv[]) {
     // Configuration from arguments
     const char *rom_file = NULL;
@@ -915,9 +955,13 @@ int main(int argc, char *argv[]) {
     if (ram_kb > 0)
         system_set_pending_ram_kb(ram_kb);
 
-    // Set the pending ROM path BEFORE system_create so SE/30 init can
-    // auto-discover a sibling builtin-se30-video-4f71ff1a.vrom file during machine bring-up.
+    // Set the pending ROM path BEFORE system_create (rom.reload depends on it).
     rom_pending_set(rom_file);
+
+    // Offer the ROM's sibling *.vrom files to the content-addressed registry
+    // BEFORE system_create so the card factories can match them during
+    // machine bring-up (offers persist across machine.boot).
+    offer_sibling_vroms(rom_file);
 
     // Stage the user's video-card pick BEFORE system_create so nubus_init
     // resolves it for the configurable slot (validated by

--- a/src/platform/wasm/em_main.c
+++ b/src/platform/wasm/em_main.c
@@ -56,6 +56,7 @@
 #include "scheduler.h"
 #include "shell.h"
 #include "system.h"
+#include "vrom.h"
 
 // ============================================================================
 // Forward Declarations
@@ -1262,6 +1263,26 @@ int main(int argc, char *argv[]) {
     mkdir("/opfs/images/cd", 0777);
     mkdir("/opfs/checkpoints", 0777);
     mkdir("/opfs/upload", 0777);
+
+    // Offer every file in the persistent vROM store to the core's content-
+    // addressed registry (names are irrelevant — each offer is identified by
+    // content).  The platform owns the filesystem; core never enumerates a
+    // directory or builds a path.  Mid-session uploads are offered by the
+    // web app's ingest path (machine.vrom.offer), so this startup pass only
+    // needs to cover what already persisted.
+    DIR *vrom_dir = opendir("/opfs/images/vrom");
+    if (vrom_dir) {
+        struct dirent *entry;
+        char vrom_path[512];
+        while ((entry = readdir(vrom_dir)) != NULL) {
+            if (entry->d_name[0] == '.')
+                continue;
+            if (snprintf(vrom_path, sizeof(vrom_path), "/opfs/images/vrom/%s", entry->d_name) >= (int)sizeof(vrom_path))
+                continue;
+            vrom_offer(vrom_path);
+        }
+        closedir(vrom_dir);
+    }
 
     // Volatile scratch space on memory backend (visible from all threads).
     backend_t membk = wasmfs_create_memory_backend();

--- a/tests/e2e/web2-specs/vrom-offer-ingest.spec.ts
+++ b/tests/e2e/web2-specs/vrom-offer-ingest.spec.ts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) pappadf
+
+// web2 e2e: content-addressed vROM provisioning — offer-on-ingest, no reload.
+//
+// Pins proposal-content-addressed-rom-provisioning.md §5/§8: the wasm
+// platform enumerates /opfs/images/vrom once at startup, so a vROM uploaded
+// MID-SESSION must be offered to the core's registry by the ingest path
+// itself (upload.ts persist → machine.vrom.offer) or an "(auto)" boot —
+// one with no explicit machine.vrom.load — would not see the file until the
+// next page reload.  Also pins §3.6a: the stored name is the content hash
+// (the declaration ROM's Format-Block CRC), the upload name is discarded,
+// and discovery is content-based so the weird upload name never matters.
+//
+// Flow (all in ONE page session, no reload):
+//   1. drop a JMFB vROM under a deliberately meaningless name — the toast
+//      identifies it by the card it provides, and it lands at
+//      /opfs/images/vrom/d1629664 (content-hashed);
+//   2. upload the IIcx ROM via the Welcome button (no auto-boot);
+//   3. boot the IIcx from the Terminal panel WITHOUT any vrom.load — the
+//      slot-$9 default card (mdc_8_24) must content-match the offered file
+//      and expose its declaration ROM (machine.nubus.slot[9].card.declrom).
+
+import { test, expect, type Page } from "@playwright/test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { gotoWeb2 } from "../helpers/web2-fs";
+
+const DATA = path.resolve(__dirname, "../../data");
+const IICX_ROM = path.join(DATA, "roms", "iix-iicx-se30-97221136.rom");
+const JMFB_VROM = path.join(DATA, "roms", "mdc-8-24-revb-d1629664.vrom");
+
+// Dispatch dragenter/dragover/drop onto the Display area with a real File in
+// the DataTransfer — same concession as display-drop.spec.ts: only the drag
+// gesture is synthetic; DropOverlay, bus/upload staging, the C-side probes,
+// persist and the vrom offer all run for real.
+async function dropOnDisplay(page: Page, fileName: string, hostFile: string) {
+  const b64 = fs.readFileSync(hostFile).toString("base64");
+  await page.evaluate(
+    ({ name, data }: { name: string; data: string }) => {
+      const el = document.querySelector(".gs-display-content, .screen-view");
+      if (!el) throw new Error("display area not found");
+      const r = el.getBoundingClientRect();
+      const cx = r.x + r.width / 2;
+      const cy = r.y + r.height / 2;
+      const bin = atob(data);
+      const buf = new Uint8Array(bin.length);
+      for (let i = 0; i < bin.length; i++) buf[i] = bin.charCodeAt(i);
+      const file = new File([buf], name, { type: "application/octet-stream" });
+      const dt = new DataTransfer();
+      dt.items.add(file);
+      const fire = (type: string) =>
+        el.dispatchEvent(
+          new DragEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            dataTransfer: dt,
+            clientX: cx,
+            clientY: cy,
+          }),
+        );
+      fire("dragenter");
+      fire("dragover");
+      fire("drop");
+    },
+    { name: fileName, data: b64 },
+  );
+}
+
+// Type one shell line into the Terminal panel's xterm.
+async function terminalRun(page: Page, line: string): Promise<void> {
+  const term = page.locator(".xterm");
+  await term.click();
+  await page.keyboard.type(line);
+  await page.keyboard.press("Enter");
+}
+
+// Echo an expression through the terminal under a unique key and return the
+// printed value (fresh key per probe so stale echoes can't satisfy the
+// match). The typed line itself is echoed too — `voiN=${expr}` — so matches
+// whose value still starts with `$` are the input echo, not the result;
+// poll until the evaluated line lands.
+let probeSeq = 0;
+async function terminalEval(page: Page, expr: string): Promise<string | null> {
+  const key = `voi${++probeSeq}`;
+  await terminalRun(page, `echo ${key}=\${${expr}}`);
+  for (let i = 0; i < 25; i++) {
+    await page.waitForTimeout(400);
+    const text = await page.locator(".xterm-rows").innerText();
+    const values = [...text.matchAll(new RegExp(`${key}=(\\S+)`, "g"))]
+      .map((m) => m[1])
+      .filter((v) => !v.startsWith("$"));
+    if (values.length) return values[values.length - 1];
+  }
+  return null;
+}
+
+test('mid-session vROM upload is offered: "(auto)" boot content-matches it without a reload', async ({
+  page,
+}) => {
+  test.setTimeout(240_000);
+  await gotoWeb2(page);
+
+  // 1. Drop the JMFB vROM under a meaningless name. The classifier probes it
+  //    as a vROM by content; the toast names the card it provides (the
+  //    "we identified it" signal — no filenames anywhere).
+  await dropOnDisplay(page, "my_weird_upload.bin", JMFB_VROM);
+  await expect(
+    page.locator(".toast .msg").filter({ hasText: "Video ROM for 'mdc_8_24'" }),
+  ).toBeVisible({ timeout: 60_000 });
+
+  // 2. Upload the IIcx ROM via the Welcome button (autoBootOnRom=false there,
+  //    so nothing boots yet). Stored content-addressed under its checksum.
+  const [chooser] = await Promise.all([
+    page.waitForEvent("filechooser"),
+    page.getByRole("button", { name: "Upload ROM..." }).click(),
+  ]);
+  await chooser.setFiles(IICX_ROM);
+  await expect(
+    page
+      .locator(".toast .msg")
+      .filter({ hasText: "iix-iicx-se30-97221136.rom uploaded" }),
+  ).toBeVisible({ timeout: 60_000 });
+
+  // 3. Everything below runs in the shipped Terminal panel — web2 has no
+  //    window.gsEval. Open it and verify the vROM landed content-hashed.
+  await page.locator('button.ptab[data-tab="terminal"]').click();
+  await expect(page.locator(".xterm")).toBeVisible({ timeout: 15_000 });
+  expect(
+    await terminalEval(page, 'storage.path_size("/opfs/images/vrom/d1629664")'),
+  ).toBe("32768");
+
+  // 4. "(auto)" boot: machine.boot + rom.load with NO vrom.load. The slot-$9
+  //    default card (mdc_8_24) must find its declaration ROM among the
+  //    offered candidates — the file we just dropped, under its hash name.
+  await terminalRun(page, 'machine.boot "iicx" 8192');
+  await terminalRun(page, 'machine.rom.load "/opfs/images/rom/97221136"');
+  expect(await terminalEval(page, "machine.id")).toBe("iicx");
+  expect(
+    await terminalEval(page, "machine.nubus.slot[9].card.declrom.present"),
+  ).toBe("true");
+});

--- a/tests/integration/core-layering/run.sh
+++ b/tests/integration/core-layering/run.sh
@@ -25,3 +25,33 @@ if [ "$fail" -ne 0 ]; then
     exit 1
 fi
 echo "core-layering: OK — src/core/ includes no machine-implementation headers"
+
+# proposal-content-addressed-rom-provisioning.md §6: core may open a path it
+# was handed, but must never FABRICATE one.  Two greps keep the boundary
+# honest:
+#   1. no environment path literal ("/opfs/…", "tests/data…") in the vROM
+#      loader areas of src/core and src/machines — the platform enumerates
+#      and offers files; core only content-matches among the offers.  (The
+#      "/opfs/" *persistence* heuristics in src/core/storage et al. are a
+#      separate is-this-path-durable concern, out of scope per §2.)
+#   2. no catalog-name→path joining anywhere in src/ — vrom_catalog_name was
+#      removed with the search; a reappearance means the name column leaked
+#      back into core.
+hits=$(grep -rnE '"(/opfs/|tests/data)' \
+    "$ROOT/src/core/peripherals/nubus" "$ROOT/src/core/memory" "$ROOT/src/machines" 2>/dev/null || true)
+if [ -n "$hits" ]; then
+    echo "PATH-FABRICATION VIOLATION: environment path literal in a ROM/vROM loader area:"
+    echo "$hits" | sed "s|$ROOT/||;s/^/    /"
+    fail=1
+fi
+hits=$(grep -rn 'vrom_catalog_name' "$ROOT/src" 2>/dev/null || true)
+if [ -n "$hits" ]; then
+    echo "PATH-FABRICATION VIOLATION: vrom_catalog_name (catalog filename column) is back in src/:"
+    echo "$hits" | sed "s|$ROOT/||;s/^/    /"
+    fail=1
+fi
+if [ "$fail" -ne 0 ]; then
+    echo "core-layering: FAILED — core must not fabricate ROM/vROM paths (proposal §6)"
+    exit 1
+fi
+echo "core-layering: OK — no path fabrication in the ROM/vROM loader areas"

--- a/tests/integration/rom-naming/config.mk
+++ b/tests/integration/rom-naming/config.mk
@@ -3,7 +3,8 @@
 # The enforcement that makes the reorganization stick.  Enumerates every file
 # in tests/data/roms and, via machine.(v)rom.identify, asserts:
 #   1. the file is RECOGNISED (no unknown blobs may live in the directory);
-#   2. its basename EQUALS the catalog's canonical_name (no drift);
+#   2. its basename EQUALS the canonical name the tooling grammar
+#      (scripts/rom_naming.py) derives from its content id (no drift);
 #   3. no two files share a checksum/CRC (kills duplicate blobs forever).
 #
 # Uses a run.sh runner because the object-model shell has no directory

--- a/tests/integration/rom-naming/run.sh
+++ b/tests/integration/rom-naming/run.sh
@@ -1,22 +1,27 @@
 #!/bin/bash
-# Canonical ROM/vROM filename conformance (proposal-test-rom-naming.md §4.3).
+# Canonical ROM/vROM filename conformance (proposal-test-rom-naming.md §4.3,
+# re-homed onto the tooling naming grammar by
+# proposal-content-addressed-rom-provisioning.md §3.6b).
 #
 # Enumerate every file in $TEST_DATA/roms and drive a single headless
 # identify pass over all of them, then assert:
 #   1. every file is RECOGNISED by machine.rom.identify / machine.vrom.identify;
-#   2. each file's basename == the catalog's reported canonical_name;
+#   2. each file's basename == the canonical name the tooling grammar
+#      (scripts/rom_naming.py) derives from its content id — identify itself
+#      reports content facts only, no filenames;
 #   3. no two files share a checksum (CPU ROM) or Format-Block CRC (vROM).
 #
 # The identify surface is picked by extension (.rom → rom, .vrom → vrom).
 set -euo pipefail
 
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 ROMS_DIR="$TEST_DATA/roms"
 [ -d "$ROMS_DIR" ] || { echo "FAIL: $ROMS_DIR does not exist"; exit 1; }
 
 # Build the headless script: for each file emit a marker line naming the file,
 # then echo its identify JSON.  The shell prints values in an unquoted display
-# form, but the fields we key on (recognised / canonical_name / checksum / crc)
-# are comma-free, so they extract cleanly regardless of the free-text `name`.
+# form, but the fields we key on (recognised / checksum / crc) are comma-free,
+# so they extract cleanly regardless of the free-text `name`.
 SCRIPT="$WORK_DIR/identify.script"
 : > "$SCRIPT"
 count=0
@@ -43,10 +48,13 @@ OUT="$WORK_DIR/identify.out"
 GS_STORAGE_CACHE="$STORAGE_CACHE" "$HEADLESS_BIN" \
     rom="$ROM_PATH" --no-prompt --speed=max "script=$SCRIPT" > "$OUT" 2>/dev/null
 
-python3 - "$OUT" "$count" <<'PY'
+python3 - "$OUT" "$count" "$REPO_ROOT/scripts" <<'PY'
 import re, sys
 
-out_path, expected = sys.argv[1], int(sys.argv[2])
+out_path, expected, scripts_dir = sys.argv[1], int(sys.argv[2]), sys.argv[3]
+sys.path.insert(0, scripts_dir)
+from rom_naming import canonical_name  # the tooling naming grammar
+
 lines = open(out_path, encoding="utf-8", errors="replace").read().splitlines()
 
 def field(js, key):
@@ -75,17 +83,24 @@ for base, js in records:
     if field(js, "recognised") != "true":
         fail.append(f"{base}: NOT recognised (unknown blobs may not live in roms/) -> {js}")
         continue
-    canon = field(js, "canonical_name")
-    if canon != base:
-        fail.append(f"{base}: filename != canonical_name (reported {canon!r})")
     # checksum for CPU ROMs, crc for vROMs — either way a content identity.
     ident = field(js, "checksum") or field(js, "crc")
-    if ident:
-        ident = ident.lower()
-        if ident in seen_ids:
-            fail.append(f"duplicate content id {ident}: {base} and {seen_ids[ident]}")
-        else:
-            seen_ids[ident] = base
+    if not ident:
+        fail.append(f"{base}: identify reported no content id -> {js}")
+        continue
+    # The canonical name is a pure function of the content id, owned by
+    # tooling — the emulator only reported the content facts above.
+    canon = canonical_name(ident)
+    if canon is None:
+        fail.append(f"{base}: content id {ident} has no canonical name in "
+                    f"scripts/rom_naming.py (add the row)")
+    elif canon != base:
+        fail.append(f"{base}: filename != canonical name (expected {canon!r})")
+    ident = ident.lower()
+    if ident in seen_ids:
+        fail.append(f"duplicate content id {ident}: {base} and {seen_ids[ident]}")
+    else:
+        seen_ids[ident] = base
 
 if fail:
     print("=== rom-naming conformance FAILURES ===")

--- a/tests/integration/vrom-identify/test.script
+++ b/tests/integration/vrom-identify/test.script
@@ -6,7 +6,9 @@
 # nubus_vrom.md §2).  vrom.identify reads it — the direct analog of
 # rom.identify keying on the main ROM's checksum word — and maps it to the
 # nubus card-kind id the blob provides, plus a `compatible:[card_ids]` list
-# mirroring rom.identify's `compatible:[model_ids]`.  This cross-check is
+# mirroring rom.identify's `compatible:[model_ids]`.  Content facts only —
+# canonical fixture naming lives in tooling (scripts/rom_naming.py, enforced
+# by the rom-naming test), not in the identify payload.  This cross-check is
 # what protects against drift between VROM_CATALOG and the card registry.
 
 # --- Part 1: the {card_id, compatible, crc} contract (stateless probe). ---
@@ -16,19 +18,19 @@ echo ${machine.vrom.identify("../../data/roms/builtin-se30-video-4f71ff1a.vrom")
 echo ${machine.vrom.identify("../../data/roms/display-card-24ac-d8daab87.vrom")}
 
 # Macintosh Display Card 8•24 → JMFB card "mdc_8_24", CRC $D1629664.
-assert ${machine.vrom.identify("../../data/roms/mdc-8-24-revb-d1629664.vrom") == "{\"recognised\":true,\"canonical_name\":\"mdc-8-24-revb-d1629664.vrom\",\"card_id\":\"mdc_8_24\",\"compatible\":[\"mdc_8_24\"],\"size\":32768,\"crc\":\"0xd1629664\"}"} "8•24 vROM identity"
+assert ${machine.vrom.identify("../../data/roms/mdc-8-24-revb-d1629664.vrom") == "{\"recognised\":true,\"card_id\":\"mdc_8_24\",\"compatible\":[\"mdc_8_24\"],\"size\":32768,\"crc\":\"0xd1629664\"}"} "8•24 vROM identity"
 
 # SE/30 onboard video (byteLanes $0F, 4-lane) → builtin card, CRC $4F71FF1A.
-assert ${machine.vrom.identify("../../data/roms/builtin-se30-video-4f71ff1a.vrom") == "{\"recognised\":true,\"canonical_name\":\"builtin-se30-video-4f71ff1a.vrom\",\"card_id\":\"builtin_se30_video\",\"compatible\":[\"builtin_se30_video\"],\"size\":32768,\"crc\":\"0x4f71ff1a\"}"} "SE/30 onboard-video vROM identity"
+assert ${machine.vrom.identify("../../data/roms/builtin-se30-video-4f71ff1a.vrom") == "{\"recognised\":true,\"card_id\":\"builtin_se30_video\",\"compatible\":[\"builtin_se30_video\"],\"size\":32768,\"crc\":\"0x4f71ff1a\"}"} "SE/30 onboard-video vROM identity"
 
 # Apple Macintosh Display Card 24AC → "display_card_24ac", CRC $D8DAAB87.
-assert ${machine.vrom.identify("../../data/roms/display-card-24ac-d8daab87.vrom") == "{\"recognised\":true,\"canonical_name\":\"display-card-24ac-d8daab87.vrom\",\"card_id\":\"display_card_24ac\",\"compatible\":[\"display_card_24ac\"],\"size\":32768,\"crc\":\"0xd8daab87\"}"} "24AC vROM identity"
+assert ${machine.vrom.identify("../../data/roms/display-card-24ac-d8daab87.vrom") == "{\"recognised\":true,\"card_id\":\"display_card_24ac\",\"compatible\":[\"display_card_24ac\"],\"size\":32768,\"crc\":\"0xd8daab87\"}"} "24AC vROM identity"
 
 # Apple Macintosh Display Card 8•24 GC ("Dolphin") → "824gc".  Three genuine
 # declaration ROMs (byteLanes $E1); v1.1 is a 64 KB chip, v1.0 / alpha 32 KB.
-assert ${machine.vrom.identify("../../data/roms/824gc-v1.1-revb-d722b053.vrom") == "{\"recognised\":true,\"canonical_name\":\"824gc-v1.1-revb-d722b053.vrom\",\"card_id\":\"824gc\",\"compatible\":[\"824gc\"],\"size\":65536,\"crc\":\"0xd722b053\"}"} "8•24 GC v1.1 vROM identity"
-assert ${machine.vrom.identify("../../data/roms/824gc-v1.0-reva-9e9857e8.vrom") == "{\"recognised\":true,\"canonical_name\":\"824gc-v1.0-reva-9e9857e8.vrom\",\"card_id\":\"824gc\",\"compatible\":[\"824gc\"],\"size\":32768,\"crc\":\"0x9e9857e8\"}"} "8•24 GC v1.0 vROM identity"
-assert ${machine.vrom.identify("../../data/roms/824gc-v1.0a16-4740028d.vrom") == "{\"recognised\":true,\"canonical_name\":\"824gc-v1.0a16-4740028d.vrom\",\"card_id\":\"824gc\",\"compatible\":[\"824gc\"],\"size\":32768,\"crc\":\"0x4740028d\"}"} "8•24 GC alpha vROM identity"
+assert ${machine.vrom.identify("../../data/roms/824gc-v1.1-revb-d722b053.vrom") == "{\"recognised\":true,\"card_id\":\"824gc\",\"compatible\":[\"824gc\"],\"size\":65536,\"crc\":\"0xd722b053\"}"} "8•24 GC v1.1 vROM identity"
+assert ${machine.vrom.identify("../../data/roms/824gc-v1.0-reva-9e9857e8.vrom") == "{\"recognised\":true,\"card_id\":\"824gc\",\"compatible\":[\"824gc\"],\"size\":32768,\"crc\":\"0x9e9857e8\"}"} "8•24 GC v1.0 vROM identity"
+assert ${machine.vrom.identify("../../data/roms/824gc-v1.0a16-4740028d.vrom") == "{\"recognised\":true,\"card_id\":\"824gc\",\"compatible\":[\"824gc\"],\"size\":32768,\"crc\":\"0x4740028d\"}"} "8•24 GC alpha vROM identity"
 
 # A main ROM is the wrong size for a vROM → recognised:false (no false match).
 assert ${machine.vrom.identify("../../data/roms/plus-v3-4d1f8172.rom") == "{\"recognised\":false}"} "non-vROM file must be unrecognised"


### PR DESCRIPTION
Implements `proposal-content-addressed-rom-provisioning.md` (single flag-day PR; amends `proposal-test-rom-naming.md` §4.1 / #68).

## What

A filename is a **handle**, not a fact. Core already identifies every ROM/vROM by content (checksum / NuBus Format-Block CRC); the one place it still *fabricated* paths was vROM discovery (`dir × catalog-name` over `/opfs/images/vrom/`, `tests/data/roms/`, cwd). This PR inverts discovery: the **platform** enumerates candidate files and *offers* their paths; core identifies each offer by content and card factories match among them.

### Core (`src/core`, `src/machines`)
- `vrom.c`: new pre-boot **offer registry** (`vrom_offer` / `vrom_offer_clear` / `vrom_offer_find`). `vrom.load` becomes an offer that is also the preferred pick; new `machine.vrom.offer` object-model method for mid-session ingest. Pick order: explicit load → catalog `preferred` bit (pins the 8•24 GC v1.1 default) → catalog order.
- `declrom_load_vrom_card` consumes the registry only — the `prefixes[]` search and `dirname(rom)+catalog-name` fabrication are deleted, along with `vrom_catalog_name()`. byteLanes-`$0F` chips now size their bus footprint correctly (chip_size, not 4×), letting the SE/30 built-in video share the loader (its duplicated prefix list is gone).
- `canonical_name` removed from `VROM_CATALOG`/`vrom_id_t`, `rom_info_t`/`ROM_TABLE`, and both `identify` payloads (content facts only). Environment-naming error strings reworded.

### Platforms
- **headless**: offers every `*.vrom` sibling of the `rom=` file before `system_create` — the integration tree stays reachable via the harness's absolute ROM path, with no `tests/data` literal in the build.
- **wasm**: offers every file in `/opfs/images/vrom` at startup.

### web2
- vROMs stored content-hashed at `/opfs/images/vrom/<crc>` (symmetric with the checksum-named CPU-ROM store); upload toast identifies the file by the `card_id` it provides; ingest offers the stored file so an "(auto)" boot sees a mid-session upload **without a page reload**.

### Tooling & enforcement
- Canonical fixture-name grammar moves to `scripts/rom_naming.py` (identity → name), used by `rom-manifest.sh` (now *computes* names instead of parsing identify output) and the `rom-naming` conformance test.
- `core-layering` gains the §6 gate: no `/opfs/` / `tests/data` literals in the ROM/vROM loader areas, no `vrom_catalog_name` anywhere in `src/`.

## Behaviour notes (deliberate)
- An explicitly `vrom.load`-ed file that doesn't content-identify is no longer loaded by size alone (old SE/30 path accepted any right-sized blob); unrecognised offers drop with a debug log.
- `machine.(v)rom.identify` no longer report `canonical_name` — all four in-tree consumers migrated in this PR. Existing OPFS files under old canonical names keep working (discovery is content-based; no rename needed).

## Verification
- Integration: **103/103 pass** (incl. `iicx-dual-display`, `iicx-824gc-16bpp`, `se30-boot`, `iifx-824gc`, updated `vrom-identify`/`rom-naming`/`core-layering`).
- CPU unit tests: 31/31.
- web2: svelte-check / eslint / prettier clean; **347 vitest tests** incl. new `media.test.ts` pinning the content-hashed store.
- e2e: `display-card-config`, `display-drop`, `checkpoint-resume`, full `iicx-video-modes` matrix, plus new `vrom-offer-ingest.spec.ts` — uploads a vROM mid-session under a garbage name, then proves an "(auto)" boot content-matches it with no reload (§8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)