### PR TITLE
nightly: the Valgrind step has never once passed

### DIFF
--- a/scripts/run-integration-test.sh
+++ b/scripts/run-integration-test.sh
@@ -83,11 +83,29 @@ for v in ${TEST_VARS:-}; do
     VAR_ARGS="$VAR_ARGS --var $v"
 done
 
+# Under a wrapper, hand custom runners a real executable rather than a
+# multi-word "valgrind --flags... /path/to/bin" string: every run.sh
+# quotes "$HEADLESS_BIN" (as it must, paths may contain spaces), which
+# turned the folded form into one nonexistent filename and failed the
+# test before it ran. A shim keeps HEADLESS_BIN a single path and moves
+# the wrapper inside it.
+RUNNER_BIN="$HEADLESS_BIN"
+if [ -n "${WRAPPER:-}" ]; then
+    SHIM="$TEST_TMPDIR/headless-wrapped"
+    {
+        echo '#!/usr/bin/env bash'
+        echo "exec $WRAPPER \"\$HEADLESS_REAL_BIN\" \"\$@\""
+    } > "$SHIM"
+    chmod +x "$SHIM"
+    export HEADLESS_REAL_BIN="$HEADLESS_BIN"
+    RUNNER_BIN="$SHIM"
+fi
+
 cd "$TEST" || exit 1
 if [ -n "$TEST_RUNNER" ]; then
-    # Custom multi-step runner: it invokes $HEADLESS_BIN itself, with the
-    # wrapper folded into the variable (the historical valgrind contract).
-    HEADLESS_BIN="${WRAPPER:+$WRAPPER }$HEADLESS_BIN" ROM_PATH="$ROM_PATH" \
+    # Custom multi-step runner: it invokes $HEADLESS_BIN itself. Under a
+    # wrapper it gets the shim path, so its quoted "$HEADLESS_BIN" works.
+    HEADLESS_BIN="$RUNNER_BIN" ROM_PATH="$ROM_PATH" \
         DUMP_BIN="$DUMP_BIN" \
         TEST_DATA="$TEST_DATA" TEST_TMPDIR="$TEST_TMPDIR" \
         TEST_RESULTS_DIR="$TEST_RESULTS_DIR" \

--- a/src/core/debug/debug.c
+++ b/src/core/debug/debug.c
@@ -2481,11 +2481,13 @@ void debug_cleanup(debug_t *debug) {
         debug->object = NULL;
     }
 
-    // Free all breakpoints
+    // Free all breakpoints — via free_breakpoint() so the entry object
+    // and condition string go with them (the same discipline every other
+    // breakpoint-removal path follows).
     breakpoint_t *bp = debug->breakpoints;
     while (bp) {
         breakpoint_t *next = bp->next;
-        free(bp);
+        free_breakpoint(bp);
         bp = next;
     }
     debug->breakpoints = NULL;

--- a/src/machines/compact/plus.c
+++ b/src/machines/compact/plus.c
@@ -286,6 +286,11 @@ static void plus_teardown(config_t *cfg) {
         scheduler_stop(cfg->scheduler);
     }
 
+    // Mirror the appletalk_init() in plus_init(): tear the AppleTalk
+    // object nodes down before the SCC and scheduler it holds pointers
+    // to are freed below.
+    appletalk_delete();
+
     if (cfg->keyboard) {
         keyboard_delete(cfg->keyboard);
         cfg->keyboard = NULL;


### PR DESCRIPTION
Nine scheduled nightly runs since 2026-07-30, nine failures, always the same 11 of 38 rows. The extended tier was green throughout (the lone `ASSERT FAILED: iici-aux3-8bpp` is a known non-fatal `MILESTONE RED`) — only the Valgrind step was red, from three unrelated bugs that happened to share a step.

## Seven of the eleven never ran an instruction

`run-integration-test.sh` folded the wrapper into the binary variable, so a custom runner received:

```
HEADLESS_BIN="valgrind --error-exitcode=1 --leak-check=full ... /path/to/gs-headless"
```

and dutifully quoted it — as it must, paths may contain spaces — turning the lot into one nonexistent filename:

```
run.sh: line 22: valgrind --error-exitcode=1 ... gs-headless: No such file or directory
```

That took out `re-disasm`, `re-extract`, `re-manifest`, `machine-capabilities`, `machine-profile-schema`, `rom-naming` and `storage-guards`. Four of the seven redirect stderr into a capture file, so the diagnosis arrived as `FAIL: legitimate move did not happen` with the actual cause on the floor.

Fixed with a generated shim: `HEADLESS_BIN` stays a single real path and the wrapper moves inside it, leaving all seven `run.sh` files untouched.

## The remaining four leaked

**`debug_cleanup` open-coded `free(bp)`** while a `free_breakpoint()` helper sat forty lines up describing itself as *"used by every code path that removes a breakpoint so the invalidation discipline is uniform"* — cleanup being the one path that did not, dropping each `entry_object` (96 bytes) and `condition` string. The logpoint side had gotten this right all along via `free_logpoint()`.

**`appletalk_delete()` was a complete, correct destructor with no callers at all.** `plus_teardown` frees keyboard, SCSI, mouse, VIA, sound, SCC, RTC, scheduler, floppy, CPU, memory map and debugger, and walked straight past AppleTalk — 8 share objects (`MAX_SHARES` = 8, matching the reported "8 blocks" exactly) plus 3 named nodes per boot. Plus is the only machine that calls `appletalk_init`, which is exactly why only Plus-booting rows tripped it. The call goes in before the SCC and scheduler it holds pointers to are freed.

## Verification

Both failure modes were reproduced locally first, then re-run after the fixes:

| | before | after |
|---|---|---|
| `make test-valgrind TIER=unit PERF_FLOORS=off` | 11 of 38 FAILED | **38/38 pass** |
| `make test-valgrind-suite-plus ROW=plus-beep` | — | **PASS** |
| `make test TIER=unit` (non-Valgrind) | 38/38 | **38/38** (unchanged) |

Both commands the nightly actually runs now pass, and the normal path is unaffected.

## Not addressed

The `re-*` tests invoke `$DUMP_BIN` unwrapped, so the dump tool still gets no memcheck coverage. Pre-existing gap, left alone rather than widen the scope here — worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
