### PR TITLE
pdm: offer the CD bay on the Power Macintosh 6100/7100/8100

### DIFF
--- a/src/machines/pdm/pm6100.c
+++ b/src/machines/pdm/pm6100.c
@@ -52,7 +52,10 @@ const hw_profile_t machine_pm6100 = {
     .ram_options = pm6100_ram_options_kb,
     .floppy_slots = pm6100_floppy_slots,
     .scsi_slots = pm6100_scsi_slots,
-    .has_cdrom = false,
+    // The AppleCD 300i rides the same Curio 53C96 bus as the HD slots
+    // (Phase G): no CD-specific hardware is involved, so the bay is
+    // offered as soon as that bus exists.
+    .has_cdrom = true,
     .cdrom_id = 3,
 
     .nubus_slots = NULL,

--- a/src/machines/pdm/pm7100.c
+++ b/src/machines/pdm/pm7100.c
@@ -47,7 +47,10 @@ const hw_profile_t machine_pm7100 = {
     .ram_options = pm7100_ram_options_kb,
     .floppy_slots = pm7100_floppy_slots,
     .scsi_slots = pm7100_scsi_slots,
-    .has_cdrom = false,
+    // The AppleCD 300i rides the same Curio 53C96 bus as the HD slots
+    // (Phase G): no CD-specific hardware is involved, so the bay is
+    // offered as soon as that bus exists.
+    .has_cdrom = true,
     .cdrom_id = 3,
 
     .nubus_slots = NULL,

--- a/src/machines/pdm/pm8100.c
+++ b/src/machines/pdm/pm8100.c
@@ -50,7 +50,10 @@ const hw_profile_t machine_pm8100 = {
     .ram_options = pm8100_ram_options_kb,
     .floppy_slots = pm8100_floppy_slots,
     .scsi_slots = pm8100_scsi_slots,
-    .has_cdrom = false,
+    // The AppleCD 300i rides the same Curio 53C96 bus as the HD slots
+    // (Phase G): no CD-specific hardware is involved, so the bay is
+    // offered as soon as that bus exists.
+    .has_cdrom = true,
     .cdrom_id = 3,
 
     .nubus_slots = NULL,

--- a/tests/integration/machine-capabilities/run.sh
+++ b/tests/integration/machine-capabilities/run.sh
@@ -154,16 +154,19 @@ done
 # machines.  cpu.model 601 + the 601 MMU kind are what gate the PPC debug
 # panels; fpu:true since Phase E landed the 601 FPU datapath and the
 # machine.cpu.fpu object (proposal-powerpc-601-pdm.md §3.6).  Phase G
-# landed the Curio SCSI bus, so two HD slots are offered; floppy (the
-# SWIM3 datapath) and NuBus (BART) remain Phase H, and this row is what
-# keeps the profile honest about it.
+# landed the Curio SCSI bus, so two HD slots AND the CD bay are offered —
+# a CD-ROM is an ordinary SCSI target on that same bus, with no
+# CD-specific hardware behind it.  Floppy (the SWIM3 datapath) and NuBus
+# (BART) remain Phase H, and this row is what keeps the profile honest
+# about which of the three is actually absent.
 for m in pm6100 pm7100 pm8100; do
     assert_contains "$m" '"model":601' "$m is a PowerPC 601"
     assert_contains "$m" '"kind":"ppc_601"' "$m has the 601 BAT/segment/HTAB MMU"
     assert_contains "$m" '"fpu":true' "$m FPU capability on since Phase E"
     assert_contains "$m" '"address_bits":32' "$m is 32-bit"
     assert_contains "$m" '"nubus":false' "$m declares no NuBus sockets yet"
-    assert_contains "$m" '"has_cdrom":false' "$m offers no CD bay yet"
+    assert_contains "$m" '"has_cdrom":true' "$m offers the Curio-bus CD bay"
+    assert_contains "$m" '"cdrom_id":3' "$m puts the CD at SCSI ID 3"
     assert_contains "$m" '"floppy_slots":[]' "$m offers no floppy drive yet (Phase H)"
     assert_contains "$m" '"scsi_slots":[{"label":"SCSI HD0","id":0},{"label":"SCSI HD1","id":1}]' "$m offers the two Curio SCSI HD slots (Phase G)"
 done

--- a/tests/integration/suite-pdm/test.script
+++ b/tests/integration/suite-pdm/test.script
@@ -10,6 +10,10 @@
 #                16 MB — 24 MB is not in the 8100's ram_options (8 MB
 #                soldered + paired 16 MB SIMMs), so this row also spreads
 #                the RAM axis.
+#   pdm-cd-device  A CD-ROM plugs into the Curio bus: CD-typed, read-only,
+#                medium present, block size from the disc's own DDM.  This
+#                is what the profile's has_cdrom:true rests on.  Boot-free,
+#                so it does not disturb the desktop goldens above.
 #
 # All three rows share one recipe (boot_pdm_75):
 #
@@ -39,6 +43,9 @@
 include "../lib/mac.script"
 
 let hd_75 = "../../data/systems/system_7_5_0_77mb_mode32_24ac.img"
+# An ordinary HD image served through attach_cdrom: "CD" is the device
+# type, not the mastering (see iici-cdrom-boot).  Already in gs-test-data.
+let cd_disc = "../../data/systems/system_7_1_20mb_24ac_cd_32bit.img"
 
 # Boot `model` from the prepared 7.5 image to a stable Finder desktop.
 def boot_pdm_75(model, ram_kb) {
@@ -80,6 +87,27 @@ def row_6100_75_hd() { pdm_75_row("pm6100", 24576, 69) }
 def row_7100_75_hd() { pdm_75_row("pm7100", 24576, 106) }
 def row_8100_75_hd() { pdm_75_row("pm8100", 16384, 59) }
 
+# ---- cd-device --------------------------------------------------------------
+# The plug contract for a CD-ROM on the Curio bus, which is what the profile's
+# has_cdrom claim rests on.  A CD is an ordinary SCSI target — no CD-specific
+# hardware sits behind it — so the assertions are the ones the IIci row makes:
+# CD-typed, read-only, medium present, and a block size taken from the disc's
+# own Driver Descriptor Map rather than a hard-coded CD default.
+#
+# Deliberately device-level and boot-free: attaching a disc to a booting row
+# would put a CD icon on the desktop and invalidate the goldens above.
+def row_pdm_cd_device() {
+    machine.boot model="pm7100" ram=24576 rom="${$ROM}"
+    machine.scsi.attach_cdrom "${$cd_disc}" 3
+    assert machine.scsi.device[3].type == "cdrom" "cd-device: SCSI 3 is not a CD-ROM"
+    assert machine.scsi.device[3].read_only "cd-device: CD-ROM is not read-only"
+    assert machine.scsi.device[3].medium_present "cd-device: no medium present"
+    assert machine.scsi.device[3].block_size == 512 "cd-device: block_size ${machine.scsi.device[3].block_size}, want 512 (from the disc's DDM)"
+    # The HD slots the same bus already served must be undisturbed by it.
+    assert try(machine.scsi.device[0].type, none) == none "cd-device: something is attached at SCSI 0"
+    report_row("7.5", "curio", "cd-device")
+}
+
 # ---- row dispatch -----------------------------------------------------------
 
 if row_on("6100-75-hd") {
@@ -101,6 +129,14 @@ if row_on("8100-75-hd") {
         row_end("8100-75-hd", try(row_8100_75_hd(), "FAILED"))
     } else {
         echo "skip: 8100-75-hd (7.5 prepared image not fetched)"
+    }
+}
+
+if row_on("pdm-cd-device") {
+    if have_media($cd_disc) {
+        row_end("pdm-cd-device", try(row_pdm_cd_device(), "FAILED"))
+    } else {
+        echo "skip: pdm-cd-device (CD disc image not fetched)"
     }
 }
 


### PR DESCRIPTION
The web UI's machine-configuration dialog shows the CD-ROM row iff the profile advertises `has_cdrom` ([WelcomeConfigSlide.svelte:174](app/web2/src/components/display/WelcomeConfigSlide.svelte#L174)), and all three PDM models declared `false` — so there was no way to insert a disc on a Power Mac.

## Why this flag guarded nothing

It sat beside two other `false`s in the same `machine-capabilities` block, but it is not like them:

| capability | PDM | reason |
|---|---|---|
| `nubus` | false | no BART bridge — genuinely absent, Phase H |
| `floppy_slots` | `[]` | no SWIM3 datapath — genuinely absent, Phase H |
| `has_cdrom` | **was false** | nothing missing — the Curio 53C96 bus landed in Phase G |

A CD-ROM is an ordinary SCSI target on the same bus that already carries the two HD slots; no CD-specific hardware sits behind it. `has_cdrom` is a UI hint only — no core code consults it — so the emulator has been able to attach a disc all along.

## Verified before claiming it

Not just "it attaches". A pm7100 booting System 7.5 from its SCSI HD with a disc attached at ID 3 **mounts and browses the volume in the Finder** — the disc's window opens, 9 items, read-only ("zero K available"). The claim is a capability that works end to end, not one that merely plugs in.

## Tests

`machine-capabilities` asserted `has_cdrom:false` as a deliberate "not yet" guard. That assertion now reads `true`, plus `cdrom_id:3`, and its rationale comment is updated to say which of the three Phase-H flags is actually absent rather than lumping them together.

`suite-pdm` gains a **boot-free** `pdm-cd-device` row pinning the plug contract, modelled on the IIci CD row: CD-typed, read-only, medium present, block size taken from the disc's own Driver Descriptor Map, and the HD slots undisturbed. It reuses `system_7_1_20mb_24ac_cd_32bit.img`, already in gs-test-data — "CD" is the device type, not the mastering.

Boot-free on purpose: attaching a disc to one of the three booting rows would put a CD icon on the desktop and invalidate its golden.

## Ran locally

`machine-capabilities` PASS, `machine-profile-schema` PASS, and the new `suite-pdm ROW=pdm-cd-device` PASS. The three golden-matching `suite-pdm` boot rows are untouched by this change but cost ~15 min each, so they are left to CI's matrix tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)