### PR TITLE
object: polymorphic V_ANY result slot; debug.mac.globals.read stops aborting on wide globals

### DIFF
--- a/.agents/skills/headless-debug/SKILL.md
+++ b/.agents/skills/headless-debug/SKILL.md
@@ -409,13 +409,18 @@ requires the matching log category to be enabled — `debug.log memory 1`.
 ```
 debug.mac.globals.read "Ticks"          # → 0xf999
 debug.mac.globals.read "MBState"        # → 0x80
+debug.mac.globals.read "KeyMap"         # → 0x0000000000000000... (16 bytes)
 debug.mac.globals.address "MBState"     # → 0x172
 debug.mac.globals.list                  # ["BusErrVct", "MonkeyLives", ..., 471 names]
 debug.mac.atrap 0xa05d                  # → "_SwapMMUMode"
 ```
 
 Sizes: 1/2/4-byte globals come back as unsigned ints; larger blobs
-(KeyMap, EventQueue, …) come back as byte buffers.
+(KeyMap, EventQueue, …) come back as byte buffers — use `len(...)` for
+the width, or `+` to concatenate. A handful of table entries are region
+markers with no size (`ScrapEnd`, `SEVarBase`); `read` errors on those,
+so use `address` and read memory directly. `write` takes 1/2/4-byte
+globals only.
 
 ### 6.7 Screen capture and matching
 

--- a/docs/core/shell/object-model.md
+++ b/docs/core/shell/object-model.md
@@ -285,17 +285,28 @@ The body always sees a value matching the declared slot kind:
 - **`OBJ_ARG_STRICT_KIND` opt-out.** A slot with this flag accepts
   exactly its declared kind and disables the coercions above.
 
-### `V_NONE`-kind slots
+### `V_ANY` slots (and the `V_NONE` spelling on arguments)
 
-A slot declared with `kind = V_NONE` is the explicit "accept any
+A slot declared with `kind = V_ANY` is the explicit "accept any
 kind" sentinel — the framework skips kind / width / enum checks
 and the body discriminates the input. Used for legitimately
 multi-kind attributes and parameters: `machine.rtc.time` accepts either an
 ISO-8601 string or a Mac-epoch integer; `machine.adb.keyboard.press` accepts
 either a key name or an ADB keycode; `machine.memory.dump.addr` accepts
 either an address integer or an alias / expression string. Most
-slots should declare a concrete kind; `V_NONE` is reserved for
+slots should declare a concrete kind; the sentinel is reserved for
 genuine dual-input shapes.
+
+On an *argument* slot `V_NONE` means the same thing, and predates
+`V_ANY`; both spellings work and existing declarations were left
+alone. On a method's *result* slot the two are not
+interchangeable: there `V_NONE` means "returns nothing" and `V_ANY`
+means "polymorphic" — see below.
+
+`V_ANY` is a declaration-only constant, deliberately outside
+`value_kind_t`'s enumerated range: it describes what a slot accepts
+or promises, never what a live value is, so switches over a value's
+kind stay exhaustive without a dead arm.
 
 ### Argv rewriting and ownership
 
@@ -336,6 +347,17 @@ error). Release builds compile the asserts out, so the production
 cost is zero. Integration and unit tests run with assertions
 enabled so cross-kind regressions surface in CI rather than only
 locally.
