### PR TITLE
storage: read UDIF (.dmg) disk images

### DIFF
--- a/docs/core/storage/image.md
+++ b/docs/core/storage/image.md
@@ -59,6 +59,28 @@ static const char *pick_delta_dir(const char *path) {
 
 `fd insert`, `fd create`, and `hd attach` all funnel through this helper.
 
+**Compressed image formats** — NDIF and UDIF
+
+Two Apple disk-image containers are decoded on open, before any of the above runs. `resolve_base_image()` tries each in turn and, on a hit, decodes the whole image once into a raw scratch file under the storage-cache directory (`GS_STORAGE_CACHE`, else `/tmp/gs-image-ro/`); everything downstream then sees an ordinary raw base. The scratch name is derived from the source path, size, and mtime, so repeated inserts reuse the decode and an edited source re-decodes.
+
+| | NDIF (Disk Copy 6.x) | UDIF (`.dmg`) |
+|---|---|---|
+| Block map | `'bcem'` resource, 12-byte descriptors | `'mish'` tables, 40-byte entries |
+| Where it lives | the **resource fork** — needs an AppleDouble sidecar or a containing HFS volume | a **plist inside the file**, found via the 512-byte `'koly'` trailer at EOF |
+| Compressors | zero-fill, raw, ADC | zero-fill, ignored, raw, ADC, zlib |
+| Parser | `image_ndif.c` | `image_udif.c` |
+
+UDIF specifics worth knowing before touching `image_udif.c`:
+
+- **Everything is big-endian**, including on the PowerPC-era images this mostly exists to read.
+- **Chunk sectors are relative to their table's `base_sector`.** Absolute position is `table.base_sector + chunk.sector`; one block table per partition, each restarting at zero. This is the classic way to misread the format, and `tests/integration/image-udif/` exists to catch it.
+- **`SectorCount` lives at trailer offset 0x1EC**, not where a naive walk of the published struct puts it — the 128-byte checksum blobs shift several fields. Static assertions in `image_udif.c` keep every offset inside the 512-byte trailer.
+- **The u32 at `mish` offset 0x24 is the blkx resource ID, not a descriptor count.** The count is at 0xC8.
+- **Each block table carries a CRC-32 over its decoded bytes**, and chunks of type `UDIF_CHUNK_IGNORE` are excluded from it. `materialize_udif_host()` verifies this as it writes, so a bad decode fails at open with a logged mismatch instead of surfacing later as a subtly corrupt disk.
+- Encrypted (`encrcdsa`), multi-segment (`.dmgpart`), bzip2, LZFSE and LZMA images are **rejected explicitly** rather than partially decoded.
+
+The zlib decompressor both this and the PNG reader use is first-party (`inflate.c`); the core links no third-party C libraries.
+
 **Volatile image persistence** — `image_persist_volatile(const char *path)`
 
 When a disk image resides in volatile storage (`/tmp/` or `/fd/`), this function copies it to `/opfs/images/<hash>.img` (OPFS-backed, content-addressed via FNV-1a hash). This runs on the worker thread where OPFS is accessible. The `fd insert` and `hd attach` commands call this automatically before opening the image. Returns a persistent path that the caller must free.

--- a/src/core/debug/debug.c
+++ b/src/core/debug/debug.c
@@ -19,6 +19,7 @@
 #include "display.h"
 #include "expr.h"
 #include "fpu.h"
+#include "inflate.h"
 #include "log.h"
 #include "memory.h"
 #include "mmu.h"
@@ -1063,18 +1064,8 @@ static uint32_t adler32(const uint8_t *data, size_t len) {
 #define DEFLATE_HASH_SIZE (1 << DEFLATE_HASH_BITS)
 #define DEFLATE_MAX_CHAIN 64
 
-// Match-length codes 257..285: first length each code covers, and how many
-// extra bits follow (RFC 1951 §3.2.5).
-static const uint16_t deflate_len_base[29] = {3,  4,  5,  6,  7,  8,  9,  10, 11,  13,  15,  17,  19,  23, 27,
-                                              31, 35, 43, 51, 59, 67, 83, 99, 115, 131, 163, 195, 227, 258};
-static const uint8_t deflate_len_extra[29] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2,
-                                              2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0};
-// Distance codes 0..29, same layout.
-static const uint16_t deflate_dist_base[30] = {1,    2,    3,    4,    5,    7,    9,    13,    17,    25,
-                                               33,   49,   65,   97,   129,  193,  257,  385,   513,   769,
-                                               1025, 1537, 2049, 3073, 4097, 6145, 8193, 12289, 16385, 24577};
-static const uint8_t deflate_dist_extra[30] = {0, 0, 0, 0, 1, 1, 2, 2,  3,  3,  4,  4,  5,  5,  6,
-                                               6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13};
+// The RFC 1951 §3.2.5 length/distance tables the writer needs are shared
+// with the decoder and now live in inflate.c (declared in inflate.h).
 
 // LSB-first bit writer over a caller-sized buffer.
 typedef struct {
@@ -1329,226 +1320,6 @@ static uint32_t read_be32(const uint8_t *p) {
     return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) | ((uint32_t)p[2] << 8) | (uint32_t)p[3];
 }
 
-// ===== Inflate (stored, fixed and dynamic Huffman blocks) ==================
-// Reference PNGs are written deflated (see zlib_compress) and may also come
-// from ordinary image tools, so the reader implements all three DEFLATE block
-// types rather than just stored blocks.
-
-// LSB-first bit reader over a deflate stream.
-typedef struct {
-    const uint8_t *data;
-    size_t len;
-    size_t pos;
-    uint32_t acc;
-    int nbits;
-    int error;
-} inflate_br_t;
-
-// Pull `need` bits (0..16), least-significant bit first.
-static uint32_t inflate_bits(inflate_br_t *b, int need) {
-    if (need <= 0)
-        return 0;
-    while (b->nbits < need) {
-        if (b->pos >= b->len) {
-            b->error = 1;
-            return 0;
-        }
-        b->acc |= (uint32_t)b->data[b->pos++] << b->nbits;
-        b->nbits += 8;
-    }
-    uint32_t v = b->acc & ((1u << need) - 1);
-    b->acc >>= need;
-    b->nbits -= need;
-    return v;
-}
-
-// A canonical Huffman table: how many codes exist per bit length, plus the
-// symbols in canonical order.
-typedef struct {
-    uint16_t counts[16];
-    uint16_t symbols[288];
-} inflate_huff_t;
-
-// Build a canonical Huffman table from an array of per-symbol code lengths.
-static void inflate_build(inflate_huff_t *h, const uint8_t *lengths, int n) {
-    for (int i = 0; i < 16; i++)
-        h->counts[i] = 0;
-    for (int i = 0; i < n; i++)
-        h->counts[lengths[i]]++;
-    h->counts[0] = 0;
-    uint16_t offsets[16];
-    offsets[0] = 0;
-    offsets[1] = 0;
-    for (int i = 1; i < 15; i++)
-        offsets[i + 1] = (uint16_t)(offsets[i] + h->counts[i]);
-    for (int i = 0; i < n; i++)
-        if (lengths[i])
-            h->symbols[offsets[lengths[i]]++] = (uint16_t)i;
-}
-
-// Decode one symbol, walking code lengths shortest-first.  Returns -1 on a
-// malformed stream.
-static int inflate_decode(inflate_br_t *b, const inflate_huff_t *h) {
-    int code = 0, first = 0, index = 0;
-    for (int len = 1; len <= 15; len++) {
-        code |= (int)inflate_bits(b, 1);
-        if (b->error)
-            return -1;
-        int count = h->counts[len];
-        if (code - first < count)
-            return h->symbols[index + (code - first)];
-        index += count;
-        first = (first + count) << 1;
-        code <<= 1;
-    }
-    return -1;
-}
-
-// Append one byte to a growing output buffer.  Returns 0 on allocation failure.
-static int inflate_push(uint8_t **out, size_t *cap, size_t *pos, uint8_t byte) {
-    if (*pos >= *cap) {
-        size_t new_cap = *cap * 2;
-        uint8_t *grown = realloc(*out, new_cap);
-        if (!grown)
-            return 0;
-        *out = grown;
-        *cap = new_cap;
-    }
-    (*out)[(*pos)++] = byte;
-    return 1;
-}
-
-// Inflate a zlib stream (2-byte header, deflate blocks, adler32 trailer).
-// Returns malloc'd output, or NULL if the stream is truncated or malformed.
-static uint8_t *png_inflate(const uint8_t *data, size_t data_len, size_t *out_len) {
-    if (data_len < 6)
-        return NULL; // zlib header + at least one block
-
-    inflate_br_t b = {data + 2, data_len - 2, 0, 0, 0, 0};
-    size_t cap = 1 << 16, pos = 0;
-    uint8_t *out = malloc(cap);
-    if (!out)
-        return NULL;
-
-    for (;;) {
-        int bfinal = (int)inflate_bits(&b, 1);
-        int btype = (int)inflate_bits(&b, 2);
-        if (b.error)
-            goto fail;
-
-        if (btype == 0) {
-            // Stored: discard the partial byte, then copy LEN raw bytes.
-            b.acc = 0;
-            b.nbits = 0;
-            if (b.pos + 4 > b.len)
-                goto fail;
-            uint16_t len = (uint16_t)(b.data[b.pos] | ((uint16_t)b.data[b.pos + 1] << 8));
-            b.pos += 4; // LEN + NLEN
-            if (b.pos + len > b.len)
-                goto fail;
-            for (uint16_t i = 0; i < len; i++)
-                if (!inflate_push(&out, &cap, &pos, b.data[b.pos + i]))
-                    goto fail;
-            b.pos += len;
-        } else if (btype == 1 || btype == 2) {
-            inflate_huff_t lit, dist;
-            if (btype == 1) {
-                // Fixed code lengths (RFC 1951 §3.2.6).
-                uint8_t ll[288], dl[30];
-                for (int i = 0; i < 288; i++)
-                    ll[i] = (i < 144) ? 8 : (i < 256) ? 9 : (i < 280) ? 7 : 8;
-                for (int i = 0; i < 30; i++)
-                    dl[i] = 5;
-                inflate_build(&lit, ll, 288);
-                inflate_build(&dist, dl, 30);
-            } else {
-                // Dynamic: read the code-length code, then the two real ones.
-                static const uint8_t order[19] = {16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15};
-                int hlit = (int)inflate_bits(&b, 5) + 257;
-                int hdist = (int)inflate_bits(&b, 5) + 1;
-                int hclen = (int)inflate_bits(&b, 4) + 4;
-                if (b.error || hlit > 286 || hdist > 30)
-                    goto fail;
-                uint8_t cl[19] = {0};
-                for (int i = 0; i < hclen; i++)
-                    cl[order[i]] = (uint8_t)inflate_bits(&b, 3);
-                if (b.error)
-                    goto fail;
-                inflate_huff_t clh;
-                inflate_build(&clh, cl, 19);
-
-                uint8_t lengths[318] = {0};
-                int n = 0;
-                while (n < hlit + hdist) {
-                    int sym = inflate_decode(&b, &clh);
-                    if (sym < 0)
-                        goto fail;
-                    if (sym < 16) {
-                        lengths[n++] = (uint8_t)sym;
-                    } else if (sym == 16) {
-                        if (n == 0)
-                            goto fail;
-                        uint8_t prev = lengths[n - 1];
-                        int repeat = 3 + (int)inflate_bits(&b, 2);
-                        while (repeat-- > 0 && n < hlit + hdist)
-                            lengths[n++] = prev;
-                    } else if (sym == 17) {
-                        int repeat = 3 + (int)inflate_bits(&b, 3);
-                        while (repeat-- > 0 && n < hlit + hdist)
-                            lengths[n++] = 0;
-                    } else {
-                        int repeat = 11 + (int)inflate_bits(&b, 7);
-                        while (repeat-- > 0 && n < hlit + hdist)
-                            lengths[n++] = 0;
-                    }
-                    if (b.error)
-                        goto fail;
-                }
-                inflate_build(&lit, lengths, hlit);
-                inflate_build(&dist, lengths + hlit, hdist);
-            }
-
-            for (;;) {
-                int sym = inflate_decode(&b, &lit);
-                if (sym < 0)
-                    goto fail;
-                if (sym == 256)
-                    break;
-                if (sym < 256) {
-                    if (!inflate_push(&out, &cap, &pos, (uint8_t)sym))
-                        goto fail;
-                    continue;
-                }
-                sym -= 257;
-                if (sym >= 29)
-                    goto fail;
-                size_t length = deflate_len_base[sym] + inflate_bits(&b, deflate_len_extra[sym]);
-                int dsym = inflate_decode(&b, &dist);
-                if (dsym < 0 || dsym >= 30)
-                    goto fail;
-                size_t distance = deflate_dist_base[dsym] + inflate_bits(&b, deflate_dist_extra[dsym]);
-                if (b.error || distance == 0 || distance > pos)
-                    goto fail;
-                for (size_t i = 0; i < length; i++)
-                    if (!inflate_push(&out, &cap, &pos, out[pos - distance]))
-                        goto fail;
-            }
-        } else {
-            goto fail; // BTYPE 3 is reserved
-        }
-
-        if (bfinal)
-            break;
-    }
-
-    *out_len = pos;
-    return out;
-
-fail:
-    free(out);
-    return NULL;
-}
-
 // Convert one row of a live framebuffer to packed RGBA (no PNG filter
 // byte).  Pulled out of save_framebuffer_as_png so screen.match can
 // compare any pixel format against an RGBA reference PNG without
@@ -1707,7 +1478,7 @@ static int load_png_to_rgba(const char *filename, int expected_width, int expect
     }
 
     size_t raw_size = 0;
-    uint8_t *raw_data = png_inflate(idat_data, idat_len, &raw_size);
+    uint8_t *raw_data = inflate_zlib_alloc(idat_data, idat_len, &raw_size);
     free(idat_data);
     if (!raw_data) {
         printf("Error: Failed to decompress PNG..\n");
@@ -1868,7 +1639,7 @@ static int load_png_to_framebuffer(const char *filename, uint8_t *fb_out, int ex
 
     // Decompress IDAT data (stored blocks only)
     size_t raw_size = 0;
-    uint8_t *raw_data = png_inflate(idat_data, idat_len, &raw_size);
+    uint8_t *raw_data = inflate_zlib_alloc(idat_data, idat_len, &raw_size);
     free(idat_data);
 
     if (!raw_data) {

--- a/src/core/storage/image.c
+++ b/src/core/storage/image.c
@@ -12,6 +12,7 @@
 
 #include "appledouble.h"
 #include "image_ndif.h"
+#include "image_udif.h"
 #include "log.h"
 #include "platform.h"
 #include "system.h"
@@ -545,11 +546,235 @@ static uint32_t fork_hash_str(const char *s, uint32_t h) {
     return h;
 }
 
-// If base_path is an NDIF image whose block map can be recovered from a fork
-// sidecar, decode it to a cached scratch raw file and return that path
-// (malloc'd, caller frees / image takes ownership).  Otherwise return a copy of
-// base_path.  NULL only on allocation failure.
+// Build the deterministic scratch path a decoded image is cached under:
+// "<scratch>/<tag>-<hash>.img", hashed from path + size + mtime so repeated
+// inserts reuse the decode and a changed source re-decodes.
+static void image_scratch_path(const char *base_path, const char *tag, char *out, size_t cap) {
+    struct stat sb;
+    uint32_t h = fork_hash_str(base_path, 0x811c9dc5u);
+    if (stat(base_path, &sb) == 0) {
+        h = fork_hash_str("\x1f", h);
+        char meta[64];
+        snprintf(meta, sizeof(meta), "%lld:%lld", (long long)sb.st_size, (long long)sb.st_mtime);
+        h = fork_hash_str(meta, h);
+    }
+    snprintf(out, cap, "%s/%s-%08x.img", image_scratch_dir(), tag, h);
+}
+
+// === UDIF (.dmg) materialisation ==========================================
+// A UDIF image needs no resource fork: the 512-byte 'koly' trailer at EOF
+// points at both the compressed payload and the XML block map, so everything
+// is reachable from the one host path.  Decode it to a scratch raw image the
+// same way NDIF is handled above.  See image_udif.h.
+
+// Largest chunk we will buffer whole for decompression.  Real writers emit
+// ~1 MB chunks; anything wildly larger means a corrupt map, not a big disk.
+#define UDIF_MAX_CHUNK_BYTES (64u * 1024u * 1024u)
+
+// Read exactly `len` bytes at absolute offset `off`.  0 / -errno.
+static int read_at(FILE *f, uint64_t off, void *buf, size_t len) {
+    if (fseeko(f, (off_t)off, SEEK_SET) != 0)
+        return -EIO;
+    return fread(buf, 1, len, f) == len ? 0 : -EIO;
+}
+
+// Fold `len` zero bytes into a running CRC-32 without allocating them.
+static uint32_t crc32_zeros(uint32_t crc, uint64_t len) {
+    static const uint8_t zeros[4096] = {0};
+    while (len) {
+        size_t n = len < sizeof(zeros) ? (size_t)len : sizeof(zeros);
+        crc = udif_crc32(crc, zeros, n);
+        len -= n;
+    }
+    return crc;
+}
+
+// Copy a RAW chunk straight through in slices, folding it into `crc`.  Raw
+// chunks can cover a whole disk, so this never buffers the run whole.
+static int copy_raw_chunk(FILE *df, FILE *out, const udif_chunk_t *c, uint64_t base_sector, uint32_t *crc) {
+    uint8_t buf[64 * 1024];
+    uint64_t remaining = c->count * 512;
+    if (c->length < remaining)
+        return -EINVAL; // the map promises more sectors than the fork holds
+    uint64_t src = c->offset;
+    if (fseeko(out, (off_t)(base_sector + c->sector) * 512, SEEK_SET) != 0)
+        return -EIO;
+    while (remaining) {
+        size_t n = remaining < sizeof(buf) ? (size_t)remaining : sizeof(buf);
+        if (read_at(df, src, buf, n) != 0 || fwrite(buf, 1, n, out) != n)
+            return -EIO;
+        *crc = udif_crc32(*crc, buf, n);
+        src += n;
+        remaining -= n;
+    }
+    return 0;
+}
+
+// Decode one compressed (or zero-fill) chunk to its place in `out`, folding
+// the decoded bytes into `crc`.  0 / -errno.
+static int write_udif_chunk(FILE *df, FILE *out, const udif_chunk_t *c, uint64_t base_sector, uint32_t *crc) {
+    // Ignored chunks are unallocated space: they read as zeros and, unlike
+    // zero-fill, are excluded from the table checksum entirely.
+    if (c->type == UDIF_CHUNK_IGNORE)
+        return 0;
+    uint64_t need = c->count * 512;
+    if (need == 0)
+        return 0;
+    // Zero-fill needs no bytes written — the file was pre-extended with zeros.
+    if (c->type == UDIF_CHUNK_ZERO) {
+        *crc = crc32_zeros(*crc, need);
+        return 0;
+    }
+    if (c->type == UDIF_CHUNK_RAW)
+        return copy_raw_chunk(df, out, c, base_sector, crc);
+
+    if (need > UDIF_MAX_CHUNK_BYTES || c->length > UDIF_MAX_CHUNK_BYTES)
+        return -EFBIG;
+    uint8_t *cbuf = (uint8_t *)malloc((size_t)c->length ? (size_t)c->length : 1);
+    uint8_t *dbuf = (uint8_t *)malloc((size_t)need);
+    int rc = 0;
+    if (!cbuf || !dbuf) {
+        rc = -ENOMEM;
+    } else if (read_at(df, c->offset, cbuf, (size_t)c->length) != 0) {
+        rc = -EIO;
+    } else if ((rc = udif_decode_chunk(c, cbuf, (size_t)c->length, dbuf, (size_t)need)) == 0) {
+        if (fseeko(out, (off_t)(base_sector + c->sector) * 512, SEEK_SET) != 0 ||
+            fwrite(dbuf, 1, (size_t)need, out) != need)
+            rc = -EIO;
+        else
+            *crc = udif_crc32(*crc, dbuf, (size_t)need);
+    }
+    free(cbuf);
+    free(dbuf);
+    return rc;
+}
+
+// Decode a whole UDIF image (host file `base_path`, trailer `tr`, block map
+// `map`) into a freshly created scratch raw file `scratch`.  Each block
+// table's stored CRC-32 is verified as it is written, so a bad decode fails
+// here rather than surfacing as a subtly corrupt disk. 0 / -errno.
+static int materialize_udif_host(const char *base_path, const udif_trailer_t *tr, udif_map_t *map,
+                                 const char *scratch) {
+    FILE *df = fopen(base_path, "rb");
+    if (!df)
+        return -errno;
+    FILE *out = fopen(scratch, "wb");
+    if (!out) {
+        int e = errno;
+        fclose(df);
+        return e ? -e : -EIO;
+    }
+
+    int rc = 0;
+    if (ftruncate(fileno(out), (off_t)(tr->sectors * 512)) != 0) {
+        rc = -EIO;
+        goto done;
+    }
+    for (size_t i = 0; i < map->n_tables && rc == 0; i++) {
+        udif_table_t *t = &map->tables[i];
+        uint32_t crc = 0;
+        for (size_t j = 0; j < t->n_chunks; j++) {
+            udif_chunk_t *c = &t->chunks[j];
+            // Absolute position is the table's base plus the chunk's own
+            // sector, which restarts at 0 in every table.
+            if (t->base_sector + c->sector + c->count > tr->sectors) {
+                rc = -EINVAL;
+                break;
+            }
+            rc = write_udif_chunk(df, out, c, t->base_sector, &crc);
+            if (rc != 0) {
+                LOG(1, "UDIF chunk %zu of '%s' (type %#x) failed: %d", j, t->name, c->type, rc);
+                break;
+            }
+        }
+        // A stored CRC of zero means the writer recorded none (every table of
+        // purely unallocated space does), so only a real value is checked.
+        if (rc == 0 && t->checksum_type == UDIF_CHECKSUM_CRC32 && t->checksum != 0 && crc != t->checksum) {
+            LOG(1, "UDIF checksum mismatch in '%s': stored %08x, decoded %08x", t->name, t->checksum, crc);
+            rc = -EINVAL;
+        }
+    }
+done:
+    fclose(df);
+    if (fclose(out) != 0 && rc == 0)
+        rc = -EIO;
+    return rc;
+}
+
+// If base_path is a UDIF image, decode it to a cached scratch raw file and
+// return that path (malloc'd, caller frees).  Returns NULL when the file is
+// not UDIF at all, or when its decode failed — both fall through to the
+// remaining formats.
+static char *resolve_udif_image(const char *base_path) {
+    FILE *f = fopen(base_path, "rb");
+    if (!f)
+        return NULL;
+    uint8_t trailer[UDIF_TRAILER_SIZE];
+    int seek_rc = fseeko(f, -(off_t)sizeof(trailer), SEEK_END);
+    bool have_trailer = seek_rc == 0 && fread(trailer, 1, sizeof(trailer), f) == sizeof(trailer);
+    fclose(f);
+    if (!have_trailer || !udif_detect(trailer, sizeof(trailer)))
+        return NULL;
+
+    udif_trailer_t tr;
+    int rc = udif_parse_trailer(trailer, sizeof(trailer), &tr);
+    if (rc != 0) {
+        LOG(1, "unsupported UDIF trailer in '%s' (%d)", base_path, rc);
+        return NULL;
+    }
+
+    char scratch[PATH_MAX];
+    image_scratch_path(base_path, "udif", scratch, sizeof(scratch));
+    struct stat cached;
+    if (stat(scratch, &cached) == 0 && cached.st_size == (off_t)(tr.sectors * 512))
+        return dup_string(scratch); // already materialised
+
+    // The block map lives in the XML plist the trailer points at.
+    uint8_t *xml = (uint8_t *)malloc((size_t)tr.xml_length);
+    if (!xml)
+        return NULL;
+    f = fopen(base_path, "rb");
+    if (!f || read_at(f, tr.xml_offset, xml, (size_t)tr.xml_length) != 0) {
+        if (f)
+            fclose(f);
+        free(xml);
+        LOG(1, "UDIF '%s': cannot read block map", base_path);
+        return NULL;
+    }
+    fclose(f);
+
+    udif_map_t *map = NULL;
+    rc = udif_parse_blkx(xml, (size_t)tr.xml_length, &map);
+    free(xml);
+    if (rc != 0) {
+        LOG(1, "UDIF '%s': block map parse failed (%d)", base_path, rc);
+        return NULL;
+    }
+
+    char *result = NULL;
+    mkdir_recursive(image_scratch_dir());
+    if (materialize_udif_host(base_path, &tr, map, scratch) == 0) {
+        LOG(3, "decoded UDIF '%s' -> '%s' (%llu sectors, %zu partitions)", base_path, scratch,
+            (unsigned long long)tr.sectors, map->n_tables);
+        result = dup_string(scratch);
+    } else {
+        remove(scratch);
+        LOG(1, "UDIF decode failed for '%s'", base_path);
+    }
+    udif_map_free(map);
+    return result;
+}
+
+// If base_path is a compressed disk image, decode it to a cached scratch raw
+// file and return that path (malloc'd, caller frees / image takes ownership).
+// UDIF (.dmg) is self-contained and checked first; NDIF needs its block map
+// recovered from a fork sidecar.  Otherwise return a copy of base_path.
+// NULL only on allocation failure.
 static char *resolve_base_image(const char *base_path) {
+    char *udif = resolve_udif_image(base_path);
+    if (udif)
+        return udif;
+
     size_t rlen = 0;
     uint8_t *rfork = acquire_resource_fork(base_path, &rlen);
     if (!rfork)
@@ -559,18 +784,8 @@ static char *resolve_base_image(const char *base_path) {
     if (ndif_detect(rfork, rlen)) {
         ndif_map_t *map = NULL;
         if (ndif_parse(rfork, rlen, &map) == 0) {
-            // Deterministic scratch name from path + size + mtime, so repeated
-            // inserts reuse the decode and a changed source re-decodes.
-            struct stat sb;
-            uint32_t h = fork_hash_str(base_path, 0x811c9dc5u);
-            if (stat(base_path, &sb) == 0) {
-                h = fork_hash_str("\x1f", h);
-                char meta[64];
-                snprintf(meta, sizeof(meta), "%lld:%lld", (long long)sb.st_size, (long long)sb.st_mtime);
-                h = fork_hash_str(meta, h);
-            }
             char scratch[PATH_MAX];
-            snprintf(scratch, sizeof(scratch), "%s/ndif-%08x.img", image_scratch_dir(), h);
+            image_scratch_path(base_path, "ndif", scratch, sizeof(scratch));
 
             struct stat cached;
             if (stat(scratch, &cached) == 0 && cached.st_size == (off_t)map->sectors * 512) {

--- a/src/core/storage/image.c
+++ b/src/core/storage/image.c
@@ -546,12 +546,30 @@ static uint32_t fork_hash_str(const char *s, uint32_t h) {
     return h;
 }
 
+// Resolve `path` through realpath() so every spelling of the same file — the
+// relative one a script passes to storage.probe, the absolute one the VFS
+// resolves, a symlink — reduces to one string.  Falls back to the input when
+// realpath cannot resolve it (e.g. the file was just deleted), preserving the
+// old keying.  image_vfs.c canonicalises its mount table the same way.
+static void image_canonicalise(const char *path, char *out, size_t cap) {
+    // Let realpath() allocate, so a host path limit above the build-time
+    // PATH_MAX does not get silently truncated.
+    char *resolved = realpath(path, NULL);
+    snprintf(out, cap, "%s", resolved ? resolved : path);
+    free(resolved);
+}
+
 // Build the deterministic scratch path a decoded image is cached under:
 // "<scratch>/<tag>-<hash>.img", hashed from path + size + mtime so repeated
-// inserts reuse the decode and a changed source re-decodes.
+// inserts reuse the decode and a changed source re-decodes.  The path is
+// canonicalised first: hashing the caller's spelling instead decoded the same
+// disc once per spelling, which for a CD-sized .dmg costs a second full decode
+// and another copy of the whole image on disk.
 static void image_scratch_path(const char *base_path, const char *tag, char *out, size_t cap) {
     struct stat sb;
-    uint32_t h = fork_hash_str(base_path, 0x811c9dc5u);
+    char canon[PATH_MAX];
+    image_canonicalise(base_path, canon, sizeof(canon));
+    uint32_t h = fork_hash_str(canon, 0x811c9dc5u);
     if (stat(base_path, &sb) == 0) {
         h = fork_hash_str("\x1f", h);
         char meta[64];

--- a/src/core/storage/image_udif.c
+++ b/src/core/storage/image_udif.c
@@ -1,0 +1,399 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) pappadf
+
+// image_udif.c
+// UDIF 'koly' trailer + 'mish' block-map parser and chunk decoder — see
+// image_udif.h.
+
+#include "image_udif.h"
+
+#include "adc.h"
+#include "inflate.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// 'koly' trailer field offsets (big-endian).  The 128-byte checksum blob at
+// 0x58 is why XMLOffset lands at 0xD8 and not, as a naive count of the struct
+// members suggests, earlier.
+#define KOLY_OFF_SIGNATURE     0x00
+#define KOLY_OFF_VERSION       0x04
+#define KOLY_OFF_HEADER_SIZE   0x08
+#define KOLY_OFF_DATA_OFFSET   0x18
+#define KOLY_OFF_DATA_LENGTH   0x20
+#define KOLY_OFF_SEGMENT_COUNT 0x3C
+#define KOLY_OFF_CHECKSUM_TYPE 0x50
+#define KOLY_OFF_CHECKSUM      0x58
+#define KOLY_OFF_XML_OFFSET    0xD8
+#define KOLY_OFF_XML_LENGTH    0xE0
+#define KOLY_OFF_VARIANT       0x1E8
+#define KOLY_OFF_SECTORS       0x1EC
+
+// The trailer is exactly 512 bytes, so a mistyped offset is a read past its
+// end — catch that at compile time instead of at decode time.
+_Static_assert(KOLY_OFF_XML_LENGTH + 8 <= UDIF_TRAILER_SIZE, "koly offset outside the trailer");
+_Static_assert(KOLY_OFF_SECTORS + 8 <= UDIF_TRAILER_SIZE, "koly offset outside the trailer");
+
+// 'mish' block-table field offsets (big-endian).
+#define MISH_OFF_SIGNATURE     0x00
+#define MISH_OFF_VERSION       0x04
+#define MISH_OFF_SECTOR        0x08
+#define MISH_OFF_SECTOR_COUNT  0x10
+#define MISH_OFF_DATA_OFFSET   0x18
+#define MISH_OFF_CHECKSUM_TYPE 0x40
+#define MISH_OFF_CHECKSUM      0x48
+#define MISH_OFF_CHUNK_COUNT   0xC8
+#define MISH_HEADER_SIZE       0xCC // chunk entries start here
+#define MISH_ENTRY_SIZE        40
+
+// Only version 4 trailers and version 1 block tables were ever written.
+#define KOLY_VERSION 4
+#define MISH_VERSION 1
+
+// A 16 MB plist is already absurd for a block map; refuse anything larger
+// rather than let a corrupt trailer drive a huge allocation.
+#define UDIF_XML_MAX (16u * 1024u * 1024u)
+
+static const uint8_t KOLY_SIGNATURE[4] = {'k', 'o', 'l', 'y'};
+#define MISH_SIGNATURE 0x6D697368u // 'mish'
+
+static uint32_t rd32(const uint8_t *p) {
+    return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) | ((uint32_t)p[2] << 8) | (uint32_t)p[3];
+}
+
+static uint64_t rd64(const uint8_t *p) {
+    return ((uint64_t)rd32(p) << 32) | (uint64_t)rd32(p + 4);
+}
+
+// CRC-32 (reflected, polynomial 0xEDB88320) — the same one zlib and PNG use,
+// which is what UDIF stores for checksum type 2.  Kept local because the
+// other two copies in the tree are private to their own subsystems.
+uint32_t udif_crc32(uint32_t crc, const uint8_t *data, size_t len) {
+    static uint32_t table[256];
+    static int table_ready = 0;
+    if (!table_ready) {
+        for (uint32_t n = 0; n < 256; n++) {
+            uint32_t c = n;
+            for (int k = 0; k < 8; k++)
+                c = (c & 1) ? (0xEDB88320u ^ (c >> 1)) : (c >> 1);
+            table[n] = c;
+        }
+        table_ready = 1;
+    }
+    crc = ~crc;
+    for (size_t i = 0; i < len; i++)
+        crc = table[(crc ^ data[i]) & 0xFF] ^ (crc >> 8);
+    return ~crc;
+}
+
+bool udif_detect(const uint8_t *trailer, size_t len) {
+    if (!trailer || len < UDIF_TRAILER_SIZE)
+        return false;
+    if (memcmp(trailer + KOLY_OFF_SIGNATURE, KOLY_SIGNATURE, sizeof(KOLY_SIGNATURE)) != 0)
+        return false;
+    // Version and header size are the two fields that separate a real trailer
+    // from four incidental bytes of payload that happen to spell 'koly'.
+    return rd32(trailer + KOLY_OFF_VERSION) == KOLY_VERSION &&
+           rd32(trailer + KOLY_OFF_HEADER_SIZE) == UDIF_TRAILER_SIZE;
+}
+
+int udif_parse_trailer(const uint8_t *trailer, size_t len, udif_trailer_t *out) {
+    if (!trailer || !out || len < UDIF_TRAILER_SIZE)
+        return -EINVAL;
+    if (!udif_detect(trailer, len))
+        return -EINVAL;
+
+    memset(out, 0, sizeof(*out));
+    out->data_fork_offset = rd64(trailer + KOLY_OFF_DATA_OFFSET);
+    out->data_fork_length = rd64(trailer + KOLY_OFF_DATA_LENGTH);
+    out->xml_offset = rd64(trailer + KOLY_OFF_XML_OFFSET);
+    out->xml_length = rd64(trailer + KOLY_OFF_XML_LENGTH);
+    out->sectors = rd64(trailer + KOLY_OFF_SECTORS);
+    out->segment_count = rd32(trailer + KOLY_OFF_SEGMENT_COUNT);
+    out->checksum_type = rd32(trailer + KOLY_OFF_CHECKSUM_TYPE);
+    out->checksum = rd32(trailer + KOLY_OFF_CHECKSUM);
+
+    // A spanned image keeps later chunks in sibling .dmgpart files we have no
+    // way to reach from one path; say so rather than decode a truncated disk.
+    if (out->segment_count > 1)
+        return -ENOTSUP;
+    // The block map is mandatory; without it there is nothing to decode.
+    if (out->xml_length == 0 || out->xml_length > UDIF_XML_MAX || out->sectors == 0)
+        return -EINVAL;
+    return 0;
+}
+
+// Decode Base64 into a malloc'd buffer, ignoring whitespace (the plist wraps
+// every blob across many lines).  Returns NULL on a malformed blob.
+static uint8_t *base64_decode(const char *src, size_t src_len, size_t *out_len) {
+    static const int8_t rev[256] = {
+        ['A'] = 1,  ['B'] = 2,  ['C'] = 3,  ['D'] = 4,  ['E'] = 5,  ['F'] = 6,  ['G'] = 7,  ['H'] = 8,
+        ['I'] = 9,  ['J'] = 10, ['K'] = 11, ['L'] = 12, ['M'] = 13, ['N'] = 14, ['O'] = 15, ['P'] = 16,
+        ['Q'] = 17, ['R'] = 18, ['S'] = 19, ['T'] = 20, ['U'] = 21, ['V'] = 22, ['W'] = 23, ['X'] = 24,
+        ['Y'] = 25, ['Z'] = 26, ['a'] = 27, ['b'] = 28, ['c'] = 29, ['d'] = 30, ['e'] = 31, ['f'] = 32,
+        ['g'] = 33, ['h'] = 34, ['i'] = 35, ['j'] = 36, ['k'] = 37, ['l'] = 38, ['m'] = 39, ['n'] = 40,
+        ['o'] = 41, ['p'] = 42, ['q'] = 43, ['r'] = 44, ['s'] = 45, ['t'] = 46, ['u'] = 47, ['v'] = 48,
+        ['w'] = 49, ['x'] = 50, ['y'] = 51, ['z'] = 52, ['0'] = 53, ['1'] = 54, ['2'] = 55, ['3'] = 56,
+        ['4'] = 57, ['5'] = 58, ['6'] = 59, ['7'] = 60, ['8'] = 61, ['9'] = 62, ['+'] = 63, ['/'] = 64,
+    };
+
+    uint8_t *out = (uint8_t *)malloc(src_len / 4 * 3 + 3);
+    if (!out)
+        return NULL;
+    size_t n = 0;
+    uint32_t acc = 0;
+    int nbits = 0;
+    for (size_t i = 0; i < src_len; i++) {
+        unsigned char c = (unsigned char)src[i];
+        if (c == '=')
+            break; // padding: whatever is left in `acc` is discarded
+        if (c == '\n' || c == '\r' || c == '\t' || c == ' ')
+            continue;
+        int v = rev[c];
+        if (v == 0) { // not a Base64 alphabet character
+            free(out);
+            return NULL;
+        }
+        acc = (acc << 6) | (uint32_t)(v - 1);
+        nbits += 6;
+        if (nbits >= 8) {
+            nbits -= 8;
+            out[n++] = (uint8_t)(acc >> nbits);
+        }
+    }
+    *out_len = n;
+    return out;
+}
+
+// Find `needle` in the [from, end) slice of a non-NUL-terminated buffer.
+static const char *find_in(const char *from, const char *end, const char *needle) {
+    size_t nlen = strlen(needle);
+    if ((size_t)(end - from) < nlen)
+        return NULL;
+    for (const char *p = from; p <= end - nlen; p++)
+        if (memcmp(p, needle, nlen) == 0)
+            return p;
+    return NULL;
+}
+
+// Copy the <string> value that follows `<key>key</key>` inside [from, end)
+// into `dst`.  Entry dicts list Attributes / CFName / Data / ID / Name in that
+// order, so the key must be matched — taking the first <string> would yield
+// the attribute word.  Returns true when the key was found.
+static bool extract_keyed_string(const char *from, const char *end, const char *key, char *dst, size_t cap) {
+    char pattern[32];
+    snprintf(pattern, sizeof(pattern), "<key>%s</key>", key);
+    const char *k = find_in(from, end, pattern);
+    if (!k)
+        return false;
+    const char *o = find_in(k, end, "<string>");
+    if (!o)
+        return false;
+    o += strlen("<string>");
+    const char *c = find_in(o, end, "</string>");
+    if (!c)
+        return false;
+    // Only a human-readable label, so silent truncation is harmless.
+    size_t n = (size_t)(c - o);
+    if (n >= cap)
+        n = cap - 1;
+    memcpy(dst, o, n);
+    dst[n] = '\0';
+    return true;
+}
+
+// Parse one Base64-decoded 'mish' blob into `t`.  0 / negative errno.
+static int parse_mish(const uint8_t *b, size_t len, udif_table_t *t) {
+    if (len < MISH_HEADER_SIZE)
+        return -EINVAL;
+    if (rd32(b + MISH_OFF_SIGNATURE) != MISH_SIGNATURE || rd32(b + MISH_OFF_VERSION) != MISH_VERSION)
+        return -EINVAL;
+    // Every image seen in the wild stores its chunks at absolute data-fork
+    // offsets and leaves this zero; a non-zero base would silently shift every
+    // read, so refuse rather than guess whether it is meant to be added.
+    if (rd64(b + MISH_OFF_DATA_OFFSET) != 0)
+        return -ENOTSUP;
+
+    t->base_sector = rd64(b + MISH_OFF_SECTOR);
+    t->sectors = rd64(b + MISH_OFF_SECTOR_COUNT);
+    t->checksum_type = rd32(b + MISH_OFF_CHECKSUM_TYPE);
+    t->checksum = rd32(b + MISH_OFF_CHECKSUM);
+
+    // NB: the u32 at 0x24 is the blkx resource ID, not a descriptor count —
+    // the count lives at 0xC8, immediately before the entry array.
+    uint32_t n_entries = rd32(b + MISH_OFF_CHUNK_COUNT);
+    if ((uint64_t)n_entries * MISH_ENTRY_SIZE > (uint64_t)(len - MISH_HEADER_SIZE))
+        return -EINVAL;
+    if (n_entries == 0)
+        return 0; // legal but empty: nothing to decode for this partition
+
+    udif_chunk_t *chunks = (udif_chunk_t *)calloc(n_entries, sizeof(udif_chunk_t));
+    if (!chunks)
+        return -ENOMEM;
+
+    size_t nc = 0;
+    for (uint32_t i = 0; i < n_entries; i++) {
+        const uint8_t *e = b + MISH_HEADER_SIZE + (size_t)i * MISH_ENTRY_SIZE;
+        uint32_t type = rd32(e);
+        if (type == UDIF_CHUNK_END)
+            break;
+        if (type == UDIF_CHUNK_COMMENT)
+            continue; // "+beg"/"+end" markers cover no sectors
+        chunks[nc].type = type;
+        chunks[nc].sector = rd64(e + 8);
+        chunks[nc].count = rd64(e + 16);
+        chunks[nc].offset = rd64(e + 24);
+        chunks[nc].length = rd64(e + 32);
+        // A chunk must stay inside the sector run its own table declares.
+        if (chunks[nc].sector + chunks[nc].count > t->sectors) {
+            free(chunks);
+            return -EINVAL;
+        }
+        nc++;
+    }
+    t->chunks = chunks;
+    t->n_chunks = nc;
+    return 0;
+}
+
+int udif_parse_blkx(const uint8_t *xml, size_t xml_len, udif_map_t **out) {
+    if (!xml || !out || xml_len == 0)
+        return -EINVAL;
+    *out = NULL;
+
+    const char *text = (const char *)xml;
+    const char *end = text + xml_len;
+
+    // Locate the blkx array.  Its entries are flat dicts of strings and one
+    // <data> blob — no nested arrays — so the first </array> closes it.  Every
+    // blob is separately validated for the 'mish' magic below, so a mis-scan
+    // fails loudly instead of yielding a plausible-looking map.
+    const char *key = find_in(text, end, "<key>blkx</key>");
+    if (!key)
+        return -ENOENT;
+    const char *arr = find_in(key, end, "<array>");
+    if (!arr)
+        return -EINVAL;
+    const char *arr_end = find_in(arr, end, "</array>");
+    if (!arr_end)
+        return -EINVAL;
+
+    udif_map_t *m = (udif_map_t *)calloc(1, sizeof(*m));
+    if (!m)
+        return -ENOMEM;
+
+    int rc = 0;
+    for (const char *p = arr; p < arr_end;) {
+        const char *dict = find_in(p, arr_end, "<dict>");
+        if (!dict)
+            break;
+        const char *dict_end = find_in(dict, arr_end, "</dict>");
+        if (!dict_end) {
+            rc = -EINVAL;
+            break;
+        }
+        p = dict_end + strlen("</dict>");
+
+        const char *data = find_in(dict, dict_end, "<data>");
+        if (!data)
+            continue; // an entry without a blob is not a block table
+        data += strlen("<data>");
+        const char *data_end = find_in(data, dict_end, "</data>");
+        if (!data_end) {
+            rc = -EINVAL;
+            break;
+        }
+
+        size_t blob_len = 0;
+        uint8_t *blob = base64_decode(data, (size_t)(data_end - data), &blob_len);
+        if (!blob) {
+            rc = -EINVAL;
+            break;
+        }
+
+        udif_table_t *grown = (udif_table_t *)realloc(m->tables, (m->n_tables + 1) * sizeof(udif_table_t));
+        if (!grown) {
+            free(blob);
+            rc = -ENOMEM;
+            break;
+        }
+        m->tables = grown;
+        udif_table_t *t = &m->tables[m->n_tables];
+        memset(t, 0, sizeof(*t));
+        // CFName carries the readable partition label; older writers set only
+        // Name.  Either way this is diagnostics, never decode input.
+        if (!extract_keyed_string(dict, dict_end, "CFName", t->name, sizeof(t->name)))
+            extract_keyed_string(dict, dict_end, "Name", t->name, sizeof(t->name));
+
+        rc = parse_mish(blob, blob_len, t);
+        free(blob);
+        if (rc != 0)
+            break;
+        m->n_tables++;
+
+        // The decoded image spans up to the far edge of the last table.
+        uint64_t top = t->base_sector + t->sectors;
+        if (top > m->sectors)
+            m->sectors = top;
+    }
+
+    if (rc == 0 && m->n_tables == 0)
+        rc = -ENOENT; // a blkx array with no usable block table
+    if (rc != 0) {
+        udif_map_free(m);
+        return rc;
+    }
+    *out = m;
+    return 0;
+}
+
+void udif_map_free(udif_map_t *m) {
+    if (!m)
+        return;
+    for (size_t i = 0; i < m->n_tables; i++)
+        free(m->tables[i].chunks);
+    free(m->tables);
+    free(m);
+}
+
+int udif_decode_chunk(const udif_chunk_t *chunk, const uint8_t *src, size_t src_len, uint8_t *dst, size_t dst_len) {
+    if (!chunk || !dst)
+        return -EINVAL;
+    size_t need = (size_t)chunk->count * UDIF_SECTOR_SIZE;
+    if (dst_len < need)
+        return -EINVAL;
+
+    switch (chunk->type) {
+    case UDIF_CHUNK_ZERO:
+    case UDIF_CHUNK_IGNORE:
+        memset(dst, 0, need);
+        return 0;
+    case UDIF_CHUNK_RAW:
+        if (!src || src_len < need)
+            return -EINVAL;
+        memcpy(dst, src, need);
+        return 0;
+    case UDIF_CHUNK_ADC: {
+        if (!src)
+            return -EINVAL;
+        long got = adc_decompress(src, src_len, dst, need);
+        // The chunk's sector count states the exact decoded size, so a short
+        // or long result means the stream and the map disagree.
+        return (got == (long)need) ? 0 : -EINVAL;
+    }
+    case UDIF_CHUNK_ZLIB: {
+        if (!src)
+            return -EINVAL;
+        long got = inflate_zlib(src, src_len, dst, need);
+        return (got == (long)need) ? 0 : -EINVAL;
+    }
+    case UDIF_CHUNK_BZ2:
+    case UDIF_CHUNK_LZFSE:
+    case UDIF_CHUNK_LZMA:
+        return -ENOTSUP; // real codecs we simply do not implement
+    default:
+        return -EINVAL;
+    }
+}

--- a/src/core/storage/image_udif.h
+++ b/src/core/storage/image_udif.h
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) pappadf
+
+// image_udif.h
+// Parser for the UDIF (Universal Disk Image Format) block map — the `.dmg`
+// container Disk Copy 6.5 and later, and every modern `hdiutil`, produce.
+//
+// A UDIF image is a single-fork file: payload chunks first, then an XML
+// property list, then a fixed 512-byte 'koly' trailer at EOF that points at
+// both.  The plist's `resource-fork` → `blkx` array holds one Base64-encoded
+// 'mish' block table per partition, each mapping sector runs of the decoded
+// image to (possibly compressed) byte ranges of the data fork.
+//
+// This module is pure in-memory: the caller reads the trailer and the plist
+// slice off the host file and supplies the data-fork bytes per chunk, exactly
+// as image_ndif.c is driven.  All fields are big-endian, including on the
+// PowerPC-era images this mostly exists to read.
+//
+// On-disk layout verified against a real Toast-mastered 1996 CD image
+// (UDZO, version 4) — its 'koly' CRC-32 and every per-table 'mish' CRC-32
+// reproduce exactly — and cross-checked with Jonathan Levin's "Demystifying
+// the DMG File Format", dmg2img and libdmg-hfsplus.
+//
+// NB: this is UDIF's 40-byte 'mish' chunk entry with 32-bit type codes — NOT
+// the classic Disk Copy 6.x NDIF 'bcem' map in image_ndif.h.  Encrypted
+// ('encrcdsa') and multi-segment (`.dmgpart`) images are rejected, not
+// misread.
+
+#ifndef GS_IMAGE_UDIF_H
+#define GS_IMAGE_UDIF_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// Every UDIF image ends with exactly this many trailer bytes.
+#define UDIF_TRAILER_SIZE 512
+#define UDIF_SECTOR_SIZE  512u
+
+// Chunk entry types (mish `EntryType`).  The high-bit codes are compressors.
+#define UDIF_CHUNK_ZERO    0x00000000u // zero-fill; no data-fork bytes
+#define UDIF_CHUNK_RAW     0x00000001u // uncompressed copy
+#define UDIF_CHUNK_IGNORE  0x00000002u // unallocated; reads as zeros
+#define UDIF_CHUNK_ADC     0x80000004u // Apple Data Compression (UDCO)
+#define UDIF_CHUNK_ZLIB    0x80000005u // zlib / DEFLATE (UDZO)
+#define UDIF_CHUNK_BZ2     0x80000006u // bzip2 (UDBZ, unsupported)
+#define UDIF_CHUNK_LZFSE   0x80000007u // LZFSE (ULFO, unsupported)
+#define UDIF_CHUNK_LZMA    0x80000008u // LZMA (ULMO, unsupported)
+#define UDIF_CHUNK_COMMENT 0x7FFFFFFEu // "+beg"/"+end" marker; no blocks
+#define UDIF_CHUNK_END     0xFFFFFFFFu // terminator
+
+// Checksum type code used by both the trailer and each block table.
+#define UDIF_CHECKSUM_NONE  0u
+#define UDIF_CHECKSUM_CRC32 2u
+
+// The 'koly' trailer, reduced to the fields a reader needs.
+typedef struct {
+    uint64_t data_fork_offset; // where the chunk payload starts (usually 0)
+    uint64_t data_fork_length; // its length in bytes
+    uint64_t xml_offset; // property-list offset
+    uint64_t xml_length; // property-list length
+    uint64_t sectors; // decoded image size, in 512-byte sectors
+    uint32_t segment_count; // >1 means a multi-part image (rejected)
+    uint32_t checksum_type; // UDIF_CHECKSUM_* over the *compressed* data fork
+    uint32_t checksum; // the CRC-32 itself, when checksum_type is CRC32
+} udif_trailer_t;
+
+// One decoded chunk entry.  `sector` is relative to the owning table's
+// `base_sector` — the single easiest thing to get wrong in this format.
+typedef struct {
+    uint32_t type; // UDIF_CHUNK_*
+    uint64_t sector; // start sector within the table
+    uint64_t count; // number of sectors this chunk covers
+    uint64_t offset; // byte offset of stored data in the data fork
+    uint64_t length; // stored byte length (0 for zero-fill / ignored)
+} udif_chunk_t;
+
+// One 'mish' block table — one partition of the decoded image.
+typedef struct {
+    char name[64]; // plist entry name, e.g. "Apple_HFS : 3"
+    uint64_t base_sector; // absolute start sector of this table
+    uint64_t sectors; // sectors it covers
+    uint32_t checksum_type; // UDIF_CHECKSUM_* over this table's decoded bytes
+    uint32_t checksum; // the CRC-32 itself
+    size_t n_chunks; // usable chunks (terminator dropped)
+    udif_chunk_t *chunks; // n_chunks entries
+} udif_table_t;
+
+// The whole block map.  Free with udif_map_free().
+typedef struct {
+    uint64_t sectors; // highest base_sector + sectors across all tables
+    size_t n_tables;
+    udif_table_t *tables;
+} udif_map_t;
+
+// True if `trailer` (the last UDIF_TRAILER_SIZE bytes of a host file) is a
+// 'koly' trailer this reader understands — used for format detection.
+bool udif_detect(const uint8_t *trailer, size_t len);
+
+// Parse the 'koly' trailer.  Returns 0 and fills *out, or a negative errno:
+// -EINVAL for a bad or unsupported trailer, -ENOTSUP for a multi-segment image.
+int udif_parse_trailer(const uint8_t *trailer, size_t len, udif_trailer_t *out);
+
+// Parse the `blkx` block tables out of the XML property list.  Returns 0 and
+// sets *out (caller frees via udif_map_free), or a negative errno.
+int udif_parse_blkx(const uint8_t *xml, size_t xml_len, udif_map_t **out);
+
+void udif_map_free(udif_map_t *m);
+
+// Decode one chunk: `src`/`src_len` are the stored data-fork bytes, `dst`/
+// `dst_len` the output (must be >= chunk->count * 512).  Handles ZERO,
+// IGNORE, RAW, ADC and ZLIB; returns -ENOTSUP for a codec we do not implement
+// (bzip2 / LZFSE / LZMA) and -EINVAL for a malformed chunk.  0 on success.
+int udif_decode_chunk(const udif_chunk_t *chunk, const uint8_t *src, size_t src_len, uint8_t *dst, size_t dst_len);
+
+// Running CRC-32 (the zlib/PNG polynomial UDIF uses), seeded with 0, so
+// callers can verify a table's decoded bytes against udif_table_t::checksum.
+// Chunks of type UDIF_CHUNK_IGNORE are excluded from that running total.
+uint32_t udif_crc32(uint32_t crc, const uint8_t *data, size_t len);
+
+#endif // GS_IMAGE_UDIF_H

--- a/src/core/storage/inflate.c
+++ b/src/core/storage/inflate.c
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) pappadf
+
+// inflate.c
+// zlib/DEFLATE decompressor — see inflate.h.  Extracted verbatim from the PNG
+// reader in debug.c (where it had been private) so image_udif.c can share it;
+// the zlib-header validation and the fixed-capacity entry point are new.
+
+#include "inflate.h"
+
+#include <stdlib.h>
+
+const uint16_t deflate_len_base[29] = {3,  4,  5,  6,  7,  8,  9,  10, 11,  13,  15,  17,  19,  23, 27,
+                                       31, 35, 43, 51, 59, 67, 83, 99, 115, 131, 163, 195, 227, 258};
+const uint8_t deflate_len_extra[29] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2,
+                                       2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0};
+const uint16_t deflate_dist_base[30] = {1,    2,    3,    4,    5,    7,    9,    13,    17,    25,
+                                        33,   49,   65,   97,   129,  193,  257,  385,   513,   769,
+                                        1025, 1537, 2049, 3073, 4097, 6145, 8193, 12289, 16385, 24577};
+const uint8_t deflate_dist_extra[30] = {0, 0, 0, 0, 1, 1, 2, 2,  3,  3,  4,  4,  5,  5,  6,
+                                        6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13};
+
+// LSB-first bit reader over a deflate stream.
+typedef struct {
+    const uint8_t *data;
+    size_t len;
+    size_t pos;
+    uint32_t acc;
+    int nbits;
+    int error;
+} inflate_br_t;
+
+// Growable or fixed output sink: `grow` distinguishes the malloc'ing entry
+// point from the caller-supplied-buffer one, which must never reallocate.
+typedef struct {
+    uint8_t *buf;
+    size_t cap;
+    size_t pos;
+    int grow;
+} inflate_out_t;
+
+// Pull `need` bits (0..16), least-significant bit first.
+static uint32_t inflate_bits(inflate_br_t *b, int need) {
+    if (need <= 0)
+        return 0;
+    while (b->nbits < need) {
+        if (b->pos >= b->len) {
+            b->error = 1;
+            return 0;
+        }
+        b->acc |= (uint32_t)b->data[b->pos++] << b->nbits;
+        b->nbits += 8;
+    }
+    uint32_t v = b->acc & ((1u << need) - 1);
+    b->acc >>= need;
+    b->nbits -= need;
+    return v;
+}
+
+// A canonical Huffman table: how many codes exist per bit length, plus the
+// symbols in canonical order.
+typedef struct {
+    uint16_t counts[16];
+    uint16_t symbols[288];
+} inflate_huff_t;
+
+// Build a canonical Huffman table from an array of per-symbol code lengths.
+static void inflate_build(inflate_huff_t *h, const uint8_t *lengths, int n) {
+    for (int i = 0; i < 16; i++)
+        h->counts[i] = 0;
+    for (int i = 0; i < n; i++)
+        h->counts[lengths[i]]++;
+    h->counts[0] = 0;
+    uint16_t offsets[16];
+    offsets[0] = 0;
+    offsets[1] = 0;
+    for (int i = 1; i < 15; i++)
+        offsets[i + 1] = (uint16_t)(offsets[i] + h->counts[i]);
+    for (int i = 0; i < n; i++)
+        if (lengths[i])
+            h->symbols[offsets[lengths[i]]++] = (uint16_t)i;
+}
+
+// Decode one symbol, walking code lengths shortest-first.  Returns -1 on a
+// malformed stream.
+static int inflate_decode(inflate_br_t *b, const inflate_huff_t *h) {
+    int code = 0, first = 0, index = 0;
+    for (int len = 1; len <= 15; len++) {
+        code |= (int)inflate_bits(b, 1);
+        if (b->error)
+            return -1;
+        int count = h->counts[len];
+        if (code - first < count)
+            return h->symbols[index + (code - first)];
+        index += count;
+        first = (first + count) << 1;
+        code <<= 1;
+    }
+    return -1;
+}
+
+// Append one byte to the output sink, growing it when allowed.  Returns 0 when
+// the fixed buffer is full or an allocation fails.
+static int inflate_push(inflate_out_t *o, uint8_t byte) {
+    if (o->pos >= o->cap) {
+        // A fixed-capacity caller stated the exact expected size: overflowing
+        // it means the stream disagrees, which is an error rather than a clamp.
+        if (!o->grow)
+            return 0;
+        size_t new_cap = o->cap * 2;
+        uint8_t *grown = realloc(o->buf, new_cap);
+        if (!grown)
+            return 0;
+        o->buf = grown;
+        o->cap = new_cap;
+    }
+    o->buf[o->pos++] = byte;
+    return 1;
+}
+
+// Inflate the deflate blocks of a zlib stream into `o`.  Returns 0 on success,
+// -1 if the stream is truncated, malformed, or overruns a fixed output buffer.
+static int inflate_stream(const uint8_t *data, size_t data_len, inflate_out_t *o) {
+    if (data_len < 6)
+        return -1; // zlib header + at least one block
+
+    // RFC 1950 §2.2: CM must be 8 (deflate), the two header bytes form a
+    // multiple of 31, and a preset dictionary (FDICT) is never used here.
+    uint8_t cmf = data[0], flg = data[1];
+    if ((cmf & 0x0F) != 8 || (((uint32_t)cmf << 8) | flg) % 31u != 0 || (flg & 0x20))
+        return -1;
+
+    inflate_br_t b = {data + 2, data_len - 2, 0, 0, 0, 0};
+
+    for (;;) {
+        int bfinal = (int)inflate_bits(&b, 1);
+        int btype = (int)inflate_bits(&b, 2);
+        if (b.error)
+            return -1;
+
+        if (btype == 0) {
+            // Stored: discard the partial byte, then copy LEN raw bytes.
+            b.acc = 0;
+            b.nbits = 0;
+            if (b.pos + 4 > b.len)
+                return -1;
+            uint16_t len = (uint16_t)(b.data[b.pos] | ((uint16_t)b.data[b.pos + 1] << 8));
+            b.pos += 4; // LEN + NLEN
+            if (b.pos + len > b.len)
+                return -1;
+            for (uint16_t i = 0; i < len; i++)
+                if (!inflate_push(o, b.data[b.pos + i]))
+                    return -1;
+            b.pos += len;
+        } else if (btype == 1 || btype == 2) {
+            inflate_huff_t lit, dist;
+            if (btype == 1) {
+                // Fixed code lengths (RFC 1951 §3.2.6).
+                uint8_t ll[288], dl[30];
+                for (int i = 0; i < 288; i++)
+                    ll[i] = (i < 144) ? 8 : (i < 256) ? 9 : (i < 280) ? 7 : 8;
+                for (int i = 0; i < 30; i++)
+                    dl[i] = 5;
+                inflate_build(&lit, ll, 288);
+                inflate_build(&dist, dl, 30);
+            } else {
+                // Dynamic: read the code-length code, then the two real ones.
+                static const uint8_t order[19] = {16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15};
+                int hlit = (int)inflate_bits(&b, 5) + 257;
+                int hdist = (int)inflate_bits(&b, 5) + 1;
+                int hclen = (int)inflate_bits(&b, 4) + 4;
+                if (b.error || hlit > 286 || hdist > 30)
+                    return -1;
+                uint8_t cl[19] = {0};
+                for (int i = 0; i < hclen; i++)
+                    cl[order[i]] = (uint8_t)inflate_bits(&b, 3);
+                if (b.error)
+                    return -1;
+                inflate_huff_t clh;
+                inflate_build(&clh, cl, 19);
+
+                uint8_t lengths[318] = {0};
+                int n = 0;
+                while (n < hlit + hdist) {
+                    int sym = inflate_decode(&b, &clh);
+                    if (sym < 0)
+                        return -1;
+                    if (sym < 16) {
+                        lengths[n++] = (uint8_t)sym;
+                    } else if (sym == 16) {
+                        if (n == 0)
+                            return -1;
+                        uint8_t prev = lengths[n - 1];
+                        int repeat = 3 + (int)inflate_bits(&b, 2);
+                        while (repeat-- > 0 && n < hlit + hdist)
+                            lengths[n++] = prev;
+                    } else if (sym == 17) {
+                        int repeat = 3 + (int)inflate_bits(&b, 3);
+                        while (repeat-- > 0 && n < hlit + hdist)
+                            lengths[n++] = 0;
+                    } else {
+                        int repeat = 11 + (int)inflate_bits(&b, 7);
+                        while (repeat-- > 0 && n < hlit + hdist)
+                            lengths[n++] = 0;
+                    }
+                    if (b.error)
+                        return -1;
+                }
+                inflate_build(&lit, lengths, hlit);
+                inflate_build(&dist, lengths + hlit, hdist);
+            }
+
+            for (;;) {
+                int sym = inflate_decode(&b, &lit);
+                if (sym < 0)
+                    return -1;
+                if (sym == 256)
+                    break;
+                if (sym < 256) {
+                    if (!inflate_push(o, (uint8_t)sym))
+                        return -1;
+                    continue;
+                }
+                sym -= 257;
+                if (sym >= 29)
+                    return -1;
+                size_t length = deflate_len_base[sym] + inflate_bits(&b, deflate_len_extra[sym]);
+                int dsym = inflate_decode(&b, &dist);
+                if (dsym < 0 || dsym >= 30)
+                    return -1;
+                size_t distance = deflate_dist_base[dsym] + inflate_bits(&b, deflate_dist_extra[dsym]);
+                if (b.error || distance == 0 || distance > o->pos)
+                    return -1;
+                for (size_t i = 0; i < length; i++)
+                    if (!inflate_push(o, o->buf[o->pos - distance]))
+                        return -1;
+            }
+        } else {
+            return -1; // BTYPE 3 is reserved
+        }
+
+        if (bfinal)
+            break;
+    }
+    return 0;
+}
+
+uint8_t *inflate_zlib_alloc(const uint8_t *data, size_t data_len, size_t *out_len) {
+    if (!data || !out_len)
+        return NULL;
+    inflate_out_t o = {malloc(1 << 16), 1 << 16, 0, 1};
+    if (!o.buf)
+        return NULL;
+    if (inflate_stream(data, data_len, &o) != 0) {
+        free(o.buf);
+        return NULL;
+    }
+    *out_len = o.pos;
+    return o.buf;
+}
+
+long inflate_zlib(const uint8_t *data, size_t data_len, uint8_t *out, size_t out_cap) {
+    if (!data || !out)
+        return -1;
+    inflate_out_t o = {out, out_cap, 0, 0};
+    if (inflate_stream(data, data_len, &o) != 0)
+        return -1;
+    return (long)o.pos;
+}

--- a/src/core/storage/inflate.h
+++ b/src/core/storage/inflate.h
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) pappadf
+
+// inflate.h
+// DEFLATE / zlib decompressor (RFC 1950 + RFC 1951), decode-only.
+//
+// Shared by the two places the emulator meets zlib streams: the PNG reader in
+// debug.c (screenshots and `screen.match` reference images) and the UDIF disk
+// image decoder (image_udif.c), whose 0x80000005 chunks are each a complete
+// zlib stream.  Handles all three DEFLATE block types (stored, fixed Huffman,
+// dynamic Huffman).  Compression lives in debug.c — only the PNG writer needs
+// it, and it shares the RFC 1951 length/distance tables exported below.
+//
+// The emulator core links no third-party C libraries, so this is a
+// first-party implementation rather than a zlib dependency.
+
+#ifndef GS_INFLATE_H
+#define GS_INFLATE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+// RFC 1951 §3.2.5 length/distance code tables, shared by the decoder here and
+// the deflate writer in debug.c.
+extern const uint16_t deflate_len_base[29];
+extern const uint8_t deflate_len_extra[29];
+extern const uint16_t deflate_dist_base[30];
+extern const uint8_t deflate_dist_extra[30];
+
+// Inflate a zlib stream into a freshly allocated buffer, for callers that do
+// not know the decompressed size up front (the PNG reader).  Returns malloc'd
+// output and sets *out_len, or NULL if the stream is truncated or malformed.
+uint8_t *inflate_zlib_alloc(const uint8_t *data, size_t data_len, size_t *out_len);
+
+// Inflate a zlib stream into a caller-supplied buffer, for callers that know
+// the exact expected size (a UDIF chunk covers a fixed sector run).  Returns
+// the number of bytes written, or -1 if the stream is truncated, malformed, or
+// would expand past `out_cap` — overflow is an error, never a silent clamp.
+long inflate_zlib(const uint8_t *data, size_t data_len, uint8_t *out, size_t out_cap);
+
+#endif // GS_INFLATE_H

--- a/tests/integration/image-udif/config.mk
+++ b/tests/integration/image-udif/config.mk
@@ -1,0 +1,22 @@
+# Integration test: UDIF (.dmg) images decode transparently on open.
+#
+# The `udif` unit suite covers the trailer/block-map parser and the chunk
+# decoders in isolation; this covers the plumbing they hang off — koly
+# detection at EOF, plist retrieval, materialisation to the storage-cache
+# scratch image, and the per-table CRC-32 verification that guards it — by
+# round-tripping a real HFS volume through the format and mounting the result.
+#
+# make-fixture.py builds the .dmg at setup time from a raw image already in
+# tests/data (which is fetched, not committed), so no binary fixture is added
+# to the tree.  It is written from the format spec rather than from the
+# reader, so agreement between the two is evidence, not tautology.
+
+TEST_NAME := storage.udif
+TEST_DESC := Decode a UDIF (.dmg) image on open and mount the volume inside it
+
+TEST_ROM := roms/iix-iicx-se30-97221136.rom
+
+TEST_SETUP := python3 image-udif/make-fixture.py "$(TEST_DATA)/systems/system_6_0_8_20mb_8_24gc.img" "$(WORK_DIR)/fixture.dmg"
+
+# CI tier (proposal-integration-test-rework §5.4): unit | matrix | extended
+TEST_TIER := unit

--- a/tests/integration/image-udif/make-fixture.py
+++ b/tests/integration/image-udif/make-fixture.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (c) pappadf
+
+"""Build a UDIF (.dmg) fixture from a raw disk image.
+
+Written straight from the format description rather than from
+src/core/storage/image_udif.c, so the two are independent implementations of
+the same spec: if the emulator's reader and this writer agree on a real
+round-trip, both are probably right.
+
+The output deliberately mixes chunk types — zlib (UDZO), raw, and zero-fill —
+so one decode exercises every branch the reader implements, and carries the
+CRC-32s (per block table and over the whole data fork) that the reader
+verifies.  It is also split into two 'mish' block tables rather than one, so
+the second table's chunk sectors restart at zero: getting that relative-to-
+absolute arithmetic wrong is the classic way to misread this format, and a
+single-table fixture would not catch it.  Encrypted, multi-segment, bzip2 and
+LZFSE images are outside what the reader supports and are not produced here.
+
+Usage: make-fixture.py <source.img> <out.dmg>
+"""
+
+import base64
+import struct
+import sys
+import zlib
+
+SECTOR = 512
+CHUNK_SECTORS = 128  # 64 KB runs, so even a small source yields many chunks
+
+CHUNK_ZERO = 0x00000000
+CHUNK_RAW = 0x00000001
+CHUNK_ZLIB = 0x80000005
+CHUNK_END = 0xFFFFFFFF
+
+CHECKSUM_CRC32 = 2
+
+
+def build_chunks(data, fork, force_raw_first):
+    """Chunk one table's sector run, appending its payload bytes to `fork`.
+
+    The returned entries carry sectors relative to the start of `data`, which
+    is what the format stores; the table's own base sector is what makes them
+    absolute again.
+    """
+    entries = []
+    total = len(data) // SECTOR
+    sector = 0
+    force_raw = force_raw_first
+    while sector < total:
+        count = min(CHUNK_SECTORS, total - sector)
+        run = data[sector * SECTOR:(sector + count) * SECTOR]
+        if not any(run):
+            # Zero-fill costs no data-fork bytes at all.
+            entries.append(dict(type=CHUNK_ZERO, sector=sector, count=count,
+                                offset=len(fork), length=0))
+        else:
+            packed = zlib.compress(run, 9)
+            # Store raw when compression does not pay, as hdiutil does — plus
+            # one forced raw run (the table's first run with actual content) so
+            # the reader's raw path stays covered even on a source where every
+            # run happens to compress.
+            if len(packed) >= len(run) or force_raw:
+                force_raw = False
+                entries.append(dict(type=CHUNK_RAW, sector=sector, count=count,
+                                    offset=len(fork), length=len(run)))
+                fork += run
+            else:
+                entries.append(dict(type=CHUNK_ZLIB, sector=sector, count=count,
+                                    offset=len(fork), length=len(packed)))
+                fork += packed
+        sector += count
+    return entries
+
+
+def build_mish(entries, base, sectors, checksum):
+    """Serialise one 'mish' block table: 0xCC header + 40-byte entries."""
+    b = bytearray(0xCC)
+    b[0x00:0x04] = b"mish"
+    struct.pack_into(">I", b, 0x04, 1)  # version
+    struct.pack_into(">Q", b, 0x08, base)  # absolute start sector of this table
+    struct.pack_into(">Q", b, 0x10, sectors)
+    struct.pack_into(">Q", b, 0x18, 0)  # data offset (always 0 in practice)
+    struct.pack_into(">I", b, 0x20, SECTOR + 8)  # buffers needed
+    struct.pack_into(">I", b, 0x24, 0)  # blkx resource ID — NOT a count
+    struct.pack_into(">I", b, 0x40, CHECKSUM_CRC32)
+    struct.pack_into(">I", b, 0x44, 32)  # checksum bits
+    struct.pack_into(">I", b, 0x48, checksum)
+    struct.pack_into(">I", b, 0xC8, len(entries) + 1)  # entries + terminator
+    for e in entries:
+        b += struct.pack(">IIQQQQ", e["type"], 0, e["sector"], e["count"],
+                         e["offset"], e["length"])
+    tail = entries[-1]["offset"] + entries[-1]["length"] if entries else 0
+    b += struct.pack(">IIQQQQ", CHUNK_END, 0, sectors, 0, tail, 0)
+    return bytes(b)
+
+
+def build_plist(tables):
+    """Wrap the Base64'd block tables in the plist hdiutil writes."""
+    entries = []
+    for i, (name, mish) in enumerate(tables):
+        blob = base64.b64encode(mish).decode()
+        wrapped = "\n\t\t\t\t".join(blob[j:j + 64] for j in range(0, len(blob), 64))
+        entries.append(
+            "\t\t\t<dict>\n"
+            "\t\t\t\t<key>Attributes</key>\n\t\t\t\t<string>0x0050</string>\n"
+            f"\t\t\t\t<key>CFName</key>\n\t\t\t\t<string>{name}</string>\n"
+            f"\t\t\t\t<key>Data</key>\n\t\t\t\t<data>\n\t\t\t\t{wrapped}\n\t\t\t\t</data>\n"
+            f"\t\t\t\t<key>ID</key>\n\t\t\t\t<string>{i}</string>\n"
+            f"\t\t\t\t<key>Name</key>\n\t\t\t\t<string>{name}</string>\n"
+            "\t\t\t</dict>\n")
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" '
+        '"http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n'
+        '<plist version="1.0">\n<dict>\n'
+        "\t<key>resource-fork</key>\n\t<dict>\n\t\t<key>blkx</key>\n\t\t<array>\n"
+        + "".join(entries) +
+        "\t\t</array>\n\t</dict>\n</dict>\n</plist>\n"
+    ).encode()
+
+
+def build_trailer(fork_len, fork_crc, xml_off, xml_len, sectors):
+    """Serialise the fixed 512-byte 'koly' trailer that ends every UDIF."""
+    t = bytearray(512)
+    t[0x00:0x04] = b"koly"
+    struct.pack_into(">I", t, 0x04, 4)  # version
+    struct.pack_into(">I", t, 0x08, 512)  # header size
+    struct.pack_into(">I", t, 0x0C, 1)  # flags
+    struct.pack_into(">Q", t, 0x18, 0)  # data fork offset
+    struct.pack_into(">Q", t, 0x20, fork_len)
+    struct.pack_into(">I", t, 0x38, 1)  # segment number
+    struct.pack_into(">I", t, 0x3C, 1)  # segment count
+    struct.pack_into(">I", t, 0x50, CHECKSUM_CRC32)  # data-fork checksum
+    struct.pack_into(">I", t, 0x54, 32)
+    struct.pack_into(">I", t, 0x58, fork_crc)
+    struct.pack_into(">Q", t, 0xD8, xml_off)
+    struct.pack_into(">Q", t, 0xE0, xml_len)
+    struct.pack_into(">I", t, 0x1E8, 1)  # image variant: device image
+    struct.pack_into(">Q", t, 0x1EC, sectors)  # NB: 0x1EC, inside the 512 bytes
+    return bytes(t)
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit("usage: make-fixture.py <source.img> <out.dmg>")
+    src, dst = sys.argv[1], sys.argv[2]
+    with open(src, "rb") as f:
+        data = f.read()
+    if len(data) % SECTOR:
+        sys.exit(f"{src}: {len(data)} bytes is not a whole number of sectors")
+
+    sectors = len(data) // SECTOR
+    # Split on a chunk boundary so neither table straddles a run.
+    split = (sectors // 2 // CHUNK_SECTORS) * CHUNK_SECTORS
+    if split == 0 or split == sectors:
+        sys.exit(f"{src}: too small to split into two block tables")
+
+    fork = bytearray()
+    tables = []
+    for i, (base, end) in enumerate(((0, split), (split, sectors))):
+        part = data[base * SECTOR:end * SECTOR]
+        entries = build_chunks(part, fork, force_raw_first=(i == 1))
+        # A table's CRC-32 covers the decoded bytes of every chunk except the
+        # ignored/unallocated ones (of which this writer emits none).
+        crc = zlib.crc32(part) & 0xFFFFFFFF
+        tables.append((f"part {i} (Apple_HFS : {i})",
+                       build_mish(entries, base, end - base, crc)))
+
+    xml = build_plist(tables)
+    with open(dst, "wb") as f:
+        f.write(fork)
+        f.write(xml)
+        f.write(build_trailer(len(fork), zlib.crc32(bytes(fork)) & 0xFFFFFFFF,
+                              len(fork), len(xml), sectors))
+    print(f"wrote {dst}: {sectors} sectors, {len(tables)} block tables, "
+          f"{len(fork)} data-fork bytes")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/image-udif/test.script
+++ b/tests/integration/image-udif/test.script
@@ -31,6 +31,17 @@ for i in 0..len($from_raw) {
 # A nested directory reads too, so the decode holds up past the volume header.
 assert vfs.list("${$dmg}/partition1/System Folder") "System Folder unreadable in the decoded image"
 
+# The same image addressed two ways decodes once, not once per spelling: the
+# scratch name is keyed on the canonicalised path.  Checked by total bytes in
+# the storage cache, which a second decode would roughly double (the decoded
+# disk is 21,411,840 bytes; the delta/journal sidecars beside it are tiny).
+assert storage.probe("${$WORK_DIR}/./fixture.dmg") "second spelling of the .dmg did not open"
+let cached = 0
+for e in vfs.list("${$WORK_DIR}/storage-cache") {
+    $cached = $cached + $e.size
+}
+assert $cached < 32000000 "image decoded once per path spelling (scratch cache holds ${$cached} bytes)"
+
 # Exporting the decoded image yields the full logical disk, not the .dmg size.
 assert storage.export_raw($dmg, "${$WORK_DIR}/exported.img") "export_raw failed"
 assert storage.path_size("${$WORK_DIR}/exported.img") == storage.path_size($raw) "exported image is not the source disk's size"

--- a/tests/integration/image-udif/test.script
+++ b/tests/integration/image-udif/test.script
@@ -1,0 +1,38 @@
+# Integration test: a UDIF (.dmg) image decodes transparently when opened.
+#
+# The fixture is built by make-fixture.py at setup time from the raw source
+# below, mixing zlib, raw and zero-fill chunks across two 'mish' block tables
+# (so the second table's chunk sectors restart at zero).  The runner cd's into
+# tests/integration/, so the source path is relative and WORK_DIR is absolute.
+
+let dmg = "${$WORK_DIR}/fixture.dmg"
+let raw = "../../data/systems/system_6_0_8_20mb_8_24gc.img"
+
+# The .dmg is far smaller on the host than the disk it carries — proof the
+# thing being opened really is the compressed container, not a raw image.
+assert storage.path_size($dmg) < 8000000 "fixture .dmg is not compressed"
+assert storage.path_size($raw) == 21411840 "raw source image changed size"
+
+# Opening it decodes the whole container.  Every block table's stored CRC-32
+# is verified during that decode, so reaching this line at the right geometry
+# already means the decoded bytes match what the writer recorded.
+storage.probe $dmg
+assert vfs.list("${$dmg}/partition1") "decoded UDIF did not mount as HFS"
+
+# The volume inside is the same one the raw source carries.
+storage.probe $raw
+let from_dmg = vfs.list("${$dmg}/partition1")
+let from_raw = vfs.list("${$raw}/partition1")
+assert len($from_dmg) == len($from_raw) "decoded volume has a different entry count"
+for i in 0..len($from_raw) {
+    assert $from_dmg[$i].name == $from_raw[$i].name "entry ${$i} differs between decoded and raw"
+}
+
+# A nested directory reads too, so the decode holds up past the volume header.
+assert vfs.list("${$dmg}/partition1/System Folder") "System Folder unreadable in the decoded image"
+
+# Exporting the decoded image yields the full logical disk, not the .dmg size.
+assert storage.export_raw($dmg, "${$WORK_DIR}/exported.img") "export_raw failed"
+assert storage.path_size("${$WORK_DIR}/exported.img") == storage.path_size($raw) "exported image is not the source disk's size"
+
+quit

--- a/tests/unit/suites/lisa_fdc/Makefile
+++ b/tests/unit/suites/lisa_fdc/Makefile
@@ -15,6 +15,8 @@ EXTRA_SRCS   := ../../../../src/machines/lisa/lisa_fdc.c \
                 ../../../../src/core/storage/storage.c \
                 ../../../../src/core/storage/appledouble.c \
                 ../../../../src/core/storage/image_ndif.c \
+                ../../../../src/core/storage/image_udif.c \
+                ../../../../src/core/storage/inflate.c \
                 ../../../../src/core/storage/adc.c \
                 ../../../../src/core/storage/resource_fork.c \
                 ../../../../src/core/storage/macroman.c \

--- a/tests/unit/suites/lisa_profile/Makefile
+++ b/tests/unit/suites/lisa_profile/Makefile
@@ -14,6 +14,8 @@ EXTRA_SRCS   := ../../../../src/machines/lisa/lisa_profile.c \
                 ../../../../src/core/storage/storage.c \
                 ../../../../src/core/storage/appledouble.c \
                 ../../../../src/core/storage/image_ndif.c \
+                ../../../../src/core/storage/image_udif.c \
+                ../../../../src/core/storage/inflate.c \
                 ../../../../src/core/storage/adc.c \
                 ../../../../src/core/storage/resource_fork.c \
                 ../../../../src/core/storage/macroman.c \

--- a/tests/unit/suites/scsi_cdrom/Makefile
+++ b/tests/unit/suites/scsi_cdrom/Makefile
@@ -14,6 +14,8 @@ EXTRA_SRCS   := ../../../../src/core/peripherals/scsi.c \
                 ../../../../src/core/storage/storage.c \
                 ../../../../src/core/storage/appledouble.c \
                 ../../../../src/core/storage/image_ndif.c \
+                ../../../../src/core/storage/image_udif.c \
+                ../../../../src/core/storage/inflate.c \
                 ../../../../src/core/storage/adc.c \
                 ../../../../src/core/storage/resource_fork.c \
                 ../../../../src/core/storage/rsrc_dcmp.c \

--- a/tests/unit/suites/udif/Makefile
+++ b/tests/unit/suites/udif/Makefile
@@ -1,0 +1,7 @@
+TEST_NAME := udif
+TEST_SRCS := test.c
+TEST_HARNESS := isolated
+EXTRA_SRCS := ../../../../src/core/storage/adc.c \
+              ../../../../src/core/storage/image_udif.c \
+              ../../../../src/core/storage/inflate.c
+include ../../common.mk

--- a/tests/unit/suites/udif/test.c
+++ b/tests/unit/suites/udif/test.c
@@ -1,0 +1,528 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) pappadf
+
+// Unit tests for the UDIF (.dmg) decoder: the shared zlib/DEFLATE
+// decompressor (src/core/storage/inflate.c) and the 'koly' trailer + 'mish'
+// block-map parser and chunk decoder (src/core/storage/image_udif.c).
+//
+// The trailer, property list and 'mish' tables are built by hand here so the
+// tests need no external image fixture, and the byte offsets are restated
+// independently of the parser's own constants.  The layout matches a real
+// Toast-mastered UDZO CD image and Jonathan Levin's "Demystifying the DMG
+// File Format".
+
+#include "image_udif.h"
+#include "inflate.h"
+#include "test_assert.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// 'koly' trailer offsets, restated from the format rather than the parser.
+#define KOLY_DATA_OFFSET   0x18
+#define KOLY_DATA_LENGTH   0x20
+#define KOLY_SEGMENT_COUNT 0x3C
+#define KOLY_XML_OFFSET    0xD8
+#define KOLY_XML_LENGTH    0xE0
+#define KOLY_SECTORS       0x1EC
+
+// 'mish' block-table offsets.
+#define MISH_SECTOR        0x08
+#define MISH_SECTOR_COUNT  0x10
+#define MISH_DATA_OFFSET   0x18
+#define MISH_CHECKSUM_TYPE 0x40
+#define MISH_CHECKSUM      0x48
+#define MISH_CHUNK_COUNT   0xC8
+#define MISH_ENTRIES       0xCC
+#define MISH_ENTRY_SIZE    40
+
+static void w_u32(uint8_t *p, uint32_t v) {
+    p[0] = (uint8_t)(v >> 24);
+    p[1] = (uint8_t)(v >> 16);
+    p[2] = (uint8_t)(v >> 8);
+    p[3] = (uint8_t)v;
+}
+
+static void w_u64(uint8_t *p, uint64_t v) {
+    w_u32(p, (uint32_t)(v >> 32));
+    w_u32(p + 4, (uint32_t)v);
+}
+
+// ---- zlib / inflate --------------------------------------------------------
+
+// A zlib stream carrying one stored (uncompressed) DEFLATE block.  Trivial to
+// build by hand, and the shape most of the chunk tests below need.
+static uint8_t *zlib_stored(const uint8_t *payload, uint16_t len, size_t *out_len) {
+    uint8_t *s = (uint8_t *)malloc((size_t)len + 11);
+    s[0] = 0x78; // CM=8, CINFO=7
+    s[1] = 0x01; // FLEVEL=0, FCHECK making (0x7801 % 31) == 0
+    s[2] = 0x01; // BFINAL=1, BTYPE=00 (stored)
+    s[3] = (uint8_t)len;
+    s[4] = (uint8_t)(len >> 8);
+    s[5] = (uint8_t)~len;
+    s[6] = (uint8_t)(~len >> 8);
+    memcpy(s + 7, payload, len);
+    memset(s + 7 + len, 0, 4); // adler32 trailer (unverified)
+    *out_len = (size_t)len + 11;
+    return s;
+}
+
+TEST(inflate_stored_block) {
+    const uint8_t payload[] = "granny smith";
+    size_t slen = 0;
+    uint8_t *stream = zlib_stored(payload, sizeof(payload), &slen);
+    uint8_t out[64] = {0};
+    long n = inflate_zlib(stream, slen, out, sizeof(out));
+    ASSERT_EQ_INT((int)sizeof(payload), (int)n);
+    ASSERT_EQ_INT(0, memcmp(out, payload, sizeof(payload)));
+    free(stream);
+}
+
+TEST(inflate_fixed_huffman) {
+    // zlib.compress("GRANNY SMITH UDIF TEST PAYLOAD " * 4, level=1) -> BTYPE=1.
+    static const uint8_t stream[] = {0x78, 0x01, 0x73, 0x0F, 0x72, 0xF4, 0xF3, 0x8B, 0x54, 0x08, 0xF6,
+                                     0xF5, 0x0C, 0xF1, 0x50, 0x08, 0x75, 0xF1, 0x74, 0x53, 0x08, 0x71,
+                                     0x0D, 0x0E, 0x51, 0x08, 0x70, 0x8C, 0xF4, 0xF1, 0x77, 0x74, 0x51,
+                                     0x70, 0xA7, 0xA5, 0x34, 0x00, 0x40, 0x00, 0x21, 0x99};
+    uint8_t out[256] = {0};
+    long n = inflate_zlib(stream, sizeof(stream), out, sizeof(out));
+    ASSERT_EQ_INT(124, (int)n);
+    ASSERT_EQ_INT(0, memcmp(out, "GRANNY SMITH UDIF TEST PAYLOAD GRANNY SMITH UDIF TEST PAYLOAD ", 62));
+}
+
+TEST(inflate_dynamic_huffman) {
+    // 600 bytes of skewed random data, zlib level 9 -> BTYPE=2 (its own code
+    // table).  Checked by length + CRC-32 rather than embedding the payload.
+    static const uint8_t stream[] = {
+        0x78, 0xDA, 0x25, 0x92, 0x89, 0x0D, 0xC4, 0x40, 0x08, 0x03, 0x6B, 0xC3, 0x06, 0xB6, 0xFF, 0x8E, 0x32, 0x26,
+        0xCA, 0x49, 0xD9, 0xC7, 0x60, 0x33, 0xB9, 0x56, 0x6F, 0x69, 0xD4, 0x53, 0xE3, 0x52, 0xB7, 0xAC, 0xE9, 0x1A,
+        0x79, 0x97, 0x23, 0x96, 0x66, 0xC3, 0xF1, 0x70, 0x3C, 0x8F, 0xCB, 0x59, 0xDF, 0x0E, 0xFD, 0xBC, 0xE9, 0x1E,
+        0x44, 0x6D, 0xA7, 0x8C, 0x15, 0x8F, 0x58, 0x45, 0xD2, 0xF5, 0x94, 0xBB, 0x28, 0x38, 0x44, 0xAD, 0xEA, 0xBD,
+        0x9A, 0x87, 0x43, 0x3B, 0x4D, 0x10, 0x1A, 0x05, 0xB7, 0x3D, 0x26, 0x85, 0x73, 0x69, 0xD4, 0xF2, 0xC3, 0x79,
+        0xEC, 0x26, 0xD5, 0xB5, 0x8E, 0xF5, 0xAB, 0xAB, 0x4F, 0x9E, 0x25, 0x1A, 0x65, 0x29, 0x2A, 0x91, 0xF1, 0x66,
+        0x48, 0x1F, 0x11, 0xF0, 0x8F, 0x91, 0x68, 0x92, 0x70, 0x32, 0x4E, 0xE9, 0x80, 0xED, 0x46, 0x63, 0xCE, 0xB8,
+        0x5C, 0xC7, 0xC0, 0xCE, 0x9C, 0x95, 0x75, 0x06, 0x08, 0x02, 0xD6, 0xA7, 0x28, 0x6C, 0x56, 0xEF, 0x5A, 0xF4,
+        0x76, 0x92, 0x88, 0x51, 0x2B, 0x59, 0xD2, 0xFF, 0x25, 0x95, 0xAA, 0x36, 0xF6, 0x76, 0xD1, 0x6D, 0xD2, 0x1E,
+        0x59, 0x81, 0x2B, 0x40, 0xC2, 0xEA, 0x60, 0x55, 0xD0, 0x66, 0xE6, 0x7E, 0x47, 0x84, 0x48, 0x54, 0xA4, 0x4B,
+        0x1D, 0xBB, 0x0C, 0x3B, 0xF7, 0xBA, 0x47, 0xBF, 0xDB, 0x0B, 0x21, 0x6C, 0xB4, 0xEF, 0xBE, 0xCD, 0x41, 0x7A,
+        0xF1, 0x81, 0x02, 0xB4, 0xD4, 0x95, 0xDA, 0xEA, 0xA3, 0x1F, 0x70, 0xBA, 0x1C, 0xEA, 0x54, 0xFE, 0x08, 0x7C,
+        0x98, 0x09, 0x79, 0xF5, 0x4E, 0x84, 0xC3, 0x5F, 0xD9, 0x5D, 0xE8, 0x0D, 0x79, 0xC6, 0x09, 0x6E, 0x57, 0x05,
+        0x7C, 0x7E, 0x7A, 0xDB, 0x37, 0x44, 0x07, 0xD3, 0xF2, 0x3F, 0x00, 0x75, 0xF8, 0x92, 0xFB, 0x31, 0x5F, 0xAA,
+        0x68, 0xE2, 0xE0, 0xED, 0xA8, 0x2A, 0x64, 0xC9, 0xA2, 0x0F, 0x63, 0x23, 0x9E, 0xA7};
+    uint8_t out[1024] = {0};
+    long n = inflate_zlib(stream, sizeof(stream), out, sizeof(out));
+    ASSERT_EQ_INT(600, (int)n);
+    ASSERT_EQ_INT((int)0xDAF73B30u, (int)udif_crc32(0, out, 600));
+}
+
+TEST(inflate_alloc_form_matches) {
+    const uint8_t payload[] = "the malloc'ing entry point the PNG reader uses";
+    size_t slen = 0;
+    uint8_t *stream = zlib_stored(payload, sizeof(payload), &slen);
+    size_t out_len = 0;
+    uint8_t *out = inflate_zlib_alloc(stream, slen, &out_len);
+    ASSERT_TRUE(out != NULL);
+    ASSERT_EQ_INT((int)sizeof(payload), (int)out_len);
+    ASSERT_EQ_INT(0, memcmp(out, payload, sizeof(payload)));
+    free(out);
+    free(stream);
+}
+
+TEST(inflate_rejects_bad_headers) {
+    uint8_t out[64];
+    const uint8_t payload[] = "x";
+    size_t slen = 0;
+    uint8_t *stream = zlib_stored(payload, sizeof(payload), &slen);
+
+    // Compression method must be 8 (deflate).
+    uint8_t bad_cm[64];
+    memcpy(bad_cm, stream, slen);
+    bad_cm[0] = 0x79;
+    ASSERT_EQ_INT(-1, (int)inflate_zlib(bad_cm, slen, out, sizeof(out)));
+
+    // The two header bytes must form a multiple of 31.
+    uint8_t bad_check[64];
+    memcpy(bad_check, stream, slen);
+    bad_check[1] = 0x02;
+    ASSERT_EQ_INT(-1, (int)inflate_zlib(bad_check, slen, out, sizeof(out)));
+
+    // A preset dictionary (FDICT) is never used by these images.
+    uint8_t fdict[64];
+    memcpy(fdict, stream, slen);
+    fdict[1] = 0x3D; // FDICT set, still a multiple of 31
+    ASSERT_EQ_INT(-1, (int)inflate_zlib(fdict, slen, out, sizeof(out)));
+
+    // Truncated mid-block.
+    ASSERT_EQ_INT(-1, (int)inflate_zlib(stream, 5, out, sizeof(out)));
+    free(stream);
+}
+
+TEST(inflate_overflow_is_an_error_not_a_clamp) {
+    // A caller with a fixed buffer stated the exact expected size, so a stream
+    // that expands past it must fail rather than silently truncate.
+    uint8_t payload[64];
+    memset(payload, 'Z', sizeof(payload));
+    size_t slen = 0;
+    uint8_t *stream = zlib_stored(payload, sizeof(payload), &slen);
+    uint8_t out[16];
+    ASSERT_EQ_INT(-1, (int)inflate_zlib(stream, slen, out, sizeof(out)));
+    free(stream);
+}
+
+TEST(crc32_known_vector) {
+    ASSERT_EQ_INT((int)0xCBF43926u, (int)udif_crc32(0, (const uint8_t *)"123456789", 9));
+}
+
+// ---- 'koly' trailer --------------------------------------------------------
+
+// Build a well-formed version-4 trailer; callers patch individual fields.
+static void build_trailer(uint8_t t[UDIF_TRAILER_SIZE]) {
+    memset(t, 0, UDIF_TRAILER_SIZE);
+    memcpy(t, "koly", 4);
+    w_u32(t + 0x04, 4); // version
+    w_u32(t + 0x08, UDIF_TRAILER_SIZE); // header size
+    w_u64(t + KOLY_DATA_OFFSET, 0);
+    w_u64(t + KOLY_DATA_LENGTH, 4096);
+    w_u32(t + KOLY_SEGMENT_COUNT, 1);
+    w_u32(t + 0x50, UDIF_CHECKSUM_CRC32);
+    w_u32(t + 0x58, 0xDEADBEEF);
+    w_u64(t + KOLY_XML_OFFSET, 4096);
+    w_u64(t + KOLY_XML_LENGTH, 512);
+    w_u64(t + KOLY_SECTORS, 128);
+}
+
+TEST(udif_detect_and_parse_trailer) {
+    uint8_t t[UDIF_TRAILER_SIZE];
+    build_trailer(t);
+    ASSERT_TRUE(udif_detect(t, sizeof(t)));
+
+    udif_trailer_t tr;
+    ASSERT_EQ_INT(0, udif_parse_trailer(t, sizeof(t), &tr));
+    ASSERT_EQ_INT(0, (int)tr.data_fork_offset);
+    ASSERT_EQ_INT(4096, (int)tr.data_fork_length);
+    ASSERT_EQ_INT(4096, (int)tr.xml_offset);
+    ASSERT_EQ_INT(512, (int)tr.xml_length);
+    ASSERT_EQ_INT(128, (int)tr.sectors);
+    ASSERT_EQ_INT((int)UDIF_CHECKSUM_CRC32, (int)tr.checksum_type);
+    ASSERT_EQ_INT((int)0xDEADBEEFu, (int)tr.checksum);
+}
+
+TEST(udif_detect_rejects_impostors) {
+    uint8_t t[UDIF_TRAILER_SIZE];
+
+    // Wrong magic — four payload bytes are not a trailer.
+    build_trailer(t);
+    memcpy(t, "koln", 4);
+    ASSERT_TRUE(!udif_detect(t, sizeof(t)));
+
+    // Right magic, wrong version.
+    build_trailer(t);
+    w_u32(t + 0x04, 3);
+    ASSERT_TRUE(!udif_detect(t, sizeof(t)));
+
+    // Right magic and version, wrong declared header size.
+    build_trailer(t);
+    w_u32(t + 0x08, 1024);
+    ASSERT_TRUE(!udif_detect(t, sizeof(t)));
+
+    // Short buffer.
+    build_trailer(t);
+    ASSERT_TRUE(!udif_detect(t, 128));
+}
+
+TEST(udif_trailer_rejects_unsupported) {
+    uint8_t t[UDIF_TRAILER_SIZE];
+    udif_trailer_t tr;
+
+    // A spanned image keeps later chunks in sibling .dmgpart files.
+    build_trailer(t);
+    w_u32(t + KOLY_SEGMENT_COUNT, 3);
+    ASSERT_EQ_INT(-ENOTSUP, udif_parse_trailer(t, sizeof(t), &tr));
+
+    // No block map at all.
+    build_trailer(t);
+    w_u64(t + KOLY_XML_LENGTH, 0);
+    ASSERT_EQ_INT(-EINVAL, udif_parse_trailer(t, sizeof(t), &tr));
+
+    // A zero-sector image has nothing to decode.
+    build_trailer(t);
+    w_u64(t + KOLY_SECTORS, 0);
+    ASSERT_EQ_INT(-EINVAL, udif_parse_trailer(t, sizeof(t), &tr));
+}
+
+// ---- 'mish' block map inside the property list -----------------------------
+
+// One chunk entry as the test wants to express it.
+typedef struct {
+    uint32_t type;
+    uint64_t sector;
+    uint64_t count;
+    uint64_t offset;
+    uint64_t length;
+} test_chunk_t;
+
+// Build a 'mish' block table with `n` entries plus a terminator.
+static uint8_t *build_mish(uint64_t base, uint64_t sectors, uint32_t checksum, const test_chunk_t *chunks, size_t n,
+                           size_t *out_len) {
+    size_t len = MISH_ENTRIES + (n + 1) * MISH_ENTRY_SIZE;
+    uint8_t *b = (uint8_t *)calloc(1, len);
+    memcpy(b, "mish", 4);
+    w_u32(b + 0x04, 1); // version
+    w_u64(b + MISH_SECTOR, base);
+    w_u64(b + MISH_SECTOR_COUNT, sectors);
+    w_u64(b + MISH_DATA_OFFSET, 0);
+    w_u32(b + 0x24, 0xFFFFFFFFu); // resource ID, deliberately not a count
+    w_u32(b + MISH_CHECKSUM_TYPE, UDIF_CHECKSUM_CRC32);
+    w_u32(b + MISH_CHECKSUM, checksum);
+    w_u32(b + MISH_CHUNK_COUNT, (uint32_t)(n + 1));
+    for (size_t i = 0; i < n; i++) {
+        uint8_t *e = b + MISH_ENTRIES + i * MISH_ENTRY_SIZE;
+        w_u32(e, chunks[i].type);
+        w_u64(e + 8, chunks[i].sector);
+        w_u64(e + 16, chunks[i].count);
+        w_u64(e + 24, chunks[i].offset);
+        w_u64(e + 32, chunks[i].length);
+    }
+    w_u32(b + MISH_ENTRIES + n * MISH_ENTRY_SIZE, UDIF_CHUNK_END);
+    *out_len = len;
+    return b;
+}
+
+// Base64-encode, wrapping like a real plist does so the decoder's whitespace
+// handling is exercised.
+static char *base64_encode(const uint8_t *data, size_t len) {
+    static const char alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    char *out = (char *)malloc(len * 2 + 64);
+    size_t o = 0, col = 0;
+    for (size_t i = 0; i < len; i += 3) {
+        uint32_t v = (uint32_t)data[i] << 16;
+        if (i + 1 < len)
+            v |= (uint32_t)data[i + 1] << 8;
+        if (i + 2 < len)
+            v |= data[i + 2];
+        out[o++] = alphabet[(v >> 18) & 63];
+        out[o++] = alphabet[(v >> 12) & 63];
+        out[o++] = (i + 1 < len) ? alphabet[(v >> 6) & 63] : '=';
+        out[o++] = (i + 2 < len) ? alphabet[v & 63] : '=';
+        if ((col += 4) >= 64) {
+            out[o++] = '\n';
+            out[o++] = '\t';
+            col = 0;
+        }
+    }
+    out[o] = '\0';
+    return out;
+}
+
+// Wrap one Base64 blob in the plist skeleton hdiutil writes.
+static char *build_plist(const char *name, const char *b64) {
+    char *xml = (char *)malloc(strlen(b64) + strlen(name) + 1024);
+    sprintf(xml,
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<plist version=\"1.0\">\n<dict>\n"
+            "\t<key>resource-fork</key>\n\t<dict>\n\t\t<key>blkx</key>\n\t\t<array>\n"
+            "\t\t\t<dict>\n"
+            "\t\t\t\t<key>Attributes</key>\n\t\t\t\t<string>0x0050</string>\n"
+            "\t\t\t\t<key>CFName</key>\n\t\t\t\t<string>%s</string>\n"
+            "\t\t\t\t<key>Data</key>\n\t\t\t\t<data>\n\t\t\t\t%s\n\t\t\t\t</data>\n"
+            "\t\t\t\t<key>ID</key>\n\t\t\t\t<string>0</string>\n"
+            "\t\t\t\t<key>Name</key>\n\t\t\t\t<string>%s</string>\n"
+            "\t\t\t</dict>\n\t\t</array>\n\t</dict>\n</dict>\n</plist>\n",
+            name, b64, name);
+    return xml;
+}
+
+// Build a one-table map from `chunks`, returning the parsed result.
+static udif_map_t *parse_one_table(uint64_t base, uint64_t sectors, const test_chunk_t *chunks, size_t n, int *rc_out) {
+    size_t mish_len = 0;
+    uint8_t *mish = build_mish(base, sectors, 0, chunks, n, &mish_len);
+    char *b64 = base64_encode(mish, mish_len);
+    char *xml = build_plist("Apple_HFS : 3", b64);
+    udif_map_t *m = NULL;
+    *rc_out = udif_parse_blkx((const uint8_t *)xml, strlen(xml), &m);
+    free(xml);
+    free(b64);
+    free(mish);
+    return m;
+}
+
+TEST(udif_parse_blkx_reads_chunks) {
+    const test_chunk_t chunks[] = {
+        {UDIF_CHUNK_ZLIB, 0, 2, 0,   40 },
+        {UDIF_CHUNK_RAW,  2, 1, 40,  512},
+        {UDIF_CHUNK_ZERO, 3, 5, 552, 0  },
+    };
+    int rc = -1;
+    udif_map_t *m = parse_one_table(10, 8, chunks, 3, &rc);
+    ASSERT_EQ_INT(0, rc);
+    ASSERT_TRUE(m != NULL);
+    ASSERT_EQ_INT(1, (int)m->n_tables);
+
+    udif_table_t *t = &m->tables[0];
+    // The name comes from CFName, not the first <string> in the dict (which
+    // is the Attributes word).
+    ASSERT_EQ_INT(0, strcmp(t->name, "Apple_HFS : 3"));
+    ASSERT_EQ_INT(10, (int)t->base_sector);
+    ASSERT_EQ_INT(8, (int)t->sectors);
+    // The terminator is dropped; three usable chunks remain.
+    ASSERT_EQ_INT(3, (int)t->n_chunks);
+    ASSERT_EQ_INT((int)UDIF_CHUNK_ZLIB, (int)t->chunks[0].type);
+    ASSERT_EQ_INT(2, (int)t->chunks[0].count);
+    ASSERT_EQ_INT(40, (int)t->chunks[0].length);
+    // Chunk sectors are relative to the table base: absolute = 10 + 2.
+    ASSERT_EQ_INT(2, (int)t->chunks[1].sector);
+    ASSERT_EQ_INT(40, (int)t->chunks[1].offset);
+    // Total image size spans to the far edge of the last table.
+    ASSERT_EQ_INT(18, (int)m->sectors);
+    udif_map_free(m);
+}
+
+TEST(udif_parse_blkx_rejects_malformed) {
+    // A chunk running past the table's own sector count.
+    const test_chunk_t overrun[] = {
+        {UDIF_CHUNK_RAW, 6, 4, 0, 2048}
+    };
+    int rc = 0;
+    udif_map_t *m = parse_one_table(0, 8, overrun, 1, &rc);
+    ASSERT_EQ_INT(-EINVAL, rc);
+    ASSERT_TRUE(m == NULL);
+
+    // A blob whose 'mish' magic is wrong must not be read as a table.
+    const test_chunk_t ok[] = {
+        {UDIF_CHUNK_ZERO, 0, 1, 0, 0}
+    };
+    size_t mish_len = 0;
+    uint8_t *mish = build_mish(0, 1, 0, ok, 1, &mish_len);
+    memcpy(mish, "hsim", 4);
+    char *b64 = base64_encode(mish, mish_len);
+    char *xml = build_plist("bogus", b64);
+    m = NULL;
+    ASSERT_EQ_INT(-EINVAL, udif_parse_blkx((const uint8_t *)xml, strlen(xml), &m));
+    ASSERT_TRUE(m == NULL);
+    free(xml);
+    free(b64);
+
+    // A non-zero mish DataOffset would silently shift every read.
+    mish = build_mish(0, 1, 0, ok, 1, &mish_len);
+    w_u64(mish + MISH_DATA_OFFSET, 512);
+    b64 = base64_encode(mish, mish_len);
+    xml = build_plist("shifted", b64);
+    m = NULL;
+    ASSERT_EQ_INT(-ENOTSUP, udif_parse_blkx((const uint8_t *)xml, strlen(xml), &m));
+    free(xml);
+    free(b64);
+    free(mish);
+
+    // A plist with no blkx key is not a block map.
+    const char *empty = "<?xml version=\"1.0\"?><plist><dict></dict></plist>";
+    m = NULL;
+    ASSERT_EQ_INT(-ENOENT, udif_parse_blkx((const uint8_t *)empty, strlen(empty), &m));
+}
+
+// ---- chunk decoding --------------------------------------------------------
+
+TEST(udif_decode_zero_ignore_raw) {
+    uint8_t dst[1024];
+
+    // Zero-fill and ignored chunks both read as zeros.
+    udif_chunk_t zero = {.type = UDIF_CHUNK_ZERO, .sector = 0, .count = 2, .offset = 0, .length = 0};
+    memset(dst, 0xAA, sizeof(dst));
+    ASSERT_EQ_INT(0, udif_decode_chunk(&zero, NULL, 0, dst, sizeof(dst)));
+    for (size_t i = 0; i < 1024; i++)
+        ASSERT_EQ_INT(0, dst[i]);
+
+    udif_chunk_t ignore = {.type = UDIF_CHUNK_IGNORE, .sector = 0, .count = 1, .offset = 0, .length = 0};
+    memset(dst, 0xAA, sizeof(dst));
+    ASSERT_EQ_INT(0, udif_decode_chunk(&ignore, NULL, 0, dst, 512));
+    for (size_t i = 0; i < 512; i++)
+        ASSERT_EQ_INT(0, dst[i]);
+
+    // Raw copies verbatim.
+    uint8_t raw[512];
+    memset(raw, 0x5A, sizeof(raw));
+    udif_chunk_t rawc = {.type = UDIF_CHUNK_RAW, .sector = 0, .count = 1, .offset = 0, .length = 512};
+    ASSERT_EQ_INT(0, udif_decode_chunk(&rawc, raw, sizeof(raw), dst, sizeof(dst)));
+    ASSERT_EQ_INT(0, memcmp(dst, raw, 512));
+
+    // A raw chunk whose source is short of a full sector run is malformed.
+    ASSERT_EQ_INT(-EINVAL, udif_decode_chunk(&rawc, raw, 256, dst, sizeof(dst)));
+}
+
+TEST(udif_decode_zlib_chunk) {
+    uint8_t sector[512];
+    for (int i = 0; i < 512; i++)
+        sector[i] = (uint8_t)(i * 7);
+    size_t slen = 0;
+    uint8_t *stream = zlib_stored(sector, sizeof(sector), &slen);
+
+    udif_chunk_t c = {.type = UDIF_CHUNK_ZLIB, .sector = 0, .count = 1, .offset = 0, .length = slen};
+    uint8_t dst[512] = {0};
+    ASSERT_EQ_INT(0, udif_decode_chunk(&c, stream, slen, dst, sizeof(dst)));
+    ASSERT_EQ_INT(0, memcmp(dst, sector, sizeof(sector)));
+
+    // A stream that decodes to the wrong length disagrees with the map, which
+    // must fail rather than yield a half-filled sector.
+    udif_chunk_t two = {.type = UDIF_CHUNK_ZLIB, .sector = 0, .count = 2, .offset = 0, .length = slen};
+    uint8_t big[1024] = {0};
+    ASSERT_EQ_INT(-EINVAL, udif_decode_chunk(&two, stream, slen, big, sizeof(big)));
+    free(stream);
+}
+
+TEST(udif_decode_adc_chunk) {
+    // ADC: 0x80|len-1 literal run.  Emit 512 bytes as four 128-byte runs.
+    uint8_t src[4 * 129];
+    uint8_t expect[512];
+    for (int r = 0; r < 4; r++) {
+        src[r * 129] = 0x80 | 127; // literal run of 128
+        for (int i = 0; i < 128; i++) {
+            uint8_t v = (uint8_t)(r * 128 + i);
+            src[r * 129 + 1 + i] = v;
+            expect[r * 128 + i] = v;
+        }
+    }
+    udif_chunk_t c = {.type = UDIF_CHUNK_ADC, .sector = 0, .count = 1, .offset = 0, .length = sizeof(src)};
+    uint8_t dst[512] = {0};
+    ASSERT_EQ_INT(0, udif_decode_chunk(&c, src, sizeof(src), dst, sizeof(dst)));
+    ASSERT_EQ_INT(0, memcmp(dst, expect, sizeof(expect)));
+}
+
+TEST(udif_decode_rejects_unimplemented_codecs) {
+    uint8_t src[16] = {0};
+    uint8_t dst[512];
+    // Real codecs we do not implement must say so, not zero-fill silently.
+    const uint32_t codecs[] = {UDIF_CHUNK_BZ2, UDIF_CHUNK_LZFSE, UDIF_CHUNK_LZMA};
+    for (size_t i = 0; i < sizeof(codecs) / sizeof(codecs[0]); i++) {
+        udif_chunk_t c = {.type = codecs[i], .sector = 0, .count = 1, .offset = 0, .length = sizeof(src)};
+        ASSERT_EQ_INT(-ENOTSUP, udif_decode_chunk(&c, src, sizeof(src), dst, sizeof(dst)));
+    }
+    // An unknown type code is malformed rather than merely unsupported.
+    udif_chunk_t bogus = {.type = 0x12345678u, .sector = 0, .count = 1, .offset = 0, .length = sizeof(src)};
+    ASSERT_EQ_INT(-EINVAL, udif_decode_chunk(&bogus, src, sizeof(src), dst, sizeof(dst)));
+
+    // A destination smaller than the chunk's sector run is a caller error.
+    udif_chunk_t zero = {.type = UDIF_CHUNK_ZERO, .sector = 0, .count = 4, .offset = 0, .length = 0};
+    ASSERT_EQ_INT(-EINVAL, udif_decode_chunk(&zero, NULL, 0, dst, sizeof(dst)));
+}
+
+int main(void) {
+    RUN(inflate_stored_block);
+    RUN(inflate_fixed_huffman);
+    RUN(inflate_dynamic_huffman);
+    RUN(inflate_alloc_form_matches);
+    RUN(inflate_rejects_bad_headers);
+    RUN(inflate_overflow_is_an_error_not_a_clamp);
+    RUN(crc32_known_vector);
+    RUN(udif_detect_and_parse_trailer);
+    RUN(udif_detect_rejects_impostors);
+    RUN(udif_trailer_rejects_unsupported);
+    RUN(udif_parse_blkx_reads_chunks);
+    RUN(udif_parse_blkx_rejects_malformed);
+    RUN(udif_decode_zero_ignore_raw);
+    RUN(udif_decode_zlib_chunk);
+    RUN(udif_decode_adc_chunk);
+    RUN(udif_decode_rejects_unimplemented_codecs);
+    fprintf(stderr, "All udif tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
Disk Copy 6.5 and every modern `hdiutil` write UDIF, not the NDIF the image layer already understood, so a `.dmg` was opaque to us — including the June 1996 Copland / Mac OS 8 DDK CD that prompted this.

## What this does

`src/core/storage/image_udif.c` parses the 512-byte `koly` trailer at EOF, retrieves the XML property list it points at, Base64-decodes each `mish` block table out of the `blkx` array, and decodes the chunks: zero-fill, ignored, raw, ADC (`adc.c` already had it) and zlib. `image.c` materialises the result into the same storage-cache scratch image NDIF uses, so nothing downstream changes — the emulator just sees a raw base.

The zlib decompressor comes from the PNG reader in `debug.c`, lifted into `src/core/storage/inflate.c` so both can share it. **The core still links no third-party C libraries.** New in the extraction: zlib-header validation (`CM==8`, mod-31 check, FDICT rejected) and a fixed-capacity entry point — a UDIF chunk's decoded size is known exactly, so overflow is an error rather than a silent clamp. The deflate *writer* stays in `debug.c` and now takes the RFC 1951 tables from `inflate.h`.

Second commit fixes a pre-existing cache bug this surfaced: `image_scratch_path()` hashed the caller's path spelling, so the same image addressed relatively and absolutely decoded twice and stored two copies. Reading the Copland CD that way cost 264 MB of scratch for one 60 MB `.dmg`. Now canonicalised through `realpath()`, as `image_vfs.c` already does for its mount table. NDIF benefits too.

## Verified against a real image

The 1996 Copland DDK CD (UDZO, v4, 60 MB → 132 MB, 5 partitions):

- the trailer's CRC-32 over the data fork and **all five block tables' CRC-32s reproduce exactly**
- the volume mounts, lists, and reads — `Mac OS 8 Runtime SW`, `Sample Code`, and the DDK read-me's 1996 text
- each table's checksum is verified during materialisation, so a bad decode fails at open with a logged mismatch rather than surfacing later as a subtly corrupt disk. Confirmed by corrupting one raw chunk and watching the open be refused.

## Format traps, all covered by tests

- **Chunk sectors are relative to their table's base sector.** Absolute position is `table.base_sector + chunk.sector`; one table per partition, each restarting at zero. The integration fixture deliberately emits two tables so a single-table fixture can't hide this.
- **`SectorCount` sits at trailer offset `0x1EC`**, not where a naive walk of the published struct puts it — the 128-byte checksum blobs shift several fields. I got this wrong first (`0x260`, past the end of the 512-byte trailer) and the unit test restated the same wrong constant, so only the real image caught it. Static assertions now keep every trailer offset inside 512 bytes.
- **The u32 at `mish` offset `0x24` is the blkx resource ID, not a descriptor count.** The count is at `0xC8`.

Encrypted (`encrcdsa`), multi-segment (`.dmgpart`), bzip2, LZFSE and LZMA images are rejected explicitly rather than half-decoded.

## Tests

- `tests/unit/suites/udif/` — 16 tests over the trailer, plist/`mish` parsing, all chunk types, and the inflate paths (stored, fixed-Huffman, dynamic-Huffman, malformed headers, overflow).
- `tests/integration/image-udif/` — builds its `.dmg` fixture at setup time with `make-fixture.py`, written from the format spec rather than from the reader, so agreement between them is evidence rather than tautology. No binary fixture added to the tree. It also asserts the decode-once-per-image behaviour; reverting the canonicalisation makes it fail with `scratch cache holds 42844640 bytes`.

## What I ran locally

Headless and wasm build clean (no new warnings vs. baseline). Unit suites `udif`, `ndif`, `storage`, `vfs`, `resfork`, `hfsplus`, `appledouble`. Thirteen integration tests individually: `image-udif`, `image-export-raw`, `image-partmap`, `image-hfs-traverse`, `image-ufs-traverse`, `object-storage`, `storage-guards`, `archive-fork-unpack`, `vfs-rsrc`, `object-floppy`, `object-scsi`, `debug`, `checkpoint`.

## Where reviewers should look hardest

**`TIER=matrix`.** This refactors the inflate that `screen.match` uses to read reference PNGs, and adds header validation to it, so every golden comparison in the suite runs through the new code. I round-tripped a PNG our own writer produced and confirmed a committed reference decodes without error, but no committed golden has been *matched successfully* through the new path locally. I believe rejection is impossible by spec (RFC 2083 forbids FDICT; CM is always 8), but that's precisely what the matrix tier tests cheaply.

Also not run locally: `TIER=extended`, `make ui2-e2e`, and valgrind — the latter matters because `image_udif.c` and `inflate.c` add new `malloc`/`realloc`/`free` paths that nothing has memchecked yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)