### PR TITLE
object: setters own the value they are handed, and now say so

### DIFF
--- a/src/core/network/appletalk.c
+++ b/src/core/network/appletalk.c
@@ -3197,8 +3197,11 @@ static value_t atalk_afp_attr_set_name(struct object *self, const member_t *m, v
     (void)self;
     (void)m;
     char err[192];
-    if (atalk_afp_set_name(in.s, err, sizeof(err)) != 0)
+    if (atalk_afp_set_name(in.s, err, sizeof(err)) != 0) {
+        value_free(&in);
         return atalk_err("cannot rename the AFP server", err);
+    }
+    value_free(&in);
     return val_none();
 }
 static value_t atalk_afp_attr_message(struct object *self, const member_t *m) {
@@ -3210,8 +3213,11 @@ static value_t atalk_afp_attr_set_message(struct object *self, const member_t *m
     (void)self;
     (void)m;
     char err[192];
-    if (atalk_afp_set_message(in.s, err, sizeof(err)) != 0)
+    if (atalk_afp_set_message(in.s, err, sizeof(err)) != 0) {
+        value_free(&in);
         return atalk_err("cannot set the server message", err);
+    }
+    value_free(&in);
     return val_none();
 }
 static value_t atalk_afp_attr_versions(struct object *self, const member_t *m) {
@@ -3281,8 +3287,11 @@ static value_t atalk_printer_attr_set_name(struct object *self, const member_t *
     (void)self;
     (void)m;
     char err[192];
-    if (atalk_printer_set_name(in.s, err, sizeof(err)) != 0)
+    if (atalk_printer_set_name(in.s, err, sizeof(err)) != 0) {
+        value_free(&in);
         return atalk_err("cannot rename the printer", err);
+    }
+    value_free(&in);
     return val_none();
 }
 

--- a/src/core/network/appletalk_aevt.c
+++ b/src/core/network/appletalk_aevt.c
@@ -1008,9 +1008,12 @@ static value_t aevt_attr_set_port_name(struct object *self, const member_t *m, v
     (void)self;
     (void)m;
     char err[192] = "";
-    if (atalk_ppc_set_host_port(in.s, g_enabled, err, sizeof(err)) != 0)
+    if (atalk_ppc_set_host_port(in.s, g_enabled, err, sizeof(err)) != 0) {
+        value_free(&in);
         return val_err("cannot rename the host program-linking port: %s", err);
+    }
     snprintf(g_port_name, sizeof(g_port_name), "%s", in.s);
+    value_free(&in);
     return val_none();
 }
 static value_t aevt_attr_auto_reply(struct object *self, const member_t *m) {
@@ -1028,10 +1031,13 @@ static value_t aevt_attr_set_auto_reply(struct object *self, const member_t *m, 
         value_t probe = aevt_parse_text(text, err, sizeof(err));
         bool bad = val_is_error(&probe);
         value_free(&probe);
-        if (bad)
+        if (bad) {
+            value_free(&in);
             return val_err("that reply template does not parse: %s", err);
+        }
     }
     snprintf(g_auto_reply, sizeof(g_auto_reply), "%s", text);
+    value_free(&in);
     return val_none();
 }
 

--- a/src/core/object/object.h
+++ b/src/core/object/object.h
@@ -93,6 +93,11 @@ typedef struct arg_decl {
 
 struct member;
 typedef value_t (*attr_get_fn)(struct object *self, const struct member *m);
+// A setter OWNS `in`: it must value_free() it on every path, including its
+// error returns (node_set frees `in` itself only when it rejects the write
+// before reaching the setter).  Copy anything you need to keep — the value's
+// string/bytes storage is heap memory that nothing else will release.  Scalar
+// kinds carry no allocation, so a setter for those may skip the free.
 typedef value_t (*attr_set_fn)(struct object *self, const struct member *m, value_t in);
 typedef value_t (*method_fn)(struct object *self, const struct member *m, int argc, const value_t *argv);
 typedef struct object *(*child_get_fn)(struct object *self, int index);
@@ -320,6 +325,9 @@ node_t object_resolve(struct object *root, const char *path);
 // Read / write / call by node. node_get on an M_CHILD member returns
 // V_OBJECT pointing at the child; on M_METHOD returns V_ERROR (use
 // node_call). node_set on a read-only attribute returns V_ERROR.
+// node_set consumes `v`: it frees the value when it rejects the write, and
+// otherwise hands ownership to the attribute's setter (see attr_set_fn).
+// Callers must not free `v` afterwards.
 value_t node_get(node_t n);
 value_t node_set(node_t n, value_t v);
 value_t node_call(node_t n, int argc, const value_t *argv);


### PR DESCRIPTION
Fixes the nightly, which has been red on the same test since **#15 (Aug 13)** —
six consecutive nights, last green was #14.

## The failure

`Nightly #20` → `extended` job → "Valgrind (unit tier + one boot)". One of 39
valgrind tests failed:

```
41 bytes in 3 blocks are definitely lost in loss record 37 of 73
   xstrdup → val_str → interp_walk → expr_parse_dq_string → parse_primary
   → … → expr_eval → exec_stmt → script_run_file → main
=== FAIL (valgrind): object-toplevel ===
1 of 39 test(s) FAILED (valgrind)
```

Bisecting the script by prefix length put the three blocks on the three
string-valued attribute assignments, and the byte counts match the assigned
literals exactly:

| statement | bytes |
|---|---|
| `appletalk.afp.name = "Test Server"` | 12 |
| `appletalk.afp.message = "Back at 5pm"` | 12 |
| `appletalk.printer.name = "Test LaserWriter"` | 17 |

## Root cause

Not any single setter — an **undocumented ownership contract**.

`node_set()` frees the incoming value on every path where it *rejects* the
write (invalid node, not an attribute, read-only, no setter, validation
failure), and otherwise passes it to `attr.set`. The setter is therefore the
owner. Nothing in `object.h` said so, and the setters split 6-to-5 on whether
they believed it:

- **free it** — `bp_attr_condition_set`, `sched_attr_mode_set`,
  `slot_attr_card_id_set`, `slot_attr_video_mode_set`, `videoin_attr_source_set`,
  `ain_attr_source_set`
- **don't** — `atalk_afp_attr_set_name`, `atalk_afp_attr_set_message`,
  `atalk_printer_attr_set_name`, `aevt_attr_set_port_name`,
  `aevt_attr_set_auto_reply`

So `obj.attr = "string"` leaked `strlen+1` bytes every time. Integer and bool
assignments carry no allocation, which is why the other 38 valgrind tests stay
clean and why this sat unnoticed.

## Why it surfaced on Aug 13

The assignment path is from **`80418fe` "Shell language v2" (#71), Jul 23** —
the leak is three weeks older than the first red nightly. **`5a92d6f` (#94)**
rewrote `object-toplevel` and gave it the first *string-valued* attribute
assignments in a valgrind-covered test. It exposed the bug, it did not
introduce it.

## The fix

State the contract at `attr_set_fn` and at `node_set`, and make the five
outliers conform. All five copy into fixed buffers via `snprintf`, so freeing
is safe; each frees after the copy is taken, on the error return as well as
the success one.

**The alternative I did not take**, deliberately: move the free into
`node_set` so forgetting becomes structurally impossible. Better shape in the
abstract, but it means auditing and removing 33 existing `value_free(&in)`
calls across 7 files, where a single miss is a double free — a worse failure
mode than the leak, on a fix whose whole purpose is memory hygiene. The
reasoning is in the commit message so it can be revisited deliberately rather
than rediscovered.

## Audit behind "5 of 11"

Every attribute setter whose type owns heap storage
(`V_STRING`/`V_BYTES`/`V_LIST`/`V_REF`/`V_MAP`), enumerated by parsing the
`.attr = {…}` initialisers — plus the macro-generated `PPC_ATTR` /
`PPC_FPR_ATTR` tables that a regex over that shape misses (both `V_UINT`, so
scalar). `node_set` is the only caller of `attr.set` anywhere in the tree, and
`node_validate_set` already frees the original when it coerces a value.

## Verification

- `object-toplevel` → **PASS** under valgrind (it was the only failing test of
  the 39).
- Both `aevt` setters exercised on their success **and** error paths by a
  directed script: 0 lost, 0 errors, no invalid frees — the frees are not
  double-freeing.
- `suite-plus` — a full Plus boot — passes under valgrind.
- The ten object-model unit suites pass.

The aggregate `make test-valgrind TIER=unit` could not run locally: this
checkout's `tests/data` is a manifest-only revision ahead of `tests/data-version`,
and `check-data` compares revision strings. CI fetches the pinned revision, so
it runs there — and the nightly is the real proof, since this PR's gate does
not run valgrind at all.

## Unrelated observation, not fixed here

`check-data` guards only the aggregate targets. `test-%` and `test-valgrind-%`
(Makefile:184, :221) have no such prerequisite, so a single-row run proceeds
against whatever media is on disk and still compares byte-exact goldens. The
failure mode is a confusing golden mismatch rather than a silent pass, but it
lets a local single-row result disagree with CI without saying why. Happy to
add the guard in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
