### PR TITLE
Shell & terminal UX: state-aware prompt, working tab completion, quieter checkpoints, persistent history

### DIFF
--- a/app/web2/src/bus/emulator.ts
+++ b/app/web2/src/bus/emulator.ts
@@ -12,6 +12,7 @@ import {
   machine,
   setSchedulerMode,
   setAcceleratedSpeed,
+  setCheckpointSaved,
   setPerfStats,
   type MachineStatus,
   type MmuKind,
@@ -86,6 +87,7 @@ interface EmscriptenModuleConfig {
   onFloppyChange?(drive: number, present: boolean): void;
   onSchedulerSpeed?(speedX256: number): void;
   onPerfUpdate?(mipsX100: number, tpsX10: number): void;
+  onCheckpointSaved?(elapsedMsX100: number): void;
   onVideoInReady?(ptr: number, w: number, h: number): void;
   onVideoInState?(active: boolean): void;
   onAudioInReady?(ptr: number, len: number, rate: number): void;
@@ -163,6 +165,7 @@ export async function bootstrap(canvas: HTMLCanvasElement, wasmArgs: string[] = 
     onFloppyChange: onFloppyDriveChange,
     onSchedulerSpeed: handleSchedulerSpeed,
     onPerfUpdate: handlePerfUpdate,
+    onCheckpointSaved: handleCheckpointSaved,
     onVideoInReady,
     onVideoInState,
     onAudioInReady,
@@ -362,6 +365,13 @@ function handleSchedulerSpeed(speedX256: number): void {
 // (x100 / x10) since MAIN_THREAD_ASYNC_EM_ASM carries ints.
 function handlePerfUpdate(mipsX100: number, tpsX10: number): void {
   setPerfStats((mipsX100 | 0) / 100, (tpsX10 | 0) / 10);
+}
+
+// Core-pushed quick/background checkpoint completion (elapsed ms x100 —
+// MAIN_THREAD_ASYNC_EM_ASM carries ints). The status bar flashes its CP
+// glyph and carries the time + duration in the tooltip.
+function handleCheckpointSaved(elapsedMsX100: number): void {
+  setCheckpointSaved((elapsedMsX100 | 0) / 100);
 }
 
 function handleScreenResize(w: number, h: number, parW?: number, parH?: number): void {

--- a/app/web2/src/components/panel-views/terminal/TerminalPane.svelte
+++ b/app/web2/src/components/panel-views/terminal/TerminalPane.svelte
@@ -11,6 +11,7 @@
   } from '@/bus/emulator';
   import { setTerminalSink } from '@/bus/logSink';
   import { layout } from '@/state/layout.svelte';
+  import { machine } from '@/state/machine.svelte';
   import { theme } from '@/state/theme.svelte';
   import { registerTerminalInsert } from './terminalBridge';
 
@@ -93,6 +94,23 @@
     clearLine();
     xterm.write(inputState.prompt);
   }
+
+  // Reseed the rendered prompt on machine state transitions (boot, toolbar
+  // pause/resume): the prompt is state-aware, and the idle input line would
+  // otherwise keep the stale pre-transition text until the next command.
+  // Only repaints an *idle* input line — while a command is in flight its
+  // own shell.run return carries the fresh prompt.
+  $effect(() => {
+    void machine.status;
+    void machine.model; // model swap can re-boot without a status edge
+    void (async () => {
+      await seedPrompt();
+      if (!destroyed && xterm && inputState.active) {
+        refreshPrompt();
+        renderInput();
+      }
+    })();
+  });
 
   function writeLine(message: string) {
     if (!xterm) return;

--- a/app/web2/src/components/panel-views/terminal/TerminalPane.svelte
+++ b/app/web2/src/components/panel-views/terminal/TerminalPane.svelte
@@ -9,6 +9,7 @@
     isModuleReady,
     whenModuleReady,
   } from '@/bus/emulator';
+  import { opfs, writeToOPFS } from '@/bus/opfs';
   import { setTerminalSink } from '@/bus/logSink';
   import { layout } from '@/state/layout.svelte';
   import { machine } from '@/state/machine.svelte';
@@ -129,12 +130,56 @@
     if (inputState.active) renderInput();
   }
 
+  // --- Persistent history (OPFS) ---------------------------------------
+  //
+  // The in-memory ring survives reloads via one newline-separated file at
+  // the OPFS root (a dotfile, like ~/.bash_history). Loaded once at
+  // component init and merged BEFORE anything typed since page load;
+  // rewritten (it is at most MAX_HISTORY small lines) after each push,
+  // coalesced so a burst of commands never overlaps writes. All
+  // best-effort: a missing file or a write failure only costs history.
+  const HISTORY_PATH = '/opfs/.shell_history';
+  let historySaving = false;
+  let historySaveQueued = false;
+
+  async function saveHistory(): Promise<void> {
+    if (historySaving) {
+      historySaveQueued = true;
+      return;
+    }
+    historySaving = true;
+    try {
+      await writeToOPFS(HISTORY_PATH, new Blob([inputState.history.join('\n') + '\n']));
+    } catch {
+      // Best-effort.
+    }
+    historySaving = false;
+    if (historySaveQueued) {
+      historySaveQueued = false;
+      void saveHistory();
+    }
+  }
+
+  async function loadHistory(): Promise<void> {
+    try {
+      const text = await (await opfs.readFile(HISTORY_PATH)).text();
+      const lines = text.split('\n').filter((l) => l.trim().length > 0);
+      if (destroyed || !lines.length) return;
+      inputState.history = [...lines, ...inputState.history].slice(-MAX_HISTORY);
+      inputState.historyIndex = inputState.history.length;
+    } catch {
+      // No history file yet.
+    }
+  }
+  void loadHistory();
+
   function pushHistory(line: string) {
     const trimmed = line?.trim();
     if (!trimmed) return;
     inputState.history.push(line);
     if (inputState.history.length > MAX_HISTORY) inputState.history.shift();
     inputState.historyIndex = inputState.history.length;
+    void saveHistory();
   }
 
   function recallHistory(delta: number) {

--- a/app/web2/src/components/panel-views/terminal/TerminalPane.svelte
+++ b/app/web2/src/components/panel-views/terminal/TerminalPane.svelte
@@ -25,6 +25,7 @@
       background: readCssToken('--gs-terminal-bg') || '#0d0f11',
       foreground: readCssToken('--gs-terminal-fg') || '#cccccc',
       cursor: readCssToken('--gs-terminal-cursor') || '#cccccc',
+      selectionBackground: readCssToken('--gs-terminal-selection') || 'rgba(128, 128, 128, 0.4)',
     };
   }
 
@@ -40,7 +41,14 @@
     focus(): void;
     scrollToBottom(): void;
     cols: number;
-    options: { theme?: { background?: string; foreground?: string; cursor?: string } };
+    options: {
+      theme?: {
+        background?: string;
+        foreground?: string;
+        cursor?: string;
+        selectionBackground?: string;
+      };
+    };
   }
   interface FitAddonLike {
     fit(): void;

--- a/app/web2/src/components/panel-views/terminal/TerminalPane.svelte
+++ b/app/web2/src/components/panel-views/terminal/TerminalPane.svelte
@@ -192,8 +192,11 @@
       const after = inputState.buffer.slice(span.end);
       inputState.buffer = before + completed + after;
       inputState.cursor = before.length + completed.length;
-      // Trailing space when caret lands at the very end.
-      if (inputState.cursor === inputState.buffer.length) {
+      // Trailing space when caret lands at the very end — except after
+      // drill-in candidates (object "name.", directory "name/", named-arg
+      // "name="), where the next keystroke continues the same token.
+      const drillIn = /[./=]$/.test(completed);
+      if (inputState.cursor === inputState.buffer.length && !drillIn) {
         inputState.buffer += ' ';
         inputState.cursor++;
       }

--- a/app/web2/src/components/status-bar/StatusBar.svelte
+++ b/app/web2/src/components/status-bar/StatusBar.svelte
@@ -33,6 +33,24 @@
       ? `${machine.acceleratedSpeed}×`
       : `${machine.acceleratedSpeed.toFixed(1)}×`,
   );
+
+  // Background-checkpoint heartbeat — same flash idiom as the drive
+  // lights; each core push (state/machine setCheckpointSaved stores a
+  // fresh object, so identity re-fires the effect) lights the glyph for
+  // the drive lights' 180 ms. The tooltip carries the time + duration
+  // that used to spam the terminal.
+  let cpFlash = $state(false);
+  $effect(() => {
+    if (!machine.checkpoint) return;
+    cpFlash = true;
+    const t = setTimeout(() => (cpFlash = false), 180);
+    return () => clearTimeout(t);
+  });
+  const cpTitle = $derived(
+    machine.checkpoint
+      ? `Last background checkpoint ${new Date(machine.checkpoint.at).toLocaleTimeString()} (${machine.checkpoint.ms.toFixed(1)} ms)`
+      : 'Background checkpoint: none yet this session',
+  );
 </script>
 
 {#if visible}
@@ -68,6 +86,7 @@
       <DriveActivity label="HD" title="Hard disk" activity={machine.driveActivity.hd} />
       <DriveActivity label="FD" title="Floppy disk" activity={machine.driveActivity.fd} />
       <DriveActivity label="CD" title="CD-ROM" activity={machine.driveActivity.cd} />
+      <DriveActivity label="CP" title={cpTitle} activity={cpFlash ? 'write' : 'idle'} />
     </div>
     <div class="statusbar-right">
       {#if activity.current}

--- a/app/web2/src/state/machine.svelte.ts
+++ b/app/web2/src/state/machine.svelte.ts
@@ -48,6 +48,11 @@ interface MachineState {
   // most everything else is square 1:1). Reported by the core via onScreenResize.
   screen: { width: number; height: number; parW: number; parH: number };
   driveActivity: { hd: DriveActivity; fd: DriveActivity; cd: DriveActivity };
+  // Last successful quick/background checkpoint, pushed from the core
+  // (bus/emulator.ts handleCheckpointSaved): wall-clock stamp + save
+  // duration. null until the first save after page load; the status bar
+  // flashes its CP glyph on each push and shows this in the tooltip.
+  checkpoint: { at: number; ms: number } | null;
   scheduler: SchedulerMode;
   // Effective CPU speed multiplier the core is currently applying (1 = the
   // original Mac's speed). Only meaningful — and only shown — in `accel` mode,
@@ -73,6 +78,7 @@ export const machine: MachineState = $state({
   audioIn: false,
   screen: { width: 512, height: 342, parW: 1, parH: 1 },
   driveActivity: { hd: 'idle', fd: 'idle', cd: 'idle' },
+  checkpoint: null,
   scheduler: 'live',
   acceleratedSpeed: 1,
   mips: 0,
@@ -108,6 +114,13 @@ export function setAcceleratedSpeed(multiplier: number): void {
 export function setPerfStats(mips: number, ticksPerSecond: number): void {
   machine.mips = mips;
   machine.ticksPerSecond = ticksPerSecond;
+}
+
+// Core-pushed quick-checkpoint completion (bus/emulator.ts
+// handleCheckpointSaved). A fresh object per push so effects keyed on
+// identity re-fire even for back-to-back saves.
+export function setCheckpointSaved(ms: number): void {
+  machine.checkpoint = { at: Date.now(), ms };
 }
 
 // ---- Drive activity mock ----

--- a/app/web2/src/styles/tokens.css
+++ b/app/web2/src/styles/tokens.css
@@ -89,6 +89,9 @@
   --gs-terminal-bg: #0d0f11; /* terminal.background dark */
   --gs-terminal-fg: #cccccc; /* terminal.foreground dark */
   --gs-terminal-cursor: #cccccc;
+  /* Selection overlay — xterm's built-in default is translucent white,
+     which vanishes on a light background, so both themes set it. */
+  --gs-terminal-selection: rgba(255, 255, 255, 0.25);
 
   /* Diff highlight — applied to debug panes (registers / FPU / memory)
      on cells whose value differs from the previous refresh. Persists
@@ -192,6 +195,7 @@
   --gs-terminal-bg: #f6f6f6; /* terminal.background light */
   --gs-terminal-fg: #333333; /* terminal.foreground light */
   --gs-terminal-cursor: #333333;
+  --gs-terminal-selection: #add6ff; /* editor-blue, visible on #f6f6f6 */
 
   /* Diff highlight (see dark theme note). */
   --gs-changed-bg: rgba(220, 170, 0, 0.22);

--- a/app/web2/tests/component/StatusBar.test.ts
+++ b/app/web2/tests/component/StatusBar.test.ts
@@ -36,12 +36,22 @@ describe('StatusBar', () => {
     expect(container.querySelector('.sb-desc')?.textContent).toBe('SE/30 · 8 MB');
   });
 
-  it('renders three drive indicators (HD, FD, CD)', () => {
+  it('renders the drive indicators plus the checkpoint glyph (HD, FD, CD, CP)', () => {
     machine.status = 'running';
     const { container } = render(StatusBar);
     const driveLabels = Array.from(container.querySelectorAll('.sb-drive .drive-ico')).map(
       (d) => d.textContent,
     );
-    expect(driveLabels).toEqual(['HD', 'FD', 'CD']);
+    expect(driveLabels).toEqual(['HD', 'FD', 'CD', 'CP']);
+  });
+
+  it('checkpoint glyph tooltip carries the last save time and duration', () => {
+    machine.status = 'running';
+    machine.checkpoint = { at: Date.now(), ms: 12.34 };
+    const { container } = render(StatusBar);
+    const cp = Array.from(container.querySelectorAll('.sb-drive')).find(
+      (d) => d.querySelector('.drive-ico')?.textContent === 'CP',
+    );
+    expect(cp?.getAttribute('title')).toMatch(/Last background checkpoint .+\(12\.3 ms\)/);
   });
 });

--- a/src/core/shell/cmd_complete.c
+++ b/src/core/shell/cmd_complete.c
@@ -110,7 +110,26 @@ static void complete_paths(const char *prefix, struct completion *out) {
             break;
         if (ent.name[0] == '.' && partial[0] != '.')
             continue;
-        const char *copy = pool_strdup(ent.name);
+        // Skip non-matches before any stat so the per-entry cost below
+        // is only paid for actual candidates.
+        size_t plen = strlen(partial);
+        if (plen && strncasecmp(ent.name, partial, plen) != 0)
+            continue;
+        // Directories complete to "name/" (bash-style) so the terminal
+        // omits the trailing space and the next Tab descends into them.
+        // Name-only backends (host readdir) leave has_stat false; one
+        // vfs_stat per matching entry types those.
+        bool is_dir = ent.has_stat && (ent.st.mode & VFS_MODE_DIR);
+        if (!ent.has_stat) {
+            char full[512];
+            snprintf(full, sizeof(full), "%s%s%s", dir, (dir[0] == '/' && dir[1] == '\0') ? "" : "/", ent.name);
+            vfs_stat_t st;
+            if (vfs_stat(full, &st) == 0 && (st.mode & VFS_MODE_DIR))
+                is_dir = true;
+        }
+        char buf[sizeof(ent.name) + 1];
+        snprintf(buf, sizeof(buf), "%s%s", ent.name, is_dir ? "/" : "");
+        const char *copy = pool_strdup(buf);
         if (!copy)
             break;
         push_match(out, copy, partial);
@@ -248,6 +267,21 @@ static bool in_special_context(const parse_state_t *st) {
 // trailing identifier. Suggestions are members of the class at
 // `head_buf` plus statically-attached children of the resolved object.
 
+// Push one member/child name; object-valued entries complete to "name."
+// (bash's directory-slash idiom) so the terminal omits the trailing
+// space and the next Tab lists the object's own members.
+static void push_name_match(struct completion *out, const char *name, bool is_object, const char *tail) {
+    if (!name)
+        return;
+    if (!is_object) {
+        push_match(out, name, tail);
+        return;
+    }
+    char buf[128];
+    snprintf(buf, sizeof(buf), "%s.", name);
+    push_match(out, pool_strdup(buf), tail);
+}
+
 static void complete_class_members(const class_desc_t *cls, const char *tail, struct completion *out) {
     if (!cls)
         return;
@@ -255,7 +289,7 @@ static void complete_class_members(const class_desc_t *cls, const char *tail, st
         const member_t *m = &cls->members[i];
         if (!m->name)
             continue;
-        push_match(out, m->name, tail);
+        push_name_match(out, m->name, m->kind == M_CHILD, tail);
     }
 }
 
@@ -270,7 +304,8 @@ static void each_attached_cb(struct object *parent, struct object *child, void *
     const char *name = object_name(child);
     if (!name)
         return;
-    push_match(acc->out, name, acc->tail);
+    // Attached children are objects: complete to "name.".
+    push_name_match(acc->out, name, true, acc->tail);
 }
 
 static void complete_attached(struct object *o, const char *tail, struct completion *out) {
@@ -287,8 +322,9 @@ static void complete_indexed_children(struct object *o, const member_t *m, const
         return;
     int idx = m->child.next(o, -1);
     while (idx >= 0 && out->count < CMD_MAX_COMPLETIONS) {
+        // Indexed children resolve to objects: complete to "N.".
         char tmp[16];
-        snprintf(tmp, sizeof(tmp), "%d", idx);
+        snprintf(tmp, sizeof(tmp), "%d.", idx);
         const char *copy = pool_strdup(tmp);
         if (!copy)
             break;

--- a/src/core/shell/cmd_complete.c
+++ b/src/core/shell/cmd_complete.c
@@ -76,6 +76,11 @@ static void complete_paths(const char *prefix, struct completion *out) {
     char dir[256] = ".";
     const char *partial = prefix;
 
+    // Candidates are bare entry names: narrow the replace span to the
+    // basename after the last '/' (out->start arrives at the word start).
+    if (last_slash)
+        out->start += (int)(last_slash - prefix) + 1;
+
     if (last_slash) {
         size_t dir_len = (size_t)(last_slash - prefix);
         if (dir_len == 0) {
@@ -600,6 +605,8 @@ void shell_complete(const char *line, int cursor_pos, struct completion *out) {
     if (!line || !out)
         return;
     out->count = 0;
+    out->start = 0;
+    out->end = 0;
     pool_reset();
 
     int len = (int)strlen(line);
@@ -609,6 +616,9 @@ void shell_complete(const char *line, int cursor_pos, struct completion *out) {
         cursor_pos = len;
 
     cursor_info_t info = scan_to_cursor(line, cursor_pos);
+    // Default span: the whole current word (complete_paths narrows it).
+    out->start = info.word_start;
+    out->end = cursor_pos;
     if (info.inside_special)
         return; // §4.6: empty inside $(...), ${...}, "..."
 

--- a/src/core/shell/cmd_complete.h
+++ b/src/core/shell/cmd_complete.h
@@ -18,10 +18,16 @@
 
 // Completion result: a fixed-capacity list of borrowed candidate
 // strings (they point at static class-member names or a per-call
-// string pool inside the completer).
+// string pool inside the completer), plus the half-open [start, end)
+// span of line text each candidate replaces. `end` is the cursor;
+// `start` is the current word's first character — except for
+// filesystem-path candidates, which are bare entry names and replace
+// only the basename after the word's last '/'.
 struct completion {
     const char *items[CMD_MAX_COMPLETIONS];
     int count;
+    int start;
+    int end;
 };
 
 // Run tab completion for the given line at cursor_pos.

--- a/src/core/shell/shell.c
+++ b/src/core/shell/shell.c
@@ -8,6 +8,7 @@
 
 #include "alias.h"
 #include "cmd_complete.h"
+#include "cpu.h"
 #include "debug.h"
 #include "expr.h"
 #include "log.h"
@@ -454,32 +455,28 @@ void shell_tab_complete(const char *line, int cursor_pos, struct completion *out
     shell_complete(line, cursor_pos, out);
 }
 
-// Compose the current shell prompt: `<disasm> > ` when a machine is up
-// (matching the headless REPL and the legacy WASM `build_prompt_text`),
-// `gs> ` otherwise. Centralised here so the Shell class's `prompt`
-// attribute, the headless REPL's `print_prompt`, and any future
-// consumer share a single source of truth.
+// Compose the current shell prompt.  Short and state-aware:
+//   no machine       -> "gs> "
+//   machine running  -> "gs <model>> "         (a sampled PC would be stale)
+//   machine stopped  -> "gs <model> @<pc>> "   (where execution halted)
+// Centralised here so the Shell class's `prompt` attribute, the headless
+// REPL's `print_prompt`, and any future consumer share a single source
+// of truth.
 void shell_build_prompt(char *buf, size_t buf_size) {
     if (!buf || buf_size == 0)
         return;
     buf[0] = '\0';
-    if (!system_is_initialized()) {
+    const char *model = system_machine_model_id();
+    if (!model) {
         snprintf(buf, buf_size, "gs> ");
         return;
     }
-    // Reserve 3 bytes for " > " suffix + 1 for terminator.
-    debugger_disasm_pc(buf, buf_size > 3 ? buf_size - 3 : 1);
-    size_t used = strnlen(buf, buf_size - 1);
-    if (used == 0) {
-        snprintf(buf, buf_size, "gs> ");
-        return;
-    }
-    if (used >= buf_size - 3)
-        used = buf_size - 4;
-    buf[used++] = ' ';
-    buf[used++] = '>';
-    buf[used++] = ' ';
-    buf[used] = '\0';
+    scheduler_t *sched = system_scheduler();
+    cpu_t *cpu = system_cpu();
+    if ((sched && scheduler_is_running(sched)) || !cpu)
+        snprintf(buf, buf_size, "gs %s> ", model);
+    else
+        snprintf(buf, buf_size, "gs %s @%08X> ", model, cpu_get_pc(cpu));
 }
 
 // Provider wired into the Meta class so `meta.complete(line, cursor)`

--- a/src/core/shell/shell.h
+++ b/src/core/shell/shell.h
@@ -26,10 +26,10 @@
 
 uint64_t shell_dispatch(char *line);
 
-// Compose the current shell prompt (e.g. "<disasm> > " when a machine
-// is up, "gs> " otherwise) into `buf`. Used by the Shell class's
-// `prompt` attribute and the headless REPL's `print_prompt`. Output is
-// NUL-terminated and truncated to `buf_size - 1`.
+// Compose the current shell prompt into `buf`: "gs> " with no machine,
+// "gs <model>> " while running, "gs <model> @<pc>> " when stopped. Used
+// by the Shell class's `prompt` attribute and the headless REPL's
+// `print_prompt`. Output is NUL-terminated and truncated to `buf_size - 1`.
 void shell_build_prompt(char *buf, size_t buf_size);
 
 // === Shell Lifecycle ===

--- a/src/core/shell/shell_class.c
+++ b/src/core/shell/shell_class.c
@@ -181,9 +181,12 @@ static value_t shell_method_run(struct object *self, const member_t *m, int argc
 }
 
 // `shell.complete(line, cursor)` — line-level tab completion. Returns
-// a V_LIST<V_STRING> of candidates. The `meta.complete` method on the
-// synthetic Meta overlay delegates here through the provider hook in
-// shell.c, so callers see a single canonical completion engine.
+// {candidates: V_LIST<V_STRING>, span: {start, end}} where span is the
+// half-open range of line text each candidate replaces (object-path
+// candidates cover the whole word; filesystem candidates only the
+// basename). The `meta.complete` method on the synthetic Meta overlay
+// delegates here through the provider hook in shell.c and keeps the
+// bare-list shape.
 static value_t shell_method_complete(struct object *self, const member_t *m, int argc, const value_t *argv) {
     (void)self;
     (void)m;
@@ -198,14 +201,21 @@ static value_t shell_method_complete(struct object *self, const member_t *m, int
     struct completion comp;
     memset(&comp, 0, sizeof(comp));
     shell_complete(line, cursor, &comp);
-    if (comp.count <= 0)
-        return val_list(NULL, 0);
-    value_t *items = (value_t *)calloc((size_t)comp.count, sizeof(value_t));
-    if (!items)
-        return val_err("shell.complete: out of memory");
-    for (int i = 0; i < comp.count; i++)
-        items[i] = val_str(comp.items[i] ? comp.items[i] : "");
-    return val_list(items, (size_t)comp.count);
+    value_t *items = NULL;
+    if (comp.count > 0) {
+        items = (value_t *)calloc((size_t)comp.count, sizeof(value_t));
+        if (!items)
+            return val_err("shell.complete: out of memory");
+        for (int i = 0; i < comp.count; i++)
+            items[i] = val_str(comp.items[i] ? comp.items[i] : "");
+    }
+    value_map_builder_t *span = val_map_new();
+    val_map_put(span, "start", val_int(comp.start));
+    val_map_put(span, "end", val_int(comp.end));
+    value_map_builder_t *b = val_map_new();
+    val_map_put(b, "candidates", val_list(items, comp.count > 0 ? (size_t)comp.count : 0));
+    val_map_put(b, "span", val_map_finish(span));
+    return val_map_finish(b);
 }
 
 // `shell.expand(text)` — interpolate a string body (`${…}` / `$name`)
@@ -351,8 +361,8 @@ static const member_t shell_members[] = {
      .method = {.args = shell_run_args, .nargs = 1, .result = V_STRING, .fn = shell_method_run}},
     {.kind = M_METHOD,
      .name = "complete",
-     .doc = "Tab-completion candidates for a partial line",
-     .method = {.args = shell_complete_args, .nargs = 2, .result = V_LIST, .fn = shell_method_complete}},
+     .doc = "Tab completion: {candidates, span:{start,end}} for a partial line",
+     .method = {.args = shell_complete_args, .nargs = 2, .result = V_MAP, .fn = shell_method_complete}},
     {.kind = M_METHOD,
      .name = "expand",
      .doc = "Expand ${...} / $(...) references in text",

--- a/src/core/system.c
+++ b/src/core/system.c
@@ -890,7 +890,10 @@ int system_checkpoint(const char *filename, checkpoint_kind_t kind) {
     checkpoint_set_files_as_refs(prev_files_mode);
 
     double elapsed_ms = host_time_ms() - start_time;
-    printf("Checkpoint saved to %s (%.2f ms)\n", filename, elapsed_ms);
+    // Ambient by default — the browser's background auto-saves land here
+    // every ~15 s and used to spam the terminal. `debug.log checkpoint 1`
+    // restores the line; the status bar gets its own push (em_main.c).
+    LOG_WITH(log_register_category("checkpoint"), 1, "Checkpoint saved to %s (%.2f ms)", filename, elapsed_ms);
     return GS_SUCCESS;
 }
 

--- a/src/platform/headless/headless_main.c
+++ b/src/platform/headless/headless_main.c
@@ -576,20 +576,13 @@ static int stdin_has_data(void) {
     return select(STDIN_FILENO + 1, &fds, NULL, NULL, &tv) > 0;
 }
 
-// Shell prompt — shows disassembled current instruction (like the web shell)
+// Shell prompt — shared builder in shell.c (same text as the web shell)
 void print_prompt(void) {
     if (g_daemon_mode)
         return;
-    if (system_is_initialized()) {
-        char disasm_buf[160];
-        debugger_disasm_pc(disasm_buf, sizeof(disasm_buf));
-        if (disasm_buf[0] != '\0')
-            printf("%s > ", disasm_buf);
-        else
-            printf("gs> ");
-    } else {
-        printf("gs> ");
-    }
+    char buf[256];
+    shell_build_prompt(buf, sizeof(buf));
+    printf("%s", buf);
     fflush(stdout);
 }
 

--- a/src/platform/wasm/em_main.c
+++ b/src/platform/wasm/em_main.c
@@ -1123,6 +1123,14 @@ static int save_quick_checkpoint(const char *reason, bool verbose, bool rate_lim
 
     if (rc == GS_SUCCESS) {
         g_last_background_checkpoint_ms = now;
+        // Status-bar heartbeat: push the save duration so the CP glyph
+        // flashes and its tooltip updates. x100 fixed-point since
+        // MAIN_THREAD_ASYNC_EM_ASM carries ints.
+        // clang-format off
+        MAIN_THREAD_ASYNC_EM_ASM(
+            { if (typeof Module.onCheckpointSaved === 'function') Module.onCheckpointSaved($0); },
+            (int)(checkpoint_elapsed_ms * 100.0));
+        // clang-format on
         if (verbose)
             printf("Checkpoint saved to %s (%.2f ms)\n", final_path, checkpoint_elapsed_ms);
     } else if (verbose) {

--- a/tests/e2e/web2-specs/checkpoint-resume.spec.ts
+++ b/tests/e2e/web2-specs/checkpoint-resume.spec.ts
@@ -102,6 +102,36 @@ async function terminalExpect(page: Page, line: string, pattern: RegExp): Promis
   await expect(page.locator('.xterm-rows')).toContainText(pattern, { timeout: 15_000 });
 }
 
+test('tick-auto checkpoint: status-bar CP glyph updates, terminal stays silent', async ({
+  page,
+}) => {
+  // The ~15 s tick-auto cadence is the one timing dependence here; the
+  // 60 s tooltip poll leaves generous RAF-jitter margin.
+  test.setTimeout(180_000);
+  await gotoWeb2(page);
+  await uploadRom(page, PLUS_ROM);
+  await startMachine(page, 'plus');
+
+  // Terminal open from the start so any stray "Checkpoint saved" print
+  // would be captured.
+  await page.locator('button.ptab[data-tab="terminal"]').click();
+  await expect(page.locator('.xterm')).toBeVisible({ timeout: 15_000 });
+
+  // The CP glyph is present with its idle tooltip before the first save.
+  const cp = page.locator('.gs-statusbar .sb-drive', { hasText: 'CP' });
+  await expect(cp).toBeVisible({ timeout: 15_000 });
+  await expect(cp).toHaveAttribute('title', /none yet this session/);
+
+  // After the first background save the tooltip carries time + duration.
+  await expect(cp).toHaveAttribute('title', /Last background checkpoint .+\(\d+(\.\d+)? ms\)/, {
+    timeout: 60_000,
+  });
+
+  // ...and the old terminal spam is gone.
+  const text = await page.locator('.xterm-rows').innerText();
+  expect(text).not.toContain('Checkpoint saved');
+});
+
 test.describe('checkpoint save → reload → resume', () => {
   test('Plus: checkpoint survives a reload and Resume brings the machine back live', async ({
     page,

--- a/tests/e2e/web2-specs/shell-prompt.spec.ts
+++ b/tests/e2e/web2-specs/shell-prompt.spec.ts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) pappadf
+
+// web2 e2e: the shell prompt is short and state-aware (shell.c
+// shell_build_prompt): "gs> " with no machine, "gs <model>> " while the
+// machine free-runs (a sampled PC would be stale), and
+// "gs <model> @<pc>> " when the scheduler is stopped. The prompt travels
+// the real path — `shell.prompt` seeds the terminal on mount and every
+// `shell.run` returns the next prompt, which xterm renders — so the
+// assertions read the rendered terminal, not the attribute.
+//
+// The machine is an SE/30 with no media, free-running at the ROM's
+// insert-disk prompt (same fixture as scheduler-accelerated.spec.ts).
+
+import { test, expect, type Page } from '@playwright/test';
+import * as path from 'node:path';
+import { gotoWeb2 } from '../helpers/web2-fs';
+
+const DATA = path.resolve(__dirname, '../../data');
+const SE30_ROM = path.join(DATA, 'roms', 'iix-iicx-se30-97221136.rom');
+
+// Last non-empty rendered terminal line — the input line, i.e. the
+// current prompt (xterm innerText drops trailing blanks/spaces).
+async function lastTermLine(page: Page): Promise<string> {
+  const text = await page.locator('.xterm-rows').innerText();
+  const lines = text
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+  return lines.length ? lines[lines.length - 1] : '';
+}
+
+// Type one shell line into the Terminal panel's xterm. A trailing settle
+// lets the async worker round-trip land before the next interaction.
+async function terminalRun(page: Page, line: string): Promise<void> {
+  const term = page.locator('.xterm');
+  await term.click();
+  await page.keyboard.type(line);
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(250);
+}
+
+test('shell prompt reflects machine and run state', async ({ page }) => {
+  test.setTimeout(5 * 60 * 1000);
+  await gotoWeb2(page);
+
+  // --- No machine: bare "gs> " ------------------------------------------
+  await page.locator('button.ptab[data-tab="terminal"]').click();
+  await expect(page.locator('.xterm')).toBeVisible({ timeout: 15_000 });
+  await expect
+    .poll(() => lastTermLine(page), { timeout: 15_000 })
+    .toMatch(/^gs>$/);
+
+  // --- Boot an SE/30 (ROM upload + New Machine, no media) ---------------
+  const [romChooser] = await Promise.all([
+    page.waitForEvent('filechooser'),
+    page.getByRole('button', { name: 'Upload ROM...' }).click(),
+  ]);
+  await romChooser.setFiles(SE30_ROM);
+
+  await page.getByRole('button', { name: 'New Machine...' }).click();
+  const model = page.locator('#cfg-model');
+  await expect(model.locator('option[value="se30"]')).toHaveCount(1, {
+    timeout: 30_000,
+  });
+  await model.selectOption('se30');
+  await page.locator('#cfg-ram').selectOption('8 MB');
+  await page.getByRole('button', { name: 'Start Machine' }).click();
+  await expect(
+    page.locator('.toast .msg').filter({ hasText: 'Machine started' }),
+  ).toBeVisible({ timeout: 60_000 });
+
+  // --- Running: "gs se30> ", no PC --------------------------------------
+  // The rendered prompt refreshes on each shell.run return, so run a
+  // no-op first; the prompt that comes back reflects the live machine.
+  await page.locator('button.ptab[data-tab="terminal"]').click();
+  await terminalRun(page, 'echo sync-running');
+  await expect
+    .poll(() => lastTermLine(page), { timeout: 15_000 })
+    .toMatch(/^gs se30>$/);
+
+  // --- Stopped: "gs se30 @<pc>> " ---------------------------------------
+  // shell.run computes the returned prompt after the command executes, so
+  // the stop's own return already carries the halted-PC form.
+  await terminalRun(page, 'scheduler.stop');
+  await expect
+    .poll(() => lastTermLine(page), { timeout: 15_000 })
+    .toMatch(/^gs se30 @[0-9A-F]{8}>$/);
+
+  // --- Resumed: back to "gs se30> " -------------------------------------
+  await terminalRun(page, 'scheduler.run');
+  await expect
+    .poll(() => lastTermLine(page), { timeout: 15_000 })
+    .toMatch(/^gs se30>$/);
+});

--- a/tests/e2e/web2-specs/shell-prompt.spec.ts
+++ b/tests/e2e/web2-specs/shell-prompt.spec.ts
@@ -40,6 +40,42 @@ async function terminalRun(page: Page, line: string): Promise<void> {
   await page.waitForTimeout(250);
 }
 
+test('terminal Tab completion replaces the right span', async ({ page }) => {
+  test.setTimeout(3 * 60 * 1000);
+  await gotoWeb2(page);
+
+  // Terminal is live pre-machine (object-model shell needs no emulated
+  // machine), which keeps this test cheap.
+  await page.locator('button.ptab[data-tab="terminal"]').click();
+  await expect(page.locator('.xterm')).toBeVisible({ timeout: 15_000 });
+  await expect
+    .poll(() => lastTermLine(page), { timeout: 15_000 })
+    .toMatch(/^gs>$/);
+  const term = page.locator('.xterm');
+  await term.click();
+
+  // Object-path completion: the single candidate replaces the whole
+  // dotted word and appends a trailing space.
+  await page.keyboard.type('shell.pro');
+  await page.keyboard.press('Tab');
+  await expect
+    .poll(() => lastTermLine(page), { timeout: 10_000 })
+    .toMatch(/^gs> shell\.prompt$/);
+  await page.keyboard.press('Enter'); // run it; harmless readback
+  await expect
+    .poll(() => lastTermLine(page), { timeout: 10_000 })
+    .toMatch(/^gs>$/);
+
+  // Filesystem-path completion in a method arg: candidates are bare
+  // entry names, so the span must narrow to the basename after the last
+  // '/' — the browser VFS root always contains /opfs.
+  await page.keyboard.type('vfs.ls /op');
+  await page.keyboard.press('Tab');
+  await expect
+    .poll(() => lastTermLine(page), { timeout: 10_000 })
+    .toMatch(/^gs> vfs\.ls \/opfs$/);
+});
+
 test('shell prompt reflects machine and run state', async ({ page }) => {
   test.setTimeout(5 * 60 * 1000);
   await gotoWeb2(page);

--- a/tests/e2e/web2-specs/shell-prompt.spec.ts
+++ b/tests/e2e/web2-specs/shell-prompt.spec.ts
@@ -91,6 +91,29 @@ test('terminal Tab completion replaces the right span', async ({ page }) => {
     .toMatch(/^gs> vfs\.ls \/opfs\/$/);
 });
 
+test('shell history persists across reloads via OPFS', async ({ page }) => {
+  test.setTimeout(3 * 60 * 1000);
+  await gotoWeb2(page);
+  await page.locator('button.ptab[data-tab="terminal"]').click();
+  await expect(page.locator('.xterm')).toBeVisible({ timeout: 15_000 });
+  await page.locator('.xterm').click();
+  await page.keyboard.type('echo history-survives-reload');
+  await page.keyboard.press('Enter');
+  await expect.poll(() => lastTermLine(page), { timeout: 10_000 }).toMatch(/^gs>$/);
+  // Let the coalesced OPFS history write land before navigating away.
+  await page.waitForTimeout(500);
+
+  // Fresh page load, same origin storage: ArrowUp must recall the line.
+  await gotoWeb2(page);
+  await page.locator('button.ptab[data-tab="terminal"]').click();
+  await expect(page.locator('.xterm')).toBeVisible({ timeout: 15_000 });
+  await page.locator('.xterm').click();
+  await page.keyboard.press('ArrowUp');
+  await expect
+    .poll(() => lastTermLine(page), { timeout: 10_000 })
+    .toMatch(/^gs> echo history-survives-reload$/);
+});
+
 test('shell prompt reflects machine and run state', async ({ page }) => {
   test.setTimeout(5 * 60 * 1000);
   await gotoWeb2(page);

--- a/tests/e2e/web2-specs/shell-prompt.spec.ts
+++ b/tests/e2e/web2-specs/shell-prompt.spec.ts
@@ -71,10 +71,21 @@ test('shell prompt reflects machine and run state', async ({ page }) => {
   ).toBeVisible({ timeout: 60_000 });
 
   // --- Running: "gs se30> ", no PC --------------------------------------
-  // The rendered prompt refreshes on each shell.run return, so run a
-  // no-op first; the prompt that comes back reflects the live machine.
+  // No command is typed first: TerminalPane reseeds the rendered prompt on
+  // the machine.status edge, so the idle input line must update by itself.
   await page.locator('button.ptab[data-tab="terminal"]').click();
-  await terminalRun(page, 'echo sync-running');
+  await expect
+    .poll(() => lastTermLine(page), { timeout: 15_000 })
+    .toMatch(/^gs se30>$/);
+
+  // --- Toolbar pause/resume: idle prompt repaints by itself -------------
+  // No terminal input at all — the run-state edge alone must flip the
+  // rendered prompt to the halted-PC form and back.
+  await page.getByRole('button', { name: 'Pause', exact: true }).click();
+  await expect
+    .poll(() => lastTermLine(page), { timeout: 15_000 })
+    .toMatch(/^gs se30 @[0-9A-F]{8}>$/);
+  await page.getByRole('button', { name: 'Run', exact: true }).click();
   await expect
     .poll(() => lastTermLine(page), { timeout: 15_000 })
     .toMatch(/^gs se30>$/);

--- a/tests/e2e/web2-specs/shell-prompt.spec.ts
+++ b/tests/e2e/web2-specs/shell-prompt.spec.ts
@@ -54,9 +54,23 @@ test('terminal Tab completion replaces the right span', async ({ page }) => {
   const term = page.locator('.xterm');
   await term.click();
 
-  // Object-path completion: the single candidate replaces the whole
-  // dotted word and appends a trailing space.
-  await page.keyboard.type('shell.pro');
+  // Object completion: a lone object candidate completes to "shell."
+  // with NO trailing space (bash's directory idiom), so Tab twice
+  // drills in instead of dead-ending on "shell ".
+  await page.keyboard.type('she');
+  await page.keyboard.press('Tab');
+  await expect
+    .poll(() => lastTermLine(page), { timeout: 10_000 })
+    .toMatch(/^gs> shell\.$/);
+
+  // Second Tab proposes the object's members.
+  await page.keyboard.press('Tab');
+  await expect
+    .poll(() => page.locator('.xterm-rows').innerText(), { timeout: 10_000 })
+    .toContain('shell.complete');
+
+  // A leaf attribute completes with the trailing space.
+  await page.keyboard.type('pro');
   await page.keyboard.press('Tab');
   await expect
     .poll(() => lastTermLine(page), { timeout: 10_000 })
@@ -67,13 +81,14 @@ test('terminal Tab completion replaces the right span', async ({ page }) => {
     .toMatch(/^gs>$/);
 
   // Filesystem-path completion in a method arg: candidates are bare
-  // entry names, so the span must narrow to the basename after the last
-  // '/' — the browser VFS root always contains /opfs.
+  // entry names (span narrows to the basename after the last '/'), and
+  // a directory completes to "name/" — the browser VFS root always
+  // contains /opfs.
   await page.keyboard.type('vfs.ls /op');
   await page.keyboard.press('Tab');
   await expect
     .poll(() => lastTermLine(page), { timeout: 10_000 })
-    .toMatch(/^gs> vfs\.ls \/opfs$/);
+    .toMatch(/^gs> vfs\.ls \/opfs\/$/);
 });
 
 test('shell prompt reflects machine and run state', async ({ page }) => {

--- a/tests/integration/shell-class/test.script
+++ b/tests/integration/shell-class/test.script
@@ -24,33 +24,41 @@ shell.vars
 # expand: no-op when nothing to expand; passes through verbatim.
 assert shell.expand("hello") == "hello" "expand pass-through"
 
-# complete: the tree-walking completer's decision tree, asserted via the
+# complete: the tree-walking completer's decision tree. Returns
+# {candidates, span:{start,end}}; candidates is asserted via the
 # expression layer's V_LIST == V_STRING comparison (a list compares equal
-# to its canonical "[a, b]" formatting). One case per branch — previously
-# these lived in the legacy web UI's tab-complete e2e (window.tabComplete
-# was a thin wrapper over this same shell.complete engine).
+# to its canonical "[a, b]" formatting), span via its int fields. One
+# case per branch — previously these lived in the legacy web UI's
+# tab-complete e2e (window.tabComplete was a thin wrapper over this same
+# shell.complete engine).
 #
 # Line-start: a prefix narrows root children / root methods.
-assert shell.complete("mach", 4) == "[machine]" "line-start child prefix"
-assert shell.complete("qu", 2) == "[quit]" "line-start method prefix"
+assert shell.complete("mach", 4).candidates == "[machine]" "line-start child prefix"
+assert shell.complete("qu", 2).candidates == "[quit]" "line-start method prefix"
 # Mid-path: members of the resolved object, composed with the head so the
-# terminal performs one full-token replace.
-assert shell.complete("machine.cpu.p", 13) == "[machine.cpu.pc]" "mid-path single match"
-assert shell.complete("machine.cpu.s", 13) == "[machine.cpu.sr, machine.cpu.ssp, machine.cpu.sp]" "mid-path multi match"
+# terminal performs one full-token replace — span covers the whole word.
+assert shell.complete("machine.cpu.p", 13).candidates == "[machine.cpu.pc]" "mid-path single match"
+assert shell.complete("machine.cpu.p", 13).span.start == 0 "mid-path span start"
+assert shell.complete("machine.cpu.p", 13).span.end == 13 "mid-path span end"
+assert shell.complete("machine.cpu.s", 13).candidates == "[machine.cpu.sr, machine.cpu.ssp, machine.cpu.sp]" "mid-path multi match"
 # Method-arg position dispatches by arg_decl kind: V_BOOL offers the
 # canonical spellings, followed by the `name=` named-argument forms
-# (proposal-named-args-boot-config §3.5).
-assert shell.complete("machine.sound.mute ", 19) == "[on, off, true, false, muted=]" "V_BOOL arg candidates"
+# (proposal-named-args-boot-config §3.5). The span is the arg word alone.
+assert shell.complete("machine.sound.mute ", 19).candidates == "[on, off, true, false, muted=]" "V_BOOL arg candidates"
 # A typed name prefix narrows to the named-argument form; `name=` prefix
 # completes the value with the name kept.
-assert shell.complete("machine.sound.mute mut", 22) == "[muted=]" "name= prefix narrows"
-assert shell.complete("machine.sound.mute muted=t", 26) == "[muted=true]" "named value completes"
+assert shell.complete("machine.sound.mute mut", 22).candidates == "[muted=]" "name= prefix narrows"
+assert shell.complete("machine.sound.mute mut", 22).span.start == 19 "arg span start"
+assert shell.complete("machine.sound.mute muted=t", 26).candidates == "[muted=true]" "named value completes"
+# Filesystem-path candidates are bare entry names: the span narrows to
+# the basename after the word's last '/'.
+assert shell.complete("vfs.ls /", 8).span.start == 8 "path span after slash"
 # Completion is deliberately suppressed inside $(...), "..." and ${...}.
 # The $ is split off via string concat so the script parser doesn't try to
 # expand a $( / ${ inside this very ${...} expression.
-assert shell.complete("echo $" + "(cpu.", 11) == "[]" "no candidates inside $()"
-assert shell.complete("echo \"machine.cpu.", 18) == "[]" "no candidates inside quotes"
-assert shell.complete("echo $" + "{cpu.", 11) == "[]" "no candidates inside dollar-brace"
+assert shell.complete("echo $" + "(cpu.", 11).candidates == "[]" "no candidates inside $()"
+assert shell.complete("echo \"machine.cpu.", 18).candidates == "[]" "no candidates inside quotes"
+assert shell.complete("echo $" + "{cpu.", 11).candidates == "[]" "no candidates inside dollar-brace"
 
 # alias_set / alias_unset round-trip. Adding "foo" -> "machine.cpu.pc" should
 # make it show up in shell.aliases, and unset should remove it.

--- a/tests/integration/shell-class/test.script
+++ b/tests/integration/shell-class/test.script
@@ -32,11 +32,15 @@ assert shell.expand("hello") == "hello" "expand pass-through"
 # tab-complete e2e (window.tabComplete was a thin wrapper over this same
 # shell.complete engine).
 #
-# Line-start: a prefix narrows root children / root methods.
-assert shell.complete("mach", 4).candidates == "[machine]" "line-start child prefix"
+# Line-start: a prefix narrows root children / root methods. Objects
+# complete to "name." (bash's directory-slash idiom) so the terminal
+# omits the trailing space and the next Tab lists their members; leaf
+# methods/attributes stay bare.
+assert shell.complete("mach", 4).candidates == "[machine.]" "line-start child prefix"
 assert shell.complete("qu", 2).candidates == "[quit]" "line-start method prefix"
 # Mid-path: members of the resolved object, composed with the head so the
 # terminal performs one full-token replace — span covers the whole word.
+assert shell.complete("machine.cp", 10).candidates == "[machine.cpu.]" "mid-path object gets a dot"
 assert shell.complete("machine.cpu.p", 13).candidates == "[machine.cpu.pc]" "mid-path single match"
 assert shell.complete("machine.cpu.p", 13).span.start == 0 "mid-path span start"
 assert shell.complete("machine.cpu.p", 13).span.end == 13 "mid-path span end"
@@ -51,8 +55,13 @@ assert shell.complete("machine.sound.mute mut", 22).candidates == "[muted=]" "na
 assert shell.complete("machine.sound.mute mut", 22).span.start == 19 "arg span start"
 assert shell.complete("machine.sound.mute muted=t", 26).candidates == "[muted=true]" "named value completes"
 # Filesystem-path candidates are bare entry names: the span narrows to
-# the basename after the word's last '/'.
+# the basename after the word's last '/'. Directories complete to
+# "name/" so the next Tab descends.
 assert shell.complete("vfs.ls /", 8).span.start == 8 "path span after slash"
+# Self-contained fixture: a directory in the test's cwd, unique enough
+# that it is the only completion for its prefix.
+vfs.mkdir "cmpl_probe_dir"
+assert shell.complete("vfs.ls cmpl_probe_d", 19).candidates == "[cmpl_probe_dir/]" "directory gets a slash"
 # Completion is deliberately suppressed inside $(...), "..." and ${...}.
 # The $ is split off via string concat so the script parser doesn't try to
 # expand a $( / ${ inside this very ${...} expression.


### PR DESCRIPTION
A batch of shell/terminal quality-of-life fixes, one commit per concern:

## Prompt
- **State-aware prompt** replacing the PC/disasm one: `gs> ` with no machine, `gs <model>> ` while running (a sampled PC is stale the moment it prints), `gs <model> @<pc>> ` when stopped. `shell_build_prompt` stays the single source of truth; the headless REPL's duplicated copy of the old logic now calls it too. The TCP daemon status line (IMP-308, `--no-prompt`) is untouched.
- **Prompt repaints on machine state edges** (boot, toolbar pause/resume, model swap) instead of waiting for the next command — TerminalPane reseeds from `shell.prompt` on `machine.status`/`model` transitions, only when the input line is idle.

## Terminal rendering
- **Light-mode selection is visible**: the xterm theme never set `selectionBackground`, so selection fell back to translucent white — invisible on `#f6f6f6`. New `--gs-terminal-selection` token in both themes.

## Tab completion
- **Completion now actually works in the browser.** The terminal expected `{candidates, span}` from `shell.complete` while the C side returned a bare list; every Tab press was silently discarded. `struct completion` now carries the replace span (whole word for object paths; basename after the last `/` for filesystem candidates) and `shell.complete` returns the map. `meta.complete` keeps its bare-list contract.
- **Drill-in completion**: objects complete to `machine.` and directories to `name/` (bash's directory idiom), with no trailing space, so Tab-Tab descends; leaves keep the trailing space. Also fixes the space wrongly appended after `name=` completions.

## Background checkpoints
- **Status-bar heartbeat instead of terminal spam**: the unconditional `printf` per ~15 s auto-save is now a level-gated `checkpoint` log line (`debug.log checkpoint 1` restores it). A `CP` glyph beside the drive lights flashes per save via a new `Module.onCheckpointSaved` push; the tooltip carries the last save's time and duration. Failure paths stay loud.

## History
- **Persistent shell history** in `/opfs/.shell_history` (256 lines, merged on load ahead of anything typed since page load, coalesced writes).

## Testing
Every change is covered: new/extended Playwright specs (`shell-prompt.spec.ts` ×4 tests, a tick-auto checkpoint test in `checkpoint-resume.spec.ts` that waits out a real ~15 s auto-save), `shell-class` integration asserts updated to the new completion shape with span/suffix cases, StatusBar component tests, and headless probes for the completion engine. All run green locally; the checkpoint e2e caught a real gating bug (`log_emit` bypasses the level check — `LOG_WITH` is the gated form) during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)