### PR TITLE
ci: verify 7z instead of installing it

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,7 +60,7 @@ jobs:
             echo '7z not on PATH — the pinned dev image is wrong or stale'
             exit 1
           }
-          7z i | head -n 2
+          7z i | sed -n '1,2p'
 
       - name: Verify m68k binutils presence
         shell: bash
@@ -69,7 +69,7 @@ jobs:
             echo 'm68k-linux-gnu-as not on PATH — the pinned dev image is wrong or stale'
             exit 1
           }
-          m68k-linux-gnu-as --version | head -n 1
+          m68k-linux-gnu-as --version | sed -n '1p'
 
       - name: Fetch test data
         id: fetch-data

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,11 +53,14 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install 7z
+      - name: Verify 7z presence
+        shell: bash
         run: |
-          if ! command -v 7z >/dev/null 2>&1; then
-            apt-get update -qq && apt-get install -y -qq 7zip
-          fi
+          which 7z || {
+            echo '7z not on PATH — the pinned dev image is wrong or stale'
+            exit 1
+          }
+          7z i | head -n 2
 
       - name: Verify m68k binutils presence
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
             echo '7z not on PATH — the pinned dev image is wrong or stale'
             exit 1
           }
-          7z i | head -n 2
+          7z i | sed -n '1,2p'
 
       # m68k binutils assembles the generic declaration-ROM fragments
       # (tools/vrom / src/core/peripherals/nubus/vrom68k).  The devcontainer
@@ -72,7 +72,7 @@ jobs:
             echo 'm68k-linux-gnu-as not on PATH — the pinned dev image is wrong or stale'
             exit 1
           }
-          m68k-linux-gnu-as --version | head -n 1
+          m68k-linux-gnu-as --version | sed -n '1p'
 
       # Fetch proprietary test data (only works for internal builds with token access)
       - name: Fetch test data
@@ -270,7 +270,7 @@ jobs:
             echo '7z not on PATH — the pinned dev image is wrong or stale'
             exit 1
           }
-          7z i | head -n 2
+          7z i | sed -n '1,2p'
 
       # m68k binutils for the WASM build's declaration-ROM fragments —
       # verified, not installed (see the matching step in the test job).
@@ -281,7 +281,7 @@ jobs:
             echo 'm68k-linux-gnu-as not on PATH — the pinned dev image is wrong or stale'
             exit 1
           }
-          m68k-linux-gnu-as --version | head -n 1
+          m68k-linux-gnu-as --version | sed -n '1p'
 
       # Fetch proprietary test data (internal builds with token access only).
       # Gates the functional web2 e2e below; the token is scoped to this step.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,15 +48,17 @@ jobs:
           submodules: recursive
 
       # 7z extracts the large binary archives (CD-ROM images and the like).
-      # Still install-if-missing: `7zip` was only just added to the devcontainer
-      # Dockerfile, and the pinned image predates it.  Once build-dev-image has
-      # published an image carrying it, this becomes a verify step like the
-      # m68k one below.
-      - name: Install 7z
+      # The devcontainer Dockerfile installs `7zip`, so this VERIFIES rather
+      # than installs — see the m68k step below for why self-repair is the
+      # wrong shape here.
+      - name: Verify 7z presence
+        shell: bash
         run: |
-          if ! command -v 7z >/dev/null 2>&1; then
-            apt-get update -qq && apt-get install -y -qq 7zip
-          fi
+          which 7z || {
+            echo '7z not on PATH — the pinned dev image is wrong or stale'
+            exit 1
+          }
+          7z i | head -n 2
 
       # m68k binutils assembles the generic declaration-ROM fragments
       # (tools/vrom / src/core/peripherals/nubus/vrom68k).  The devcontainer
@@ -261,11 +263,14 @@ jobs:
 
       # 7z extracts the large binary archives (e.g. the A/UX HD) the functional
       # web2 e2e specs boot from (see the matching step in the test job).
-      - name: Install 7z
+      - name: Verify 7z presence
+        shell: bash
         run: |
-          if ! command -v 7z >/dev/null 2>&1; then
-            apt-get update -qq && apt-get install -y -qq 7zip
-          fi
+          which 7z || {
+            echo '7z not on PATH — the pinned dev image is wrong or stale'
+            exit 1
+          }
+          7z i | head -n 2
 
       # m68k binutils for the WASM build's declaration-ROM fragments —
       # verified, not installed (see the matching step in the test job).


### PR DESCRIPTION
Completes what #79 started.

#79 had to leave 7z as install-if-missing: `7zip` had only just been added
to the devcontainer Dockerfile, and no published image carried it yet, so a
verify step could not have gone green. The image build triggered by that
merge now shows `Setting up 7zip (23.01+dfsg-11)` in its layer, so the
published `node22` image genuinely ships it.

Checked against the image build log this time. In #79 I checked `which 7z`
inside my own devcontainer and read that as proof the image had it — but
`scripts/fetch-test-data.sh` apt-installs 7z when missing and I had run it
earlier in the session, so I was measuring a container I had already
contaminated. CI caught it in about a minute.

With this, **no CI step installs a toolchain dependency any more.** A
missing tool is an image problem and gets reported as one, rather than
papered over per-run while the pin quietly rots — which is exactly how the
publish workflows sat on a five-month-old image for two months without
anyone noticing.

Self-verifying: if the image somehow lacks it, these steps fail fast and
cheap rather than deep into a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