+
+A method whose result kind genuinely depends on its arguments
+declares `result = V_ANY` and is not checked. The one such surface
+today is `debug.mac.globals.read`, which hands back a `V_UINT` for a
+1/2/4-byte low-memory global and `V_BYTES` for a wider one
+(`KeyMap`, `EventQueue`, `FileVars`, …). Declaring that method
+`V_UINT` aborted the process on every wide global (issue #106);
+`V_NONE` would have aborted on all of them, since a `V_NONE` result
+slot asserts that the method returns nothing at all. Reach for
+`V_ANY` only when the polymorphism is real — a concrete kind is
+still the norm, and it is what makes the assertion useful.
 
 ## Foundation for shell and configuration
 
@@ -425,7 +447,7 @@ singleton or cfg-scoped:
    non-emptiness, or enum membership. Bodies still own *semantic*
    checks — value ranges that depend on runtime state ("HD already
    attached at id %d", "frequency must be a power of two") — and
-   discrimination on `V_NONE`-kind slots.
+   discrimination on `V_ANY` / `V_NONE`-kind slots.
 3. **Attach the object** at the right lifecycle point — for cfg-scoped
    classes, do it inside the existing `*_init` (next to the
    `cfg->foo = foo_init(...)` call); for process-singletons, add a

--- a/src/core/debug/debug.c
+++ b/src/core/debug/debug.c
@@ -3426,9 +3426,16 @@ static value_t method_mac_globals_read(struct object *self, const member_t *m, i
         return v;
     }
     default: {
-        if (sz <= 0 || sz > 256)
-            return val_err("debug.mac.globals.read: unexpected entry size %d", sz);
+        // Wider entries (KeyMap 16, EventQueue 10, FileVars 184, …) come
+        // back as a byte buffer; the method's result slot is declared
+        // V_ANY precisely so this branch is legal (issue #106).
         uint8_t buf[256];
+        if (sz <= 0)
+            return val_err("debug.mac.globals.read: '%s' is a region marker with no size — "
+                           "use debug.mac.globals.address(\"%s\") and read memory directly",
+                           argv[0].s, argv[0].s);
+        if (sz > (int)sizeof(buf))
+            return val_err("debug.mac.globals.read: '%s' is %d bytes (max %zu)", argv[0].s, sz, sizeof(buf));
         for (int i = 0; i < sz; i++)
             buf[i] = memory_debug_read_uint8(debug_mac_xlate(addr + (uint32_t)i));
         return val_bytes(buf, (size_t)sz);
@@ -3529,7 +3536,9 @@ static const member_t debug_mac_globals_members[] = {
     {.kind = M_METHOD,
      .name = "read",
      .doc = "Read a Mac low-memory global by name (uint for 1/2/4-byte; bytes for larger)",
-     .method = {.args = mac_globals_name_arg, .nargs = 1, .result = V_UINT, .fn = method_mac_globals_read}   },
+     // V_ANY, not V_UINT: the result kind follows the entry's width — 49
+     // of the 471 globals are wider than 4 bytes and read as V_BYTES.
+     .method = {.args = mac_globals_name_arg, .nargs = 1, .result = V_ANY, .fn = method_mac_globals_read}    },
     {.kind = M_METHOD,
      .name = "write",
      .doc = "Write a 1/2/4-byte Mac low-memory global by name",

--- a/src/core/object/object.c
+++ b/src/core/object/object.c
@@ -530,6 +530,14 @@ bool object_validate_class(const class_desc_t *cls, char *err_buf, size_t err_si
                     snprintf(err_buf, err_size, "%s.%s: arg-only flag set on attribute slot", cls->name, m->name);
                 return false;
             }
+            // V_ANY is a method-slot sentinel: an attribute needs a
+            // concrete kind so the getter/setter round-trip and the
+            // formatters have something to agree on.
+            if (m->attr.type == V_ANY) {
+                if (err_buf && err_size)
+                    snprintf(err_buf, err_size, "%s.%s: V_ANY is not a valid attribute kind", cls->name, m->name);
+                return false;
+            }
             if (m->attr.type == V_ENUM && (!m->attr.enum_values || !m->attr.enum_values[0])) {
                 if (err_buf && err_size)
                     snprintf(err_buf, err_size, "%s.%s: V_ENUM attribute slot has no enum_values table", cls->name,
@@ -889,6 +897,9 @@ static void slot_from_attr(typed_slot_t *out, const member_t *m) {
 
 // Human-readable kind name used in error messages.
 static const char *kind_name(value_kind_t k) {
+    // Slot-declaration sentinel; not one of the live value kinds below.
+    if (k == V_ANY)
+        return "ANY";
     switch (k) {
     case V_NONE:
         return "NONE";
@@ -990,11 +1001,12 @@ static validate_status_t validate_slot(const typed_slot_t *s, const value_t *in,
     bool rewrote = false;
     *out = *in;
 
-    // V_NONE-kind slot is the "accept any kind" sentinel — body sees the
-    // value as-is and does its own discrimination. Used today for slots
-    // that legitimately accept multiple kinds (e.g. storage.hd_create's
-    // size arg, which takes either a string label or an integer count).
-    if (s->kind == V_NONE) {
+    // V_ANY — and V_NONE, its historical spelling on an argument slot —
+    // is the "accept any kind" sentinel: the body sees the value as-is
+    // and does its own discrimination. Used today for slots that
+    // legitimately accept multiple kinds (e.g. storage.hd_create's size
+    // arg, which takes either a string label or an integer count).
+    if (s->kind == V_NONE || s->kind == V_ANY) {
         if ((s->flags & OBJ_ARG_NONEMPTY) && in->kind == V_STRING) {
             if (!in->s || !*in->s) {
                 snprintf(err_buf, err_size, "must not be empty");
@@ -1243,8 +1255,8 @@ static value_t node_validate_args(struct object *obj, const member_t *m, int in_
         const arg_decl_t *rest = &args[nargs - 1];
         typed_slot_t s;
         slot_from_arg(&s, rest);
-        // V_NONE rest accepts any kind without coercion.
-        bool accept_any = (rest->kind == V_NONE);
+        // A V_ANY / V_NONE rest slot accepts any kind without coercion.
+        bool accept_any = (rest->kind == V_NONE || rest->kind == V_ANY);
         for (int i = fixed_n; i < in_argc; i++) {
             char err[160];
             value_t out_v;
@@ -1305,8 +1317,11 @@ static void assert_return_matches(const typed_slot_t *slot, const value_t *out, 
     (void)site;
     if (out->kind == V_ERROR)
         return;
-    // V_NONE-kind slot is the "no constraint" sentinel; no return-kind check.
-    if (slot->kind == V_NONE)
+    // V_ANY declares a polymorphic result; V_NONE reaches here only from
+    // an argument-shaped slot, where it is the same "any kind" sentinel
+    // (node_call handles a V_NONE *result* slot itself — there it means
+    // "returns nothing"). Either way there is nothing to check.
+    if (slot->kind == V_ANY || slot->kind == V_NONE)
         return;
     if (slot->kind != out->kind) {
         fprintf(stderr, "[object] %s: kind mismatch (declared %s, got %s)\n", site, kind_name(slot->kind),
@@ -1457,7 +1472,11 @@ value_t node_call(node_t n, int argc, const value_t *argv) {
     value_t out = n.member->method.fn(n.obj, n.member, eff_argc, eff_argv);
 #ifndef NDEBUG
     value_kind_t want = n.member->method.result;
-    if (want == V_NONE) {
+    if (want == V_ANY) {
+        // Polymorphic result: the kind is the method's own business
+        // (debug.mac.globals.read hands back a uint or bytes depending on
+        // the width of the named global). Nothing to assert.
+    } else if (want == V_NONE) {
         assert((out.kind == V_NONE || out.kind == V_ERROR) && "method declared result V_NONE but returned a value");
     } else {
         typed_slot_t result_slot = {.kind = want};

--- a/src/core/object/object.h
+++ b/src/core/object/object.h
@@ -75,6 +75,8 @@ struct class_desc;
 //      call time on a method-arg slot, but propagated to help text.
 typedef struct arg_decl {
     const char *name;
+    // Declared kind. V_ANY (or, historically, V_NONE — the two are
+    // equivalent here) accepts a value of any kind without coercion.
     value_kind_t kind;
     uint8_t width; // 1/2/4/8 for V_INT/V_UINT range check; 0 = unconstrained
     uint16_t validation_flags; // OBJ_ARG_OPTIONAL | OBJ_ARG_REST | OBJ_ARG_NONEMPTY | OBJ_ARG_STRICT_KIND
@@ -143,6 +145,14 @@ typedef struct member {
         struct {
             const arg_decl_t *args;
             int nargs;
+            // Declared result kind, checked by node_call in debug builds:
+            //   V_NONE — the method returns nothing (only V_NONE/V_ERROR).
+            //   V_ANY  — polymorphic: the kind depends on the arguments or
+            //            on machine state (debug.mac.globals.read returns a
+            //            uint for a 1/2/4-byte global, bytes for a wider
+            //            one). Nothing is asserted about the kind.
+            //   others — the result must carry exactly that kind (V_ERROR
+            //            is always allowed, as the in-band error path).
             value_kind_t result;
             method_fn fn;
             // UI metadata (proposal §7.3): MM_DESTRUCTIVE | MM_MUTATE | MM_HIDDEN.

--- a/src/core/object/value.h
+++ b/src/core/object/value.h
@@ -40,6 +40,17 @@ typedef enum {
     V_RANGE, // half-open integer range [start, stop)
 } value_kind_t;
 
+// Declaration-only sentinel: "any kind" (see object.h). Valid in a typed
+// slot — a method's declared `result`, or an argument slot — to declare a
+// genuinely polymorphic contract, e.g. debug.mac.globals.read, whose
+// result kind follows the width of the named global. It never appears as
+// the kind of a live value_t: it says what a slot accepts or promises,
+// not what a value is. Deliberately a constant outside the enumerated
+// range rather than another enumerator, so that switches over a live
+// value's kind stay exhaustive without a dead arm for a kind no value
+// ever carries.
+#define V_ANY ((value_kind_t)0x7F)
+
 // Display / semantic flags. Stored on attribute member_t and copied onto
 // value_t so formatters see the intent of the originating attribute.
 #define VAL_HEX       0x0001u // prefer hex output

--- a/tests/integration/object-eval/test.script
+++ b/tests/integration/object-eval/test.script
@@ -24,6 +24,14 @@ scheduler
 echo "${debug.mac.globals.read("MBState")}"
 echo "${debug.mac.globals.read("Ticks")}"
 echo "${debug.mac.globals.read("ROMBase")}"
+
+# Globals wider than 4 bytes read back as a byte buffer rather than a
+# uint (issue #106): the read method's result slot is polymorphic, and
+# reading one of the 49 wide entries used to abort the process on the
+# object model's return-kind assertion.
+assert len(debug.mac.globals.read("KeyMap")) == 16 "KeyMap should read as a 16-byte buffer"
+assert len(debug.mac.globals.read("EventQueue")) == 10 "EventQueue should read as a 10-byte buffer"
+echo "${debug.mac.globals.read("KeyMap")}"
 machine.cpu.ccr
 machine.cpu.sp
 

--- a/tests/unit/suites/object_method/test.c
+++ b/tests/unit/suites/object_method/test.c
@@ -6,6 +6,12 @@
 // (close/abs/min/max). Drive both via node_call and via expr_eval
 // over `$(class.method(args))` to confirm the call form parses and
 // evaluates inside expressions.
+//
+// `math2.poly` covers the V_ANY result slot (issue #106): a method
+// whose result kind follows its argument, the shape
+// debug.mac.globals.read has. These tests only bite in an
+// assertion-enabled build — node_call's return-kind assert is what
+// used to abort the process on the V_BYTES branch.
 
 #include "expr.h"
 #include "object.h"
@@ -62,6 +68,38 @@ static value_t math2_id(struct object *self, const member_t *m, int argc, const 
     return val_int((int64_t)val_as_i64(&argv[0], NULL));
 }
 
+// A polymorphic method: `poly(width)` returns a uint for a 1/2/4-byte
+// width and a byte buffer for anything wider — the same contract
+// debug.mac.globals.read has. Declared `.result = V_ANY`.
+static value_t math2_poly(struct object *self, const member_t *m, int argc, const value_t *argv) {
+    (void)self;
+    (void)m;
+    if (argc < 1)
+        return val_err("need one arg");
+    int64_t width = val_as_i64(&argv[0], NULL);
+    if (width == 1 || width == 2 || width == 4)
+        return val_uint((uint8_t)width, 0x11223344u >> (8 * (4 - width)));
+    if (width <= 0)
+        return val_err("width must be positive");
+    uint8_t buf[64];
+    if (width > (int64_t)sizeof(buf))
+        return val_err("width too large");
+    for (int64_t i = 0; i < width; i++)
+        buf[i] = (uint8_t)i;
+    return val_bytes(buf, (size_t)width);
+}
+
+// Accepts any kind in its one slot (V_ANY on an argument slot) and
+// reports what it was handed, so the sentinel is exercised on the
+// input side too.
+static value_t math2_kind_of(struct object *self, const member_t *m, int argc, const value_t *argv) {
+    (void)self;
+    (void)m;
+    if (argc < 1)
+        return val_err("need one arg");
+    return val_int((int64_t)argv[0].kind);
+}
+
 static const arg_decl_t close_args[] = {
     {.name = "a",   .kind = V_FLOAT, .doc = "a"  },
     {.name = "b",   .kind = V_FLOAT, .doc = "b"  },
@@ -74,13 +112,23 @@ static const arg_decl_t pair_args[] = {
 static const arg_decl_t one_arg[] = {
     {.name = "x", .kind = V_INT, .doc = "x"},
 };
+static const arg_decl_t width_arg[] = {
+    {.name = "width", .kind = V_INT, .doc = "byte width"},
+};
+static const arg_decl_t any_arg[] = {
+    {.name = "v", .kind = V_ANY, .doc = "a value of any kind"},
+};
 
 static const member_t math2_members[] = {
     {.kind = M_METHOD,
      .name = "close",
-     .method = {.args = close_args, .nargs = 3, .result = V_BOOL, .fn = math2_close}                             },
-    {.kind = M_METHOD, .name = "min", .method = {.args = pair_args, .nargs = 2, .result = V_INT, .fn = math2_min}},
-    {.kind = M_METHOD, .name = "id",  .method = {.args = one_arg, .nargs = 1, .result = V_INT, .fn = math2_id}   },
+     .method = {.args = close_args, .nargs = 3, .result = V_BOOL, .fn = math2_close}                               },
+    {.kind = M_METHOD, .name = "min",  .method = {.args = pair_args, .nargs = 2, .result = V_INT, .fn = math2_min} },
+    {.kind = M_METHOD, .name = "id",   .method = {.args = one_arg, .nargs = 1, .result = V_INT, .fn = math2_id}    },
+    {.kind = M_METHOD, .name = "poly", .method = {.args = width_arg, .nargs = 1, .result = V_ANY, .fn = math2_poly}},
+    {.kind = M_METHOD,
+     .name = "kind_of",
+     .method = {.args = any_arg, .nargs = 1, .result = V_INT, .fn = math2_kind_of}                                 },
 };
 
 static const class_desc_t math2_class = {
@@ -191,6 +239,110 @@ TEST(test_zero_arg_method_call_explicit) {
     object_root_reset();
 }
 
+// === Polymorphic (V_ANY) result slot — issue #106 =========================
+
+TEST(test_variant_result_uint_branch) {
+    install_math2();
+    node_t n = object_resolve(object_root(), "math2.poly");
+    ASSERT_TRUE(node_valid(n));
+    value_t four = val_int(4);
+    value_t r = node_call(n, 1, &four);
+    ASSERT_EQ_INT(V_UINT, r.kind);
+    ASSERT_EQ_INT(0x11223344, (int)r.u);
+    value_free(&r);
+    value_free(&four);
+    object_root_reset();
+}
+
+TEST(test_variant_result_bytes_branch) {
+    install_math2();
+    // The regression: a V_BYTES result from a slot that also yields
+    // V_UINT used to trip node_call's return-kind assertion and abort
+    // the process (debug.mac.globals.read "KeyMap").
+    node_t n = object_resolve(object_root(), "math2.poly");
+    ASSERT_TRUE(node_valid(n));
+    value_t sixteen = val_int(16);
+    value_t r = node_call(n, 1, &sixteen);
+    ASSERT_EQ_INT(V_BYTES, r.kind);
+    ASSERT_EQ_INT(16, (int)r.bytes.n);
+    ASSERT_EQ_INT(3, (int)r.bytes.p[3]);
+    value_free(&r);
+    value_free(&sixteen);
+    object_root_reset();
+}
+
+TEST(test_variant_result_error_branch) {
+    install_math2();
+    node_t n = object_resolve(object_root(), "math2.poly");
+    ASSERT_TRUE(node_valid(n));
+    value_t zero = val_int(0);
+    value_t r = node_call(n, 1, &zero);
+    ASSERT_TRUE(val_is_error(&r));
+    value_free(&r);
+    value_free(&zero);
+    object_root_reset();
+}
+
+TEST(test_variant_result_in_expr) {
+    install_math2();
+    // Both branches reachable from expression context: arithmetic on
+    // the uint one, len() on the bytes one.
+    value_t v = eval_with_root("math2.poly(2) + 1");
+    bool ok = false;
+    int64_t i = val_as_i64(&v, &ok);
+    ASSERT_TRUE(ok);
+    ASSERT_EQ_INT(0x1123, (int)i); // 0x11223344 >> 16, + 1
+    value_free(&v);
+
+    v = eval_with_root("len(math2.poly(10))");
+    i = val_as_i64(&v, &ok);
+    ASSERT_TRUE(ok);
+    ASSERT_EQ_INT(10, (int)i);
+    value_free(&v);
+    object_root_reset();
+}
+
+TEST(test_any_arg_slot_accepts_every_kind) {
+    install_math2();
+    node_t n = object_resolve(object_root(), "math2.kind_of");
+    ASSERT_TRUE(node_valid(n));
+
+    value_t s = val_str("hello");
+    value_t r = node_call(n, 1, &s);
+    ASSERT_EQ_INT(V_STRING, (int)r.i); // passed through uncoerced
+    value_free(&r);
+    value_free(&s);
+
+    value_t b = val_bool(true);
+    r = node_call(n, 1, &b);
+    ASSERT_EQ_INT(V_BOOL, (int)r.i);
+    value_free(&r);
+    value_free(&b);
+    object_root_reset();
+}
+
+// A V_ANY attribute slot is a class-author mistake: attributes need a
+// concrete kind for the getter/setter round-trip. Registration rejects it.
+static value_t any_attr_get(struct object *self, const member_t *m) {
+    (void)self;
+    (void)m;
+    return val_uint(4, 0);
+}
+static const member_t any_attr_members[] = {
+    {.kind = M_ATTR, .name = "x", .flags = VAL_RO, .attr = {.type = V_ANY, .get = any_attr_get}},
+};
+static const class_desc_t any_attr_class = {
+    .name = "anyattr",
+    .members = any_attr_members,
+    .n_members = 1,
+};
+
+TEST(test_any_attribute_slot_rejected) {
+    char err[200];
+    ASSERT_TRUE(!object_validate_class(&any_attr_class, err, sizeof(err)));
+    ASSERT_TRUE(strstr(err, "ANY") != NULL);
+}
+
 int main(void) {
     RUN(test_node_call_succeeds);
     RUN(test_node_call_too_few_args);
@@ -199,5 +351,11 @@ int main(void) {
     RUN(test_method_predicate);
     RUN(test_method_error_propagates);
     RUN(test_zero_arg_method_call_explicit);
+    RUN(test_variant_result_uint_branch);
+    RUN(test_variant_result_bytes_branch);
+    RUN(test_variant_result_error_branch);
+    RUN(test_variant_result_in_expr);
+    RUN(test_any_arg_slot_accepts_every_kind);
+    RUN(test_any_attribute_slot_rejected);
     return 0;
 }


### PR DESCRIPTION
## Summary

`debug.mac.globals.read` is declared `result = V_UINT` but returns `V_BYTES` for any low-memory global wider than 4 bytes, so `node_call`'s return-kind assertion aborted the process on 49 of the 471 entries. This adds the missing polymorphic result declaration (`V_ANY`) to the object model, declares `read` with it, and reconciles the two conflicting readings of `V_NONE` in a result slot.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Build/CI changes
- [ ] Code cleanup/refactoring

## Description

The method's docstring already described the polymorphic contract — *"uint for 1/2/4-byte; bytes for larger"* — so the declaration was the thing out of step. `V_NONE` is not a usable substitute: `node_call` reads a `V_NONE` **result** as "returns nothing", so it would have aborted on all 471 globals instead of 49. Option 3 from the issue, kept as tight as it can be:

- **`V_ANY`** (`src/core/object/value.h`) — a declaration-only constant, deliberately outside `value_kind_t`'s enumerated range: it says what a slot accepts or promises, never what a live value is, so switches over a value's kind stay exhaustive with no dead arm. No `value_t` ever carries it, so no formatter, converter or JSON encoder changes.
- **Result slots**: `V_NONE` = returns nothing (unchanged, ~30 methods rely on it); `V_ANY` = polymorphic, unchecked. That is the `V_NONE` disagreement the issue flagged, settled explicitly and documented at both sites.
- **Argument slots**: `V_NONE` already meant "accept any kind" there; `V_ANY` is now accepted as the explicit spelling and the two are equivalent. Existing declarations are untouched.
- **Attribute slots**: `V_ANY` is a class-author mistake (attributes need a concrete kind for the getter/setter round-trip) and is rejected by `object_validate_class` at registration, in the style of the other hard registration errors.
- **`debug.mac.globals.read`** declares `V_ANY`. Its wide-entry branch also now reports the two zero-size region markers (`ScrapEnd`, `SEVarBase`) and any over-long entry as named errors instead of `unexpected entry size %d`.
- Docs: `docs/core/shell/object-model.md` (the sentinel-slot and return-kind-assertion sections) and the `headless-debug` skill's globals section.

Read of a wide global now returns a byte buffer, which the shell prints as hex and `api.c` already serialises as a `"0x…"` JSON string — the same shape a hex uint takes, so the browser frontend needs nothing.

## Related Issues

- Fixes #106

## Testing

- [x] I have tested the changes locally
- [ ] All existing tests pass (`make integration-test`) — not runnable here: the integration suite needs the private test-data ROMs (`scripts/fetch-test-data.sh`), which this environment has no token for
- [x] I have added new tests for the changes (if applicable)

What was run:

- **Repro before/after** — headless built with assertions (`make headless`), driven both by script and over the daemon's TCP socket. Before: `[object] method.fn: kind mismatch (declared UINT, got BYTES)` → `Aborted (core dumped)`. After: `KeyMap` returns 16 bytes, `TheCrsr` 68, `FileVars` 184; `Ticks` still reads as a uint and still does arithmetic (`read("Ticks") + 100`).
- **Sweep of all 470 unique global names** — every one reads cleanly; the only two errors are the zero-size markers, which now carry a useful message instead of aborting.
- **`tests/unit/suites/object_method`** — new cases for the `V_ANY` result slot (uint, bytes and error branches, plus use from expression context), for a `V_ANY` argument slot accepting several kinds uncoerced, and for the attribute-slot rejection. Verified they are real regression tests: flipping the toy method's declaration back to `V_UINT` reproduces the abort.
- **All `object_*` unit suites** — 143 tests, green.
- `clang-format-18` clean over `src/`; headless build shows no new warnings.

### Test Environment
- Browser: n/a (core + headless change)
- OS: Ubuntu 24.04 container, gcc, assertion-enabled headless build

## Checklist

- [x] Code follows the project [style guide](docs/STYLE_GUIDE.md)
- [x] New source files include SPDX license header (no new files)
- [x] Documentation updated (if applicable)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWEBXwjzCLoi1u4piWa3YF)_