### PR TITLE
ci: pin gs-pages checkout to main so deploys survive REST quota exhaustion

### DIFF
--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -69,10 +69,19 @@ jobs:
         run: make clean && make && make ui2
 
       # 3. Checkout the deployment repository.
+      #    `ref` is pinned rather than left to default, deliberately:
+      #    without it actions/checkout must call the REST API to ask
+      #    which branch is default, and that single call is billed to
+      #    the DEPLOY_TOKEN owner's personal 5,000 req/hr budget --
+      #    shared across every PAT on that account. A staging deploy
+      #    failed on exactly that (run 32534746678). Git fetch/push
+      #    over HTTPS is not REST-rate-limited, so pinning the ref
+      #    makes this step immune to quota exhaustion.
       - name: Checkout gs-pages
         uses: actions/checkout@v7
         with:
           repository: pappadf/gs-pages
+          ref: main
           token: ${{ secrets.DEPLOY_TOKEN }}
           path: deploy
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,10 +50,19 @@ jobs:
           make clean && make && make ui2
 
       # 3. Checkout the deployment repository
+      #    `ref` is pinned rather than left to default, deliberately:
+      #    without it actions/checkout must call the REST API to ask
+      #    which branch is default, and that single call is billed to
+      #    the DEPLOY_TOKEN owner's personal 5,000 req/hr budget --
+      #    shared across every PAT on that account. A staging deploy
+      #    failed on exactly that (run 32534746678). Git fetch/push
+      #    over HTTPS is not REST-rate-limited, so pinning the ref
+      #    makes this step immune to quota exhaustion.
       - name: Checkout gs-pages
         uses: actions/checkout@v7
         with:
           repository: pappadf/gs-pages
+          ref: main
           token: ${{ secrets.DEPLOY_TOKEN }}
           path: deploy
 


### PR DESCRIPTION
The staging deploy ([run 32534746678](https://github.com/pappadf/granny-smith/actions/runs/32534746678)) failed at **Checkout gs-pages**:

```
API rate limit exceeded for user ID 95528397.
```

The build itself was fine — only the deploy-repo checkout died, and nothing was pushed to `/staging/`.

## Cause

`actions/checkout` makes exactly one REST call when given a `repository` but no `ref`: it has to ask the API which branch is the default. That is the `Determining the default branch` / `Retrieving the default branch name` pair in the log, and it is the *only* API call the step makes — git fetch and push over HTTPS are not REST-rate-limited.

That one call is billed to the `DEPLOY_TOKEN` owner’s personal **5,000 req/hr** budget. That budget is per-*user*, not per-token, and is shared across every classic/fine-grained PAT on the account. So an unrelated consumer can starve a deploy that needs a single request.

## Fix

Pinning `ref: main` removes the call, making the step immune to quota exhaustion regardless of what else is spending the account’s budget. `main` is correct — the workflow already does `git push origin main`.

Applied to `publish.yml` as well, which had the identical gap and would have failed the same way on a real tagged release.

## Validation

YAML re-parsed on both files; the `Checkout gs-pages` step resolves to `ref: main` with `DEPLOY_TOKEN` intact in each.

Not yet exercised end-to-end — `workflow_dispatch` needs `actions: write`, which the Codespaces token does not carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)