### PR TITLE
ppc: PowerPC 604 CPU model (TNT Phase A)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,10 +233,13 @@ Hardware paths are model-independent: `machine.scsi.device[0]` means the
 same on a Plus, a IIcx, and a Lisa. The `$reg` aliases (`$pc`, `$d0`, …)
 still resolve (now to `machine.cpu.*`). On the PowerPC machines (pm6100/
 pm7100/pm8100) the aliases are the PPC set instead — `$pc $lr $ctr $cr
-$msr $xer $r0..$r31` — and `machine.cpu` exposes the 601 register file
+$msr $xer $r0..$r31` — and `machine.cpu` exposes the PPC register file
 (`pc`, `r0..r31`, `lr`, `ctr`, `cr`, `xer`, `msr`, `srr0/1`, `dec`,
-`rtcu/rtcl`, `mq`, `sdr1`, `sr0..15`, `bat0u..bat3l`, `fpscr`); the
-68K-style `$d0`/`$a0` aliases don't exist there.
+`rtcu/rtcl`, `mq`, `sdr1`, `sr0..15`, `bat0u..bat3l`, `dbat0u..dbat3l`,
+`tbu/tbl`, `fpscr`); the 68K-style `$d0`/`$a0` aliases don't exist there.
+The `dbat*`/`tbu`/`tbl` members are live on the 604 model (the coming TNT
+machines — on a 604, `rtcu/rtcl` read the timebase halves) and inert on
+the 601.
 
 The browser frontend calls into the tree via `gsEval(path, args?)` (see
 `app/web2/src/bus/emulator.ts`). Inside the shell (v2 script language —

--- a/docs/core/cpu/ppc.md
+++ b/docs/core/cpu/ppc.md
@@ -1,15 +1,20 @@
-# PPC core — MPC601 main CPU
+# PPC core — MPC601/MPC604 main CPU
 
-`src/core/cpu/ppc/` implements the PowerPC 601 as a **main CPU** — the first
-non-68K architecture to own emulated time (proposal-powerpc-601-pdm.md).
-The module is named `ppc`, not `ppc601`: the decode tree and register file
-are architectural 32-bit PowerPC with 601-specific behavior (POWER
-holdovers, MQ, RTC-instead-of-timebase, 601 BAT format, HID SPRs, 601-only
-vectors) behind `cpu_model` discrimination.  Nothing beyond the 601 is
-implemented.
+`src/core/cpu/ppc/` implements the PowerPC 601 and 604 as a **main CPU** —
+the first non-68K architecture to own emulated time
+(proposal-powerpc-601-pdm.md).  The module is named `ppc`, not `ppc601`:
+the decode tree and register file are architectural 32-bit PowerPC with
+model-specific behavior behind `cpu_model` discrimination, exactly the way
+`cpu.c` discriminates 68000/030/040.  Two models exist —
+`CPU_MODEL_PPC601` (the PDM machines) and `CPU_MODEL_PPC604` (Phase A of
+the TNT proposal; see "The 604 model" below).  `ppc_init` takes the model;
+`ppc_reset` preserves it.
 
-Source of truth: Motorola/IBM, *PowerPC 601 RISC Microprocessor User's
-Manual*, 1995 (MPC601UM/AD) — cited per chapter/table in the code.
+Sources of truth: Motorola/IBM, *PowerPC 601 RISC Microprocessor User's
+Manual*, 1995 (MPC601UM/AD) for the 601; *PowerPC 604 RISC Microprocessor
+User's Manual*, 1994 (MPC604UM/AD) and *PowerPC Microprocessor Family:
+The Programming Environments* (MPCFPE32B, "PEM") for the 604 — cited per
+chapter/table in the code.
 
 ## Files — the shared decoder/disassembler pattern
 
@@ -195,6 +200,79 @@ bit for the PDM profiles.
   timed guest measurements are only exact in free-running execution — an
   active debugger single-steps and suppresses folding.
 
+## The 604 model (TNT proposal Phase A)
+
+`CPU_MODEL_PPC604` is a bounded delta over the shared machinery — decoder
+template, softfloat kernel, exception plumbing, sched-if/debug-if, SoA
+discipline all carry over untouched.  It is dead code on every shipping
+machine until the TNT family lands (the DSP3210/601 precedent).  The
+deltas, each keyed on `cpu_model`:
+
+- **Holdover rejection**: every POWER holdover, MQ (SPR 0), the RTC SPRs
+  (4/5/20/21), the POWER DEC read (SPR 6) and HID1 take the illegal
+  program exception.  The decode tree stays model-blind; the leaves
+  decide (`M601()`/`M604()` guards in `ppc_ops.h`).
+- **Time**: TBL/TBU replace the RTC — read via `mftb`/`mftbu` (xo 371,
+  user-readable), written via SPR 284/285 (supervisor), stored in the
+  same `rtcu/rtcl` slots at their rebase instant.  DEC decrements once
+  per timebase tick.  `ppc_bind_time(p, s, freq_hz, tick_hz)` takes the
+  tick rate explicitly: 7,833,600 on the 601 (PDM), bus/4 on the 604.
+- **MSR**: adds POW (accepted as a no-op idle hint), BE, PM, RI.
+  Exception entry keeps ME/EP/PM and clears the rest; `rfi` restores
+  MSR[16-31] only (POW survives).  ILE/LE stay unimplemented on both
+  models (big-endian Macs).
+- **MMU**: the ARCHITECTED BAT format (BEPI/BL/Vs/Vp upper,
+  BRPN/WIMG/PP lower; blocks 128 KB–256 MB; PP-only protection) with
+  four SPLIT pairs each way — fetch consults the IBATs (`batu/batl`),
+  data the DBATs (`dbatu/dbatl`, SPR 536-543).  BATs take precedence
+  over the segment; T=1 is consulted only after a BAT miss, and MSR[DR]=0
+  is true real addressing mode (no segment consult — `sr_t_mask` stays
+  zero).  The HTAB search is byte-identical to the 601's.  `tlbie`
+  invalidates by EA[14-19] (64 classes, 604UM §5.4.3.2); `tlbsync` is a
+  supervisor no-op (invalidation is synchronous here).
+- **Fault images**: ISI HTAB miss sets SRR1 bit 1 alone ($40000000);
+  direct-store fetches set SRR1[3]; direct-store data accesses take a DSI
+  with DSISR bit 0 (bit 5 for lwarx/stwcx./eciwx/ecowx) — there is no
+  $00A00 vector.  The trace vector is $00D00 and $00F00 is the (never
+  firing) performance monitor; neither model delivers trace today
+  (MSR[SE]/[BE] are storage-only).  A TEA machine check sets SRR1[13],
+  zeroes SRR1[30], and clears MSR[ME] (604UM Table 4-8).
+- **Alignment** (604UM §4.5.6): only FP loads/stores, lmw/stmw,
+  lwarx/stwcx. and eciwx/ecowx require word alignment; every other
+  misaligned access is split by hardware — `ppc_scalar_gate` performs a
+  translated page-crossing access byte-wise, since the two pages need not
+  be physically adjacent.  `dcbz` additionally faults with the data cache
+  disabled (HID0[17] clear — the HRESET state) or locked (HID0[19]).
+  The string rules stay 601-shaped on both models (implementation-
+  specific per the PEM; ladder-observable).
+- **SPR file**: undefined SPR numbers trap (the 604 fully decodes the
+  field — 604UM §4.5.7) where the 601 no-ops; MMCR0/PMC1/PMC2/SIA/SDA are
+  supervisor read-zero/write-ignore stubs; PIR/DABR/IABR/HID0 are
+  store-and-readback.  Reset state: MSR = $00000040 (HRESET sets only
+  IP), PVR = $00040103 (the kernel keys on the $0004 half; the revision
+  is a chosen constant), HID0 = 0.
+- **Optional FP** (PEM pages): `fsel` (no FPSCR effects; −0 counts as
+  ≥ 0, NaN selects frB), `stfiwx`, and the estimates `fres`/`frsqrte`.
+  The estimates are implementation-defined within architected envelopes
+  (2⁻⁸ / 2⁻⁵ relative); this model's documented constants are the
+  correctly-rounded single quotient 1.0/frB (through the integer div
+  kernel) and the round-to-nearest of a 62-bit-truncated integer-sqrt
+  reciprocal (relative error < 2⁻⁶¹).  Both report only their architected
+  FPSCR effects — never XX; FR/FI ("undefined") read cleared.  `fsqrt`
+  remains illegal: the 604 does not implement it.
+- **Superscalar timing is not modeled**: the 604 keeps the sprint/CPI-1.0
+  model and 601-style branch folding (TNT proposal §4.2), for the same
+  determinism-and-measurement reasons as the 601.
+- **Object model**: `machine.cpu` adds `dbat0u..dbat3l` and `tbu`/`tbl`
+  (aliases of the rtcu/rtcl storage); the members are static per class,
+  so they exist — inert — on the 601 too.
+- **Disassembler**: the union of both models decodes; `is_power` flags the
+  601-only encodings, `is_604` the 604-only ones, and
+  `ppc_disassemble_model(word, addr, 601|604, out)` applies one model's
+  validity view (`.long` for the other model's exclusives — matching the
+  runtime trap and `objdump -m powerpc:<model>`).  `tools/disasm` grows
+  `--arch ppc604` (`ppc`/`ppc601` keep the 601 view).
+
 ## Verification
 
 - `tests/unit/suites/ppc_vectors/` — the [powerpc-test](https://github.com/pappadf/powerpc-test)
@@ -208,17 +286,31 @@ bit for the PDM profiles.
   model, not to silicon; the eight defects the first replay found here,
   and the six it found upstream, are adjudicated against the 601UM in
   gs-docs `notes/2026-08-18-powerpc-test-vector-disagreements.md`.
+  The tier replays TWICE: once as the 601 (every file), once as the 604
+  with the model-divergent mnemonics filtered (POWER holdovers,
+  mfspr/mtspr/mtmsr/rfi, the word-alignment classes, dcbz) — the shared
+  ISA must replay bit-identically under both models.
 - `tests/unit/suites/ppc/` — directed semantics tests from the chapter-10
   RTL, written before the corpus above existed and still the place where a
   manual-cited rule gets pinned (`test_conformance_regressions` restates
   every rule the vectors caught).  Executed words are cross-checked against
   the disassembler so encoder typos cannot agree with decoder typos.
+  A `test_604_*` matrix covers the model deltas: reset state, the
+  holdover-rejection table, MSR bits, timebase reads/writes/privilege,
+  the split-BAT SPR file and PM stubs, the word-alignment classes, the
+  TEA machine-check image, and the optional-FP group (with the 601-side
+  rejections).
 - `tests/unit/suites/ppc_mmu/` — the Phase-D proof list: 601 BAT
   protection keys, T=1 with DT off and the SR-toggle alias, primary and
   secondary HTAB search with R/C write-back (PTEG addresses computed
   independently from Figure 6-19), exact DSI/ISI images, the abandoned
   update-form rule, the (PR,DT) SoA discipline, tlbie congruence classes,
   mtsr change-triggered invalidation, dcbz W/I, and the $00A00 contract.
+  The `test_604_*` section proves the split I/D BAT files (and the
+  architected format's BL/Vs/Vp/PP fields), BAT-before-segment ordering,
+  real-mode segment blindness, the direct-store DSI/ISI images, the
+  hardware-split page-crossing access over discontiguous translations,
+  per-class tlbie, and the 604 dcbz rules.
 - `tests/integration/pdm-rom-ladder/` — the shipping ROM as test program;
   high-water rung **L20** (the gray desktop through the Ariel scanout, with
   the AWACS chime, the exact VIA tick rate and the 68k emulator dispatching

--- a/src/core/cpu/cpu.c
+++ b/src/core/cpu/cpu.c
@@ -40,6 +40,7 @@ bool cpu_has_fpu(int cpu_model) {
     case CPU_MODEL_68030: // paired 68882
     case CPU_MODEL_68040: // on-chip FPU
     case CPU_MODEL_PPC601: // on-chip FPU (datapath live since Phase E)
+    case CPU_MODEL_PPC604: // on-chip FPU
         return true;
     default: // 68000 compacts
         return false;

--- a/src/core/cpu/ppc/ppc.c
+++ b/src/core/cpu/ppc/ppc.c
@@ -2,8 +2,9 @@
 // Copyright (c) pappadf
 
 // ppc.c
-// PPC (MPC601) core: lifecycle, exception machinery, SPR file, scheduler and
-// debugger adapters, object class.  The interpreter lives in ppc_run.c.
+// PPC (MPC601/MPC604) core: lifecycle, exception machinery, SPR file,
+// scheduler and debugger adapters, object class.  The interpreter lives in
+// ppc_run.c; model-specific behavior is discriminated on ppc_t.cpu_model.
 
 #include "ppc_internal.h"
 #include "ppc_softfp.h"
@@ -24,14 +25,15 @@ extern const class_desc_t ppc_cpu_class;
 
 // === Exception machinery ====================================================
 
-// Raise an exception (601UM §5.4, per-exception Register Settings tables):
-// SRR0 = resume_pc; SRR1 = exception-specific high bits | MSR[16-31]; MSR
-// clears EE/PR/FP/FE0/SE/FE1/IT/DT and keeps ME/EP; PC = vector, prefixed
-// $FFF00000 when MSR[EP] is set.
+// Raise an exception (601UM §5.4 / 604UM §4.3, per-exception Register
+// Settings tables): SRR0 = resume_pc; SRR1 = exception-specific high bits
+// | MSR[16-31]; MSR keeps ME/EP (+PM on the 604) and clears everything
+// else — which covers the 604's POW/BE/RI-cleared rows too; PC = vector,
+// prefixed $FFF00000 when MSR[EP] is set.
 void ppc_exception(ppc_t *p, uint32_t vector, uint32_t srr1_hi, uint32_t resume_pc) {
     p->srr0 = resume_pc;
     p->srr1 = (srr1_hi & 0xFFFF0000u) | (p->msr & 0x0000FFFFu);
-    p->msr &= PPC_MSR_ME | PPC_MSR_EP;
+    p->msr &= ppc_msr_exception_keep(p);
     ppc_update_active_maps(p);
     p->pc = ((p->msr & PPC_MSR_EP) ? 0xFFF00000u : 0u) + vector;
     // Record in the shared exception trace ring (§3.9c field mapping:
@@ -57,7 +59,7 @@ void ppc_set_ext_irq(ppc_t *p, bool level) {
     p->ext_irq = level ? 1u : 0u;
 }
 
-// === RTC/DEC time derivation (§3.7) =========================================
+// === RTC/TB/DEC time derivation (§3.7; TNT proposal §4.4) ===================
 
 // Exact rational cycles→ticks: q*mul + r*mul/div never overflows (r < div,
 // both 32-bit after reduction) and is exact over any interval.
@@ -94,13 +96,28 @@ uint32_t ppc_rtcl_now(ppc_t *p) {
     return l;
 }
 
-// DEC decrements 128 units per tick (DecClockRateHz = 1,002,700,800
-// RTCL-units/s — the constant HWInit hard-codes).
+// 604 timebase: a plain 64-bit counter advancing one unit per tick (604UM
+// §1.3.2.2 — the tick rate is bus/4, bound by ppc_bind_time).  rtcu/rtcl
+// hold TBU/TBL at the rebase instant.
+uint64_t ppc_tb_now(ppc_t *p) {
+    uint64_t base = ((uint64_t)p->rtcu << 32) | p->rtcl;
+    if (!p->tick_mul)
+        return base;
+    return base + (ppc_ticks_now(p) - p->rtc_base_ticks);
+}
+
+// DEC units per tick, as a shift: the 601 decrements 128 RTCL-units per
+// 7.8336 MHz tick (DecClockRateHz = 1,002,700,800 — the constant HWInit
+// hard-codes); the 604 decrements once per timebase tick (604UM §4.5.9).
+static inline int ppc_dec_shift(const ppc_t *p) {
+    return ppc_is_604(p) ? 0 : 7;
+}
+
 uint32_t ppc_dec_now(ppc_t *p) {
     if (!p->tick_mul)
         return p->dec;
     uint64_t elapsed = ppc_ticks_now(p) - p->dec_base_ticks;
-    return p->dec - (uint32_t)(elapsed * 128u);
+    return p->dec - (uint32_t)(elapsed << ppc_dec_shift(p));
 }
 
 // DEC expiry event: latch the exception request (taken when MSR[EE] allows)
@@ -119,28 +136,29 @@ void ppc_dec_arm(ppc_t *p) {
     remove_event(p->scheduler, ppc_dec_event, p);
     uint32_t dec = ppc_dec_now(p);
     // Ticks until the sign transition: a non-negative DEC crosses below zero
-    // after floor(dec/128)+1 ticks; an already-negative DEC transitions again
-    // only after wrapping through zero.
+    // after floor(dec/units_per_tick)+1 ticks; an already-negative DEC
+    // transitions again only after wrapping through zero.
+    int shift = ppc_dec_shift(p);
     uint64_t ticks_until;
     if ((int32_t)dec >= 0)
-        ticks_until = (dec >> 7) + 1u;
+        ticks_until = (dec >> shift) + 1u;
     else
-        ticks_until = (((uint64_t)dec + 0x100000000ull) >> 7) + 1u;
+        ticks_until = (((uint64_t)dec + 0x100000000ull) >> shift) + 1u;
     // ticks→cycles, rounded up so the event never fires early.
     uint64_t cycles = (ticks_until * p->tick_div + p->tick_mul - 1) / p->tick_mul;
     scheduler_new_cpu_event(p->scheduler, ppc_dec_event, p, 0, cycles, 0);
 }
 
-void ppc_bind_time(ppc_t *p, struct scheduler *s, uint32_t freq_hz) {
-    // Reduce 7,833,600/freq once; all derivations use the reduced pair.
-    uint32_t a = 7833600u, b = freq_hz;
+void ppc_bind_time(ppc_t *p, struct scheduler *s, uint32_t freq_hz, uint32_t tick_hz) {
+    // Reduce tick_hz/freq_hz once; all derivations use the reduced pair.
+    uint32_t a = tick_hz, b = freq_hz;
     while (b) {
         uint32_t t = a % b;
         a = b;
         b = t;
     }
     p->scheduler = s;
-    p->tick_mul = 7833600u / a;
+    p->tick_mul = tick_hz / a;
     p->tick_div = freq_hz / a;
     scheduler_new_event_type(s, "ppc", p, "dec", ppc_dec_event);
     // No rebase: the stored base ticks are in the scheduler-cycle-derived
@@ -167,24 +185,52 @@ static inline uint32_t spr_number(uint32_t iw) {
     return (((iw) >> 16) & 0x1Fu) | ((((iw) >> 11) & 0x1Fu) << 5);
 }
 
+// SPR number not defined for the active model.  Both models: SPR[0]=1 from
+// user mode is the privileged program exception (bit 4 of the swapped `n`).
+// Past that they diverge: the 601 treats the access as a no-op (601UM
+// mfspr page "treated as a no-op"); the 604 fully decodes the SPR field
+// and raises the illegal-instruction program exception (604UM §4.5.7).
+// Returns true when an exception was raised.
+static bool spr_undefined(ppc_t *p, uint32_t n, bool is_read) {
+    (void)is_read; // only the (compiled-out-in-tests) log consumes it
+    if ((n & 0x10u) && (p->msr & PPC_MSR_PR)) {
+        ppc_exception(p, PPC_VEC_PROGRAM, PPC_SRR1_PROG_PRIV, p->instruction_pc);
+        return true;
+    }
+    if (ppc_is_604(p)) {
+        ppc_exception(p, PPC_VEC_PROGRAM, PPC_SRR1_PROG_ILLEGAL, p->instruction_pc);
+        return true;
+    }
+    LOG(5, "%s %u: unimplemented SPR (no-op)", is_read ? "mfspr" : "mtspr", n);
+    return false;
+}
+
 bool ppc_mfspr(ppc_t *p, uint32_t iw) {
     uint32_t n = spr_number(iw);
     uint32_t d = PPC_RT(iw);
     uint32_t v;
     switch (n) {
-    case 0:
+    case 0: // MQ: 601-only (the 604 rejects the POWER SPRs — 604UM §2.3)
+        if (ppc_is_604(p))
+            goto undefined;
         v = p->mq;
         break;
     case 1:
         v = p->xer;
         break;
-    case 4:
+    case 4: // RTC reads use SPR 4/5 in EVERY mode (601 asymmetry); no RTC on the 604
+        if (ppc_is_604(p))
+            goto undefined;
         v = ppc_rtcu_now(p);
-        break; // RTC reads use SPR 4/5 in EVERY mode (601 asymmetry)
+        break;
     case 5:
+        if (ppc_is_604(p))
+            goto undefined;
         v = ppc_rtcl_now(p);
         break;
     case 6: // POWER user-level DEC read, 601-supported (601UM Table 10-4 note 3)
+        if (ppc_is_604(p))
+            goto undefined;
         v = ppc_dec_now(p);
         break;
     case 8:
@@ -248,19 +294,48 @@ bool ppc_mfspr(ppc_t *p, uint32_t iw) {
     case 532:
     case 533:
     case 534:
-    case 535: {
+    case 535: { // 601 unified BATs / 604 IBATs — same storage
         if (spr_priv_fault(p, iw))
             return false;
         uint32_t pair = (n - 528) >> 1;
         v = (n & 1) ? p->batl[pair] : p->batu[pair];
         break;
     }
+    case 536:
+    case 537:
+    case 538:
+    case 539:
+    case 540:
+    case 541:
+    case 542:
+    case 543: { // DBATs: 604 only (PEM Table 2-8)
+        if (!ppc_is_604(p))
+            goto undefined;
+        if (spr_priv_fault(p, iw))
+            return false;
+        uint32_t pair = (n - 536) >> 1;
+        v = (n & 1) ? p->dbatl[pair] : p->dbatu[pair];
+        break;
+    }
+    case 952: // MMCR0 — 604 performance monitor group: read-zero stubs
+    case 953: // PMC1     (TNT proposal §4.2; the $00F00 interrupt never fires)
+    case 954: // PMC2
+    case 955: // SIA
+    case 959: // SDA
+        if (!ppc_is_604(p))
+            goto undefined;
+        if (spr_priv_fault(p, iw))
+            return false;
+        v = 0;
+        break;
     case 1008:
         if (spr_priv_fault(p, iw))
             return false;
         v = p->hid0;
         break;
-    case 1009:
+    case 1009: // HID1: 601 only (the 604 defines no HID1)
+        if (ppc_is_604(p))
+            goto undefined;
         if (spr_priv_fault(p, iw))
             return false;
         v = p->hid1;
@@ -281,25 +356,36 @@ bool ppc_mfspr(ppc_t *p, uint32_t iw) {
         v = p->pir;
         break;
     default:
-        // Invalid SPR: no-op, unless SPR[0]=1 in user mode → privileged
-        // program exception (601UM mfspr page).  SPR[0] is the high bit of
-        // the low half of the swapped number, i.e. bit 4 of `n`.
-        if ((n & 0x10u) && (p->msr & PPC_MSR_PR)) {
-            ppc_exception(p, PPC_VEC_PROGRAM, PPC_SRR1_PROG_PRIV, p->instruction_pc);
-            return false;
-        }
-        LOG(5, "mfspr r%u,%u: unimplemented SPR (no-op)", d, n);
-        return true;
+    undefined:
+        return !spr_undefined(p, n, true);
     }
     p->gpr[d] = v;
     return true;
+}
+
+// mftb/mftbu (opcode 31 xo 371, 604-only — the 601 traps the opcode
+// before reaching here).  User-readable in every mode (PEM §2.2.1); the
+// TBR field uses the same swapped halves as an SPR number, and only 268
+// (TBL) / 269 (TBU) are defined — anything else is an invalid form
+// taking the illegal-instruction program exception (PEM mftb page).
+void ppc_do_mftb(ppc_t *p, uint32_t iw) {
+    uint32_t n = spr_number(iw);
+    uint64_t tb = ppc_tb_now(p);
+    if (n == 268)
+        p->gpr[PPC_RT(iw)] = (uint32_t)tb;
+    else if (n == 269)
+        p->gpr[PPC_RT(iw)] = (uint32_t)(tb >> 32);
+    else
+        ppc_exception(p, PPC_VEC_PROGRAM, PPC_SRR1_PROG_ILLEGAL, p->instruction_pc);
 }
 
 bool ppc_mtspr(ppc_t *p, uint32_t iw) {
     uint32_t n = spr_number(iw);
     uint32_t v = p->gpr[PPC_RT(iw)];
     switch (n) {
-    case 0:
+    case 0: // MQ: 601-only
+        if (ppc_is_604(p))
+            goto undefined;
         p->mq = v;
         break;
     case 1:
@@ -321,7 +407,9 @@ bool ppc_mtspr(ppc_t *p, uint32_t iw) {
             return false;
         p->dar = v;
         break;
-    case 20: // RTC writes use SPR 20/21 (supervisor); reads use 4/5
+    case 20: // RTC writes use SPR 20/21 (supervisor); reads use 4/5; 601-only
+        if (ppc_is_604(p))
+            goto undefined;
         if (spr_priv_fault(p, iw))
             return false;
         p->rtcl = ppc_rtcl_now(p); // keep RTCL's live phase across the rebase
@@ -329,6 +417,8 @@ bool ppc_mtspr(ppc_t *p, uint32_t iw) {
         p->rtc_base_ticks = ppc_ticks_now(p);
         break;
     case 21:
+        if (ppc_is_604(p))
+            goto undefined;
         if (spr_priv_fault(p, iw))
             return false;
         p->rtcu = ppc_rtcu_now(p);
@@ -374,6 +464,24 @@ bool ppc_mtspr(ppc_t *p, uint32_t iw) {
             return false;
         p->ear = v;
         break;
+    case 284: // TBL write (604; reads go through mftb — PEM §2.3.1)
+        if (!ppc_is_604(p))
+            goto undefined;
+        if (spr_priv_fault(p, iw))
+            return false;
+        p->rtcu = (uint32_t)(ppc_tb_now(p) >> 32); // TBU keeps counting across the rebase
+        p->rtcl = v;
+        p->rtc_base_ticks = ppc_ticks_now(p);
+        break;
+    case 285: // TBU write (604)
+        if (!ppc_is_604(p))
+            goto undefined;
+        if (spr_priv_fault(p, iw))
+            return false;
+        p->rtcl = (uint32_t)ppc_tb_now(p);
+        p->rtcu = v;
+        p->rtc_base_ticks = ppc_ticks_now(p);
+        break;
     case 528:
     case 529:
     case 530:
@@ -381,7 +489,7 @@ bool ppc_mtspr(ppc_t *p, uint32_t iw) {
     case 532:
     case 533:
     case 534:
-    case 535: {
+    case 535: { // 601 unified BATs / 604 IBATs — same storage
         if (spr_priv_fault(p, iw))
             return false;
         uint32_t pair = (n - 528) >> 1;
@@ -394,12 +502,44 @@ bool ppc_mtspr(ppc_t *p, uint32_t iw) {
         }
         break;
     }
+    case 536:
+    case 537:
+    case 538:
+    case 539:
+    case 540:
+    case 541:
+    case 542:
+    case 543: { // DBATs: 604 only
+        if (!ppc_is_604(p))
+            goto undefined;
+        if (spr_priv_fault(p, iw))
+            return false;
+        uint32_t pair = (n - 536) >> 1;
+        uint32_t *slot = (n & 1) ? &p->dbatl[pair] : &p->dbatu[pair];
+        if (*slot != v) {
+            *slot = v;
+            ppc_mmu_invalidate_all(p);
+        }
+        break;
+    }
+    case 952: // 604 performance monitor group: write-ignore stubs
+    case 953:
+    case 954:
+    case 955:
+    case 959:
+        if (!ppc_is_604(p))
+            goto undefined;
+        if (spr_priv_fault(p, iw))
+            return false;
+        break;
     case 1008:
         if (spr_priv_fault(p, iw))
             return false;
         p->hid0 = v;
         break;
-    case 1009:
+    case 1009: // HID1: 601 only
+        if (ppc_is_604(p))
+            goto undefined;
         if (spr_priv_fault(p, iw))
             return false;
         p->hid1 = v;
@@ -420,12 +560,8 @@ bool ppc_mtspr(ppc_t *p, uint32_t iw) {
         p->pir = v;
         break;
     default:
-        if ((n & 0x10u) && (p->msr & PPC_MSR_PR)) {
-            ppc_exception(p, PPC_VEC_PROGRAM, PPC_SRR1_PROG_PRIV, p->instruction_pc);
-            return false;
-        }
-        LOG(5, "mtspr %u,$%08X: unimplemented SPR (no-op)", n, v);
-        return true;
+    undefined:
+        return !spr_undefined(p, n, false);
     }
     return true;
 }
@@ -455,7 +591,7 @@ uint32_t ppc_get_msr(ppc_t *restrict p) {
 }
 
 void ppc_set_msr(ppc_t *restrict p, uint32_t value) {
-    p->msr = value & PPC_MSR_MASK;
+    p->msr = value & ppc_msr_mask(p);
     ppc_update_active_maps(p);
 }
 
@@ -465,20 +601,28 @@ bool ppc_is_supervisor(ppc_t *restrict p) {
 
 // === Lifecycle ==============================================================
 
-// Hard-reset register state (601UM Table 5-8)
+// Hard-reset register state per model (601UM Table 5-8; 604UM §8.8.4 —
+// HRESET sets only MSR[IP], and the 604's HID0 comes up all-zero with the
+// caches and BHT disabled).  The cpu_model itself survives the reset.
 void ppc_reset(ppc_t *p) {
     struct object *keep_cpu = p->cpu_object;
     struct object *keep_fpu = p->fpu_object;
     struct object *keep_mmu = p->mmu_object;
+    int keep_model = p->cpu_model;
     memset(p, 0, sizeof(*p));
     p->cpu_object = keep_cpu;
     p->fpu_object = keep_fpu;
     p->mmu_object = keep_mmu;
-    p->cpu_model = CPU_MODEL_PPC601;
-    p->msr = PPC_MSR_ME | PPC_MSR_EP; // $00001040
-    p->pvr = 0x00010001u;
-    p->hid0 = 0x80010080u;
-    p->pc = 0xFFF00100u; // reset vector, MSR[EP]=1
+    p->cpu_model = keep_model;
+    if (ppc_is_604(p)) {
+        p->msr = PPC_MSR_EP; // $00000040 (IP only)
+        p->pvr = 0x00040103u; // 604, revision 1.3 (chosen constant; the kernel keys on the $0004 half)
+    } else {
+        p->msr = PPC_MSR_ME | PPC_MSR_EP; // $00001040
+        p->pvr = 0x00010001u;
+        p->hid0 = 0x80010080u;
+    }
+    p->pc = 0xFFF00100u; // reset vector, MSR[EP]=1 on both models
     p->instruction_pc = p->pc;
     ppc_mmu_invalidate_all(p); // translation state gone with the SRs/BATs
 }
@@ -527,10 +671,11 @@ static uint32_t ppc_hook_logical_xlate(uint32_t addr, bool *ok) {
     return ppc_mmu_translate_debug(g_hook_ppc, addr, true, ok);
 }
 
-ppc_t *ppc_init(checkpoint_t *checkpoint) {
+ppc_t *ppc_init(checkpoint_t *checkpoint, int cpu_model) {
     ppc_t *p = (ppc_t *)malloc(sizeof(ppc_t));
     if (!p)
         return NULL;
+    assert(cpu_model == CPU_MODEL_PPC601 || cpu_model == CPU_MODEL_PPC604);
 
     // The user SoA arrays carry this MMU's logical fills — the generic
     // identity-restore paths must leave them alone (memory.h).
@@ -556,6 +701,7 @@ ppc_t *ppc_init(checkpoint_t *checkpoint) {
         ppc_update_active_maps(p);
     } else {
         memset(p, 0, sizeof(ppc_t));
+        p->cpu_model = cpu_model; // ppc_reset keeps the model
         ppc_reset(p);
     }
 
@@ -662,7 +808,7 @@ static int ppc_dbgif_disasm(void *ctx, uint32_t pc, char *buf) {
     bool ok;
     uint32_t pa = ppc_mmu_translate_debug(p, pc, false, &ok);
     ppc_insn ins;
-    ppc_disassemble(ok ? memory_debug_read_uint32(pa) : 0, pc, &ins);
+    ppc_disassemble_model(ok ? memory_debug_read_uint32(pa) : 0, pc, p->cpu_model, &ins);
     // debug.c splits on '\t'; ppc_disasm emits "mnemonic\toperands" already.
     snprintf(buf, 100, "%s", ins.text);
     return 4;
@@ -712,7 +858,8 @@ enum ppc_attr_id {
     PA_DSISR,
     PA_GPR0 = 0x100, // ..0x11F
     PA_SR0 = 0x200, // ..0x20F
-    PA_BAT0U = 0x300, // U/L interleaved ..0x307
+    PA_BAT0U = 0x300, // U/L interleaved ..0x307 (601 unified / 604 IBATs)
+    PA_DBAT0U = 0x400, // U/L interleaved ..0x407 (604 DBATs)
 };
 
 static uint32_t *ppc_attr_slot(ppc_t *p, int id) {
@@ -723,6 +870,10 @@ static uint32_t *ppc_attr_slot(ppc_t *p, int id) {
     if (id >= PA_BAT0U && id < PA_BAT0U + 8) {
         int i = id - PA_BAT0U;
         return (i & 1) ? &p->batl[i >> 1] : &p->batu[i >> 1];
+    }
+    if (id >= PA_DBAT0U && id < PA_DBAT0U + 8) {
+        int i = id - PA_DBAT0U;
+        return (i & 1) ? &p->dbatl[i >> 1] : &p->dbatu[i >> 1];
     }
     switch (id) {
     case PA_PC:
@@ -767,11 +918,12 @@ static value_t attr_ppc_get(struct object *self, const member_t *m) {
         return val_err("cpu not initialised");
     int id = (int)(uintptr_t)m->attr.user_data;
     uint32_t raw;
-    // The time-derived SPRs read live, exactly as mfspr does.
+    // The time-derived SPRs read live, exactly as mfspr/mftb do; on the
+    // 604 the rtcu/rtcl slots ARE the timebase halves (tbu/tbl aliases).
     if (id == PA_RTCU)
-        raw = ppc_rtcu_now(p);
+        raw = ppc_is_604(p) ? (uint32_t)(ppc_tb_now(p) >> 32) : ppc_rtcu_now(p);
     else if (id == PA_RTCL)
-        raw = ppc_rtcl_now(p);
+        raw = ppc_is_604(p) ? (uint32_t)ppc_tb_now(p) : ppc_rtcl_now(p);
     else if (id == PA_DEC)
         raw = ppc_dec_now(p);
     else {
@@ -798,9 +950,10 @@ static value_t attr_ppc_set(struct object *self, const member_t *m, value_t in) 
     // SR/BAT/SDR1 pokes invalidate the translation caches like their
     // instruction-level counterparts do.
     if (id == PA_MSR) {
-        p->msr &= PPC_MSR_MASK;
+        p->msr &= ppc_msr_mask(p);
         ppc_update_active_maps(p);
-    } else if ((id >= PA_SR0 && id < PA_SR0 + 16) || (id >= PA_BAT0U && id < PA_BAT0U + 8) || id == PA_SDR1) {
+    } else if ((id >= PA_SR0 && id < PA_SR0 + 16) || (id >= PA_BAT0U && id < PA_BAT0U + 8) ||
+               (id >= PA_DBAT0U && id < PA_DBAT0U + 8) || id == PA_SDR1) {
         ppc_recompute_sr_t_mask(p);
         ppc_mmu_invalidate_all(p);
     }
@@ -844,6 +997,13 @@ static const member_t ppc_members[] = {
     PPC_ATTR("bat0u", PA_BAT0U + 0), PPC_ATTR("bat0l", PA_BAT0U + 1), PPC_ATTR("bat1u", PA_BAT0U + 2),
     PPC_ATTR("bat1l", PA_BAT0U + 3), PPC_ATTR("bat2u", PA_BAT0U + 4), PPC_ATTR("bat2l", PA_BAT0U + 5),
     PPC_ATTR("bat3u", PA_BAT0U + 6), PPC_ATTR("bat3l", PA_BAT0U + 7),
+    // 604 additions: the DBAT file, and tbu/tbl as aliases of the rtcu/rtcl
+    // storage (which holds the timebase halves on that model).  Present on
+    // both models — a static member table — and simply inert on the 601.
+    PPC_ATTR("dbat0u", PA_DBAT0U + 0), PPC_ATTR("dbat0l", PA_DBAT0U + 1), PPC_ATTR("dbat1u", PA_DBAT0U + 2),
+    PPC_ATTR("dbat1l", PA_DBAT0U + 3), PPC_ATTR("dbat2u", PA_DBAT0U + 4), PPC_ATTR("dbat2l", PA_DBAT0U + 5),
+    PPC_ATTR("dbat3u", PA_DBAT0U + 6), PPC_ATTR("dbat3l", PA_DBAT0U + 7),
+    PPC_ATTR("tbu", PA_RTCU),          PPC_ATTR("tbl", PA_RTCL),
 };
 // clang-format on
 

--- a/src/core/cpu/ppc/ppc.h
+++ b/src/core/cpu/ppc/ppc.h
@@ -2,14 +2,17 @@
 // Copyright (c) pappadf
 
 // ppc.h
-// Public interface for the PowerPC main-CPU core (MPC601).
+// Public interface for the PowerPC main-CPU core (MPC601 / MPC604).
 //
 // The module is named `ppc`, not `ppc601`: the decode tree and register file
-// are architectural 32-bit PowerPC, with 601-specific behavior (POWER
-// holdovers, MQ, RTC-instead-of-timebase, 601 BAT format, HID SPRs, the
-// 601-only exception vectors) carried behind cpu_model discrimination —
-// a future 603/604 would be a second model here, not a second module.
-// Nothing beyond the 601 is implemented.
+// are architectural 32-bit PowerPC, with model-specific behavior carried
+// behind cpu_model discrimination the way cpu.c discriminates 68000/030/040.
+// Two models exist:
+//   CPU_MODEL_PPC601 — POWER holdovers, MQ, RTC-instead-of-timebase, the
+//     601 unified BAT format, the $00A00/$02000 vectors;
+//   CPU_MODEL_PPC604 — timebase/mftb, architected split I/D BATs, per-class
+//     tlbie + tlbsync, POW/BE/RI/PM MSR bits, the optional FP group
+//     (fsel/fres/frsqrte/stfiwx), holdover rejection, trace at $00D00.
 //
 // Unlike the auxiliary DSP3210 core, this is a MAIN CPU (cores.md): it reads
 // and writes guest memory through the global fast-path accessors
@@ -17,9 +20,11 @@
 // MSR[PR] transitions, and registers `machine.cpu` and the `$` register
 // aliases when instantiated by a machine.
 //
-// Source of truth: Motorola/IBM, "PowerPC 601 RISC Microprocessor User's
-// Manual", 1995 (MPC601UM/AD) — chapter/table references in comments below
-// cite that document.
+// Sources of truth: Motorola/IBM, "PowerPC 601 RISC Microprocessor User's
+// Manual", 1995 (MPC601UM/AD) for the 601 model, and "PowerPC 604 RISC
+// Microprocessor User's Manual", 1994 (MPC604UM/AD) plus "PowerPC
+// Microprocessor Family: The Programming Environments" (MPCFPE32B) for the
+// 604 — chapter/table references in comments cite those documents.
 
 #ifndef GS_CPU_PPC_H
 #define GS_CPU_PPC_H
@@ -36,19 +41,23 @@ typedef struct ppc ppc_t;
 
 // === Lifecycle ===
 
-// Create a 601 core in the hard-reset state (601UM Table 5-8): all register
-// files zeroed, MSR = $00001040 (ME + EP), PVR = $00010001, HID0 = $80010080.
-// If `checkpoint` is non-NULL, state is restored from the stream instead.
+// Create a core of `cpu_model` (CPU_MODEL_PPC601 / CPU_MODEL_PPC604) in the
+// hard-reset state: 601 per 601UM Table 5-8 (MSR = $00001040 (ME + EP),
+// PVR = $00010001, HID0 = $80010080); 604 per 604UM §8.8.4 (MSR = $00000040
+// — HRESET sets only IP — PVR = $00040103, HID0 = 0).
+// If `checkpoint` is non-NULL, state (including the model) is restored from
+// the stream instead and `cpu_model` is ignored.
 // Registers the `machine.cpu` object node and `$` register aliases (the
 // main-CPU privilege per docs/core/cpu/cores.md).
-ppc_t *ppc_init(checkpoint_t *checkpoint);
+ppc_t *ppc_init(checkpoint_t *checkpoint, int cpu_model);
 
 void ppc_delete(ppc_t *p);
 
 void ppc_checkpoint(ppc_t *restrict p, checkpoint_t *checkpoint);
 
-// Hard reset (power-on): 601UM Table 5-8 register state; execution resumes
-// at $FFF00100 (MSR[EP]=1 vectors the reset exception high).
+// Hard reset (power-on): per-model register state (see ppc_init); the
+// cpu_model itself survives.  Execution resumes at $FFF00100 (MSR[EP]=1
+// vectors the reset exception high on both models).
 void ppc_reset(ppc_t *p);
 
 // === Execution ===
@@ -63,12 +72,16 @@ void ppc_run(ppc_t *restrict p, uint32_t *instructions);
 // has no STOP-equivalent the Mac uses (guest idles in loops).
 sched_cpu_if_t ppc_sched_if(ppc_t *p);
 
-// Bind the RTC/DEC time source (§3.7): RTCU/RTCL/DEC are derived from
-// scheduler_cpu_cycles at exactly 7.8336 MHz-equivalent via the reduced
-// rational 7,833,600/freq_hz — the dossier's hard constraint.  Registers the
-// "ppc.dec" event type, so call before scheduler_start.  Unbound (unit
-// tests), the RTC/DEC SPRs are static state.
-void ppc_bind_time(ppc_t *p, struct scheduler *s, uint32_t freq_hz);
+// Bind the RTC/TB/DEC time source (601 proposal §3.7, generalized per the
+// TNT proposal §4.4): the time SPRs are derived from scheduler_cpu_cycles
+// via the reduced rational tick_hz/freq_hz.  On the 601 `tick_hz` is the
+// 7.8336 MHz RTC input (RTCL advances 128 ns-units, DEC decrements 128
+// units per tick — the dossier's hard constraint); on the 604 it is the
+// timebase rate (bus clock / 4 — 604UM §1.3.2.2), with TB incrementing and
+// DEC decrementing once per tick.  Registers the "ppc.dec" event type, so
+// call before scheduler_start.  Unbound (unit tests), the time SPRs are
+// static state.
+void ppc_bind_time(ppc_t *p, struct scheduler *s, uint32_t freq_hz, uint32_t tick_hz);
 
 // Debugger adapter (PPC proposal §3.9b): PC access, pc-based disassembly,
 // logical→physical translation.

--- a/src/core/cpu/ppc/ppc_decode.h
+++ b/src/core/cpu/ppc/ppc_decode.h
@@ -2,7 +2,7 @@
 // Copyright (c) pappadf
 
 // ppc_decode.h
-// Instruction decoder for the PPC (MPC601) core.
+// Instruction decoder for the PPC (MPC601 / MPC604) core.
 // Note: this header is a template intended for multiple inclusion with
 // different macro parameters; it intentionally has no include guard (the
 // cpu_decode.h pattern — proposal-heterogeneous-multi-cpu.md §3.3.1).
@@ -11,10 +11,16 @@
 // they cannot drift out of sync.
 //
 // The tree decides VALIDITY as well as identity: invalid forms (reserved
-// fields set, invalid BO encodings, instructions the 601 lacks — 601UM
-// §10.3 Tables 10-6/10-8) route to OP_ILLEGAL on both sides.  Leaves name
-// what was recognized and nothing more; Rc/OE/field variants are read from
-// `iw` by the includer's OP_ overloads.
+// fields set, invalid BO encodings, instructions neither model has — 601UM
+// §10.3 Tables 10-6/10-8; PEM appendix A) route to OP_ILLEGAL on both
+// sides.  MODEL validity is the leaves' job, not the tree's: encodings only
+// one model implements (the POWER holdovers and MQ/RTC moves on the 601;
+// mftb/tlbsync/stfiwx/fsel/fres/frsqrte on the 604) decode here
+// unconditionally, and the emulator's OP_ overloads raise the program
+// exception on the other model while the disassembler's flag the encoding
+// (is_power / is_604) for its model filter.  Leaves name what was
+// recognized and nothing more; Rc/OE/field variants are read from `iw` by
+// the includer's OP_ overloads.
 
 // Required macro configuration (provided by includer):
 // - PPC_DECODER_NAME:        Symbol/name of the generated decoder function
@@ -208,8 +214,13 @@ PPC_DECODER_RETURN_TYPE PPC_DECODER_NAME(PPC_DECODER_ARGS) {
         case 659: OP_MFSRIN; break;
         case 242: OP_MTSRIN; break;
         case 306: OP_TLBIE; break;
-        // xo 371 (mftb) deliberately absent: the 601 has RTC SPRs instead
-        // of the timebase and traps mftb as illegal (601UM mfspr page).
+        // mftb (604): the TBR field is read by the leaf; the 601 has RTC
+        // SPRs instead of the timebase and traps it (601UM mfspr page).
+        case 371: if (PPC_RC(iw)) { OP_ILLEGAL; break; }
+                  OP_MFTB; break;
+        // tlbsync (604): every operand field reserved-zero (PEM page).
+        case 566: if (PPC_RT(iw) || PPC_RA(iw) || PPC_RB(iw) || PPC_RC(iw)) { OP_ILLEGAL; break; }
+                  OP_TLBSYNC; break;
 
         // --- storage control (RT and Rc are reserved-zero) ---
         case 598: OP_SYNC; break;
@@ -269,6 +280,7 @@ PPC_DECODER_RETURN_TYPE PPC_DECODER_NAME(PPC_DECODER_ARGS) {
         case 695: if (PPC_RC(iw)) { OP_ILLEGAL; break; } OP_STFSUX; break;
         case 727: if (PPC_RC(iw)) { OP_ILLEGAL; break; } OP_STFDX; break;
         case 759: if (PPC_RC(iw)) { OP_ILLEGAL; break; } OP_STFDUX; break;
+        case 983: if (PPC_RC(iw)) { OP_ILLEGAL; break; } OP_STFIWX; break; // 604
 
         default:  OP_ILLEGAL; break;
         }
@@ -307,6 +319,8 @@ PPC_DECODER_RETURN_TYPE PPC_DECODER_NAME(PPC_DECODER_ARGS) {
         case 18: if (PPC_FRC(iw)) { OP_ILLEGAL; break; } OP_FDIVS; break;
         case 20: if (PPC_FRC(iw)) { OP_ILLEGAL; break; } OP_FSUBS; break;
         case 21: if (PPC_FRC(iw)) { OP_ILLEGAL; break; } OP_FADDS; break;
+        case 24: if (PPC_RA(iw) || PPC_FRC(iw)) { OP_ILLEGAL; break; }
+                 OP_FRES; break;                                    // 604
         case 25: if (PPC_RB(iw)) { OP_ILLEGAL; break; } OP_FMULS; break;
         case 28: OP_FMSUBS; break;
         case 29: OP_FMADDS; break;
@@ -339,6 +353,9 @@ PPC_DECODER_RETURN_TYPE PPC_DECODER_NAME(PPC_DECODER_ARGS) {
             case 18: if (PPC_FRC(iw)) { OP_ILLEGAL; break; } OP_FDIV; break;
             case 20: if (PPC_FRC(iw)) { OP_ILLEGAL; break; } OP_FSUB; break;
             case 21: if (PPC_FRC(iw)) { OP_ILLEGAL; break; } OP_FADD; break;
+            case 23: OP_FSEL; break;                                // 604
+            case 26: if (PPC_RA(iw) || PPC_FRC(iw)) { OP_ILLEGAL; break; }
+                     OP_FRSQRTE; break;                             // 604
             case 25: if (PPC_RB(iw)) { OP_ILLEGAL; break; } OP_FMUL; break;
             case 28: OP_FMSUB; break;
             case 29: OP_FMADD; break;

--- a/src/core/cpu/ppc/ppc_disasm.c
+++ b/src/core/cpu/ppc/ppc_disasm.c
@@ -2,15 +2,17 @@
 // Copyright (c) pappadf
 
 // ppc_disasm.c
-// Dependency-free MPC601 disassembler: the second instantiation of the
-// shared decode tree (ppc_decode.h), with the OP_ leaves overloaded by
+// Dependency-free MPC601/MPC604 disassembler: the second instantiation of
+// the shared decode tree (ppc_decode.h), with the OP_ leaves overloaded by
 // sprintf-style printing macros — the cpu_disasm.c pattern
 // (proposal-heterogeneous-multi-cpu.md §3.3.1).  Because this is literally
 // the same decode tree the interpreter runs, the two cannot drift.
 //
 // Output uses standard mnemonics with the common simplified forms (li,
 // lis, mr, nop, blr, bctr, cmpwi, mflr, ...) the way the development
-// oracle (powerpc-linux-gnu-objdump -m powerpc:601) prints them.
+// oracle (powerpc-linux-gnu-objdump -m powerpc:601 / powerpc:604) prints
+// them.  Model validity is flag-based (is_power / is_604) with
+// ppc_disassemble_model() applying one model's view.
 
 #include "ppc_disasm.h"
 
@@ -52,7 +54,8 @@ static void invalid(ppc_insn *o) {
     snprintf(o->text, sizeof(o->text), ".long\t$%08X", (unsigned)o->word);
 }
 
-// SPR name per the 601 encoding tables (10-4/10-5); NULL if unknown.
+// SPR name per the 601 encoding tables (10-4/10-5) and the 604 additions
+// (604UM Table 2-43 + the OEA set); NULL if unknown.
 static const char *spr_name(uint32_t n) {
     switch (n) {
     case 0:
@@ -95,6 +98,10 @@ static const char *spr_name(uint32_t n) {
         return "sprg3";
     case 282:
         return "ear";
+    case 284:
+        return "tbl"; // 604 write encoding (reads via mftb)
+    case 285:
+        return "tbu";
     case 287:
         return "pvr";
     case 528:
@@ -113,6 +120,32 @@ static const char *spr_name(uint32_t n) {
         return "ibat3u";
     case 535:
         return "ibat3l";
+    case 536:
+        return "dbat0u"; // 604 split file
+    case 537:
+        return "dbat0l";
+    case 538:
+        return "dbat1u";
+    case 539:
+        return "dbat1l";
+    case 540:
+        return "dbat2u";
+    case 541:
+        return "dbat2l";
+    case 542:
+        return "dbat3u";
+    case 543:
+        return "dbat3l";
+    case 952:
+        return "mmcr0"; // 604 performance monitor group
+    case 953:
+        return "pmc1";
+    case 954:
+        return "pmc2";
+    case 955:
+        return "sia";
+    case 959:
+        return "sda";
     case 1008:
         return "hid0";
     case 1009:
@@ -218,7 +251,7 @@ static void dis_xform_mem(ppc_insn *o, uint32_t w, const char *mnem, int fp) {
         emitf(o, "%s\t%c%u,0,r%u", mnem, fp ? 'f' : 'r', (unsigned)PPC_RT(w), (unsigned)PPC_RB(w));
 }
 
-// mfspr/mtspr with the 601 SPR names; the canonical short forms for the
+// mfspr/mtspr with the model SPR names; the canonical short forms for the
 // user SPRs (mflr/mtctr/...); MQ/RTC encodings flagged 601-specific.
 static void dis_spr(ppc_insn *o, uint32_t w, int is_mf) {
     uint32_t n = ((w >> 16) & 0x1Fu) | (((w >> 11) & 0x1Fu) << 5);
@@ -228,7 +261,7 @@ static void dis_spr(ppc_insn *o, uint32_t w, int is_mf) {
         return;
     }
     if (n == 0 || n == 4 || n == 5 || n == 20 || n == 21)
-        o->is_power = 1; // MQ/RTC encodings are 601-specific
+        o->is_power = 1; // MQ/RTC encodings are 601-specific (the 604 traps them)
     if (is_mf) {
         if (name)
             emitf(o, "mfspr\tr%u,%s", (unsigned)PPC_RT(w), name);
@@ -240,6 +273,18 @@ static void dis_spr(ppc_insn *o, uint32_t w, int is_mf) {
         else
             emitf(o, "mtspr\t%u,r%u", (unsigned)n, (unsigned)PPC_RT(w));
     }
+}
+
+// mftb/mftbu simplified mnemonics per the TBR number (604-only encoding).
+static void dis_mftb(ppc_insn *o, uint32_t w) {
+    uint32_t n = ((w >> 16) & 0x1Fu) | (((w >> 11) & 0x1Fu) << 5);
+    o->is_604 = 1;
+    if (n == 268)
+        emitf(o, "mftb\tr%u", (unsigned)PPC_RT(w));
+    else if (n == 269)
+        emitf(o, "mftbu\tr%u", (unsigned)PPC_RT(w));
+    else // undefined TBR: print the raw form (traps at runtime)
+        emitf(o, "mftb\tr%u,%u", (unsigned)PPC_RT(w), (unsigned)n);
 }
 
 // === The OP_ printing table =================================================
@@ -397,6 +442,8 @@ static void dis_spr(ppc_insn *o, uint32_t w, int is_mf) {
 #define OP_MFSRIN     ASM("mfsrin\tr%u,r%u", RT_, RB_)
 #define OP_MTSRIN     ASM("mtsrin\tr%u,r%u", RT_, RB_)
 #define OP_TLBIE      ASM("tlbie\tr%u", RB_)
+#define OP_MFTB       dis_mftb(o, iw)
+#define OP_TLBSYNC    (o->is_604 = 1, ASM("tlbsync"))
 
 // --- storage control ---
 #define OP_SYNC       ASM("sync")
@@ -471,6 +518,7 @@ static void dis_spr(ppc_insn *o, uint32_t w, int is_mf) {
 #define OP_STFSUX     dis_xform_mem(o, iw, "stfsux", 1)
 #define OP_STFDX      dis_xform_mem(o, iw, "stfdx", 1)
 #define OP_STFDUX     dis_xform_mem(o, iw, "stfdux", 1)
+#define OP_STFIWX     (o->is_604 = 1, dis_xform_mem(o, iw, "stfiwx", 1))
 
 // --- FP moves / FPSCR / compares ---
 #define OP_FCMPU      ASM("fcmpu\tcr%u,f%u,f%u", CRFD_, RA_, RB_)
@@ -507,6 +555,11 @@ static void dis_spr(ppc_insn *o, uint32_t w, int is_mf) {
 #define OP_FNMSUBS    ASM_FMADD("fnmsubs")
 #define OP_FNMADDS    ASM_FMADD("fnmadds")
 
+// --- 604 optional-FP group ---
+#define OP_FSEL       (o->is_604 = 1, ASM_FMADD("fsel"))
+#define OP_FRES       (o->is_604 = 1, ASM_FRT_FRB("fres"))
+#define OP_FRSQRTE    (o->is_604 = 1, ASM_FRT_FRB("frsqrte"))
+
 #define OP_ILLEGAL    invalid(o)
 
 // clang-format on
@@ -527,5 +580,14 @@ int ppc_disassemble(uint32_t word, uint32_t addr, ppc_insn *out) {
     out->addr = addr;
     out->status = PPC_DIS_OK;
     ppc_disasm_one(word, addr, out);
+    return out->status;
+}
+
+int ppc_disassemble_model(uint32_t word, uint32_t addr, int model, ppc_insn *out) {
+    ppc_disassemble(word, addr, out);
+    // The other model's exclusives trap as illegal there — render them
+    // the way any invalid word renders.
+    if ((model == 604 && out->is_power) || (model == 601 && out->is_604))
+        invalid(out);
     return out->status;
 }

--- a/src/core/cpu/ppc/ppc_disasm.h
+++ b/src/core/cpu/ppc/ppc_disasm.h
@@ -2,11 +2,13 @@
 // Copyright (c) pappadf
 
 // ppc_disasm.h
-// Dependency-free disassembler for the PPC (MPC601) core, per the
+// Dependency-free disassembler for the PPC (MPC601/MPC604) core, per the
 // core-module contract (docs/core/cpu/cores.md): raw word + pc in, text
-// out; linkable standalone (tools/disasm --arch ppc).  Covers the full
-// 601 instruction set including the POWER holdovers, flagging 601-only
-// SPR names and POWER-architecture mnemonics.
+// out; linkable standalone (tools/disasm --arch ppc / ppc604).  Covers
+// the union of both models' instruction sets — the 601's POWER holdovers
+// and MQ/RTC SPR moves flagged `is_power`, the 604-only encodings (mftb,
+// tlbsync, stfiwx, fsel, fres, frsqrte) flagged `is_604` — with
+// ppc_disassemble_model() applying one model's validity view.
 //
 // Portable C99: no I/O, no allocation, no global state.
 
@@ -21,24 +23,34 @@ extern "C" {
 
 // Decode status
 enum {
-    PPC_DIS_OK = 0, // valid 601 instruction
-    PPC_DIS_INVALID = 1, // not a 601 instruction (takes the program exception)
+    PPC_DIS_OK = 0, // valid instruction (on some model — see the flags)
+    PPC_DIS_INVALID = 1, // no model implements it (takes the program exception)
 };
 
 typedef struct {
     uint32_t word; // raw instruction word
     uint32_t addr; // address the word was fetched from
     int status; // PPC_DIS_OK / PPC_DIS_INVALID
-    int is_power; // 1 for a POWER-architecture holdover (601-specific)
+    int is_power; // 1 for a POWER-architecture holdover / MQ/RTC SPR move (601-only)
+    int is_604; // 1 for a 604-only encoding (mftb/tlbsync/stfiwx/fsel/fres/frsqrte)
     int is_branch; // 1 for any control transfer (b/bc/bclr/bcctr/rfi/sc)
     int has_target; // 1 if `target` holds a resolved branch target
     uint32_t target; // absolute branch target when has_target
     char text[96]; // "mnemonic\toperands" (tab-separated, NUL-terminated)
 } ppc_insn;
 
-// Disassemble one instruction word.  `addr` resolves pc-relative branch
-// targets.  `out` is filled in completely; returns out->status.
+// Disassemble one instruction word against the union of both models.
+// `addr` resolves pc-relative branch targets.  `out` is filled in
+// completely; returns out->status.
 int ppc_disassemble(uint32_t word, uint32_t addr, ppc_insn *out);
+
+// Model-filtered disassembly: `model` is 601 or 604 (numerically equal to
+// the machine_profile.h CPU_MODEL_PPC* ids; plain ints keep this TU
+// dependency-free).  Encodings the model rejects at runtime — the POWER
+// holdovers on the 604, the 604-only group on the 601 — come back
+// PPC_DIS_INVALID with `.long` text, matching the model's program
+// exception and the objdump -m powerpc:<model> oracle.
+int ppc_disassemble_model(uint32_t word, uint32_t addr, int model, ppc_insn *out);
 
 #ifdef __cplusplus
 }

--- a/src/core/cpu/ppc/ppc_fpu.c
+++ b/src/core/cpu/ppc/ppc_fpu.c
@@ -137,6 +137,36 @@ void ppc_do_frsp(ppc_t *p, uint32_t iw) {
     ppc_fp_trap_check(p);
 }
 
+// === The 604 optional-FP group (PEM fselx/fresx/frsqrtex pages) =============
+
+// fsel: frD = (frA >= 0.0) ? frC : frB — the compare ignores the sign of
+// zero, and a NaN frA selects frB.  No FPSCR effects at all.
+void ppc_do_fsel(ppc_t *p, uint32_t iw) {
+    uint64_t a = p->fpr[PPC_RA(iw)];
+    bool ge_zero = !f64_is_nan(a) && (!(a >> 63) || (a & 0x7FFFFFFFFFFFFFFFull) == 0);
+    p->fpr[PPC_RT(iw)] = ge_zero ? p->fpr[PPC_FRC(iw)] : p->fpr[PPC_RB(iw)];
+    if (PPC_RC(iw))
+        ppc_set_cr_field(p, 1, p->fpscr >> 28);
+}
+
+void ppc_do_fres(ppc_t *p, uint32_t iw) {
+    uint64_t frt;
+    if (ppc_sf_fres(p->fpr[PPC_RB(iw)], &p->fpscr, &frt))
+        p->fpr[PPC_RT(iw)] = frt;
+    if (PPC_RC(iw))
+        ppc_set_cr_field(p, 1, p->fpscr >> 28);
+    ppc_fp_trap_check(p);
+}
+
+void ppc_do_frsqrte(ppc_t *p, uint32_t iw) {
+    uint64_t frt;
+    if (ppc_sf_frsqrte(p->fpr[PPC_RB(iw)], &p->fpscr, &frt))
+        p->fpr[PPC_RT(iw)] = frt;
+    if (PPC_RC(iw))
+        ppc_set_cr_field(p, 1, p->fpscr >> 28);
+    ppc_fp_trap_check(p);
+}
+
 void ppc_do_fctiw(ppc_t *p, uint32_t iw, bool round_to_zero) {
     uint64_t frt;
     if (ppc_sf_fctiw(p->fpr[PPC_RB(iw)], round_to_zero, &p->fpscr, &frt))

--- a/src/core/cpu/ppc/ppc_internal.h
+++ b/src/core/cpu/ppc/ppc_internal.h
@@ -2,15 +2,19 @@
 // Copyright (c) pappadf
 
 // ppc_internal.h
-// Internal state and shared helpers for the PPC (MPC601) core.
-// All chapter/table citations refer to Motorola/IBM, "PowerPC 601 RISC
-// Microprocessor User's Manual", 1995 (MPC601UM/AD).
+// Internal state and shared helpers for the PPC (MPC601 / MPC604) core.
+// Unqualified chapter/table citations refer to Motorola/IBM, "PowerPC 601
+// RISC Microprocessor User's Manual", 1995 (MPC601UM/AD); citations marked
+// "604UM" refer to "PowerPC 604 RISC Microprocessor User's Manual", 1994
+// (MPC604UM/AD), and "PEM" to "PowerPC Microprocessor Family: The
+// Programming Environments", 32-bit (MPCFPE32B).
 
 #ifndef GS_CPU_PPC_INTERNAL_H
 #define GS_CPU_PPC_INTERNAL_H
 
 #include "ppc.h"
 
+#include "machine_profile.h" // CPU_MODEL_PPC601 / CPU_MODEL_PPC604
 #include "memory.h"
 
 #include <assert.h>
@@ -29,11 +33,19 @@
 #define PPC_MSR_EP  0x0040u // exception prefix: 1 = $FFFnnnnn (bit 25)
 #define PPC_MSR_IT  0x0020u // instruction translation (bit 26)
 #define PPC_MSR_DT  0x0010u // data translation (bit 27)
+// 604-only MSR bits (604UM Table 4-3); ILE/LE stay unimplemented on both
+// models (big-endian Macs — TNT proposal §4.2).
+#define PPC_MSR_POW 0x00040000u // power management enable (bit 13; accepted as a no-op idle hint)
+#define PPC_MSR_BE  0x0200u // branch trace enable (bit 22)
+#define PPC_MSR_PM  0x0004u // performance monitor marked mode (bit 29)
+#define PPC_MSR_RI  0x0002u // recoverable interrupt (bit 30)
 // All MSR bits the 601 implements — mtmsr/rfi writes are masked to this
 // (601 has no POW/ILE/BE/RI; those bits read as zero).
 #define PPC_MSR_MASK                                                                                                   \
     (PPC_MSR_EE | PPC_MSR_PR | PPC_MSR_FP | PPC_MSR_ME | PPC_MSR_FE0 | PPC_MSR_SE | PPC_MSR_FE1 | PPC_MSR_EP |         \
      PPC_MSR_IT | PPC_MSR_DT)
+// The 604 adds POW/BE/PM/RI (604UM Table 4-3).
+#define PPC_MSR_MASK_604 (PPC_MSR_MASK | PPC_MSR_POW | PPC_MSR_BE | PPC_MSR_PM | PPC_MSR_RI)
 
 // === XER bits ===
 #define PPC_XER_SO      0x80000000u
@@ -55,6 +67,12 @@
 #define PPC_VEC_IOERROR   0x00A00u // 601-only I/O controller interface error
 #define PPC_VEC_SYSCALL   0x00C00u
 #define PPC_VEC_TRACE     0x02000u // 601 run-mode/trace (not $00D00)
+// 604-only vectors (604UM Table 4-2).  Neither model delivers trace today
+// (MSR[SE]/[BE] are storage-only, matching the 601 model's standing
+// behavior); the constants pin the per-model addresses.  $00F00 never
+// fires: the performance monitor SPRs are read-zero/write-ignore stubs.
+#define PPC_VEC_TRACE604 0x00D00u
+#define PPC_VEC_PERFMON  0x00F00u
 
 // SRR1 exception-specific bits for the program exception (Table 5-16)
 #define PPC_SRR1_PROG_FPENABLED 0x00100000u // bit 11
@@ -62,9 +80,11 @@
 #define PPC_SRR1_PROG_PRIV      0x00040000u // bit 13
 #define PPC_SRR1_PROG_TRAP      0x00020000u // bit 14
 
-// DSISR bits for the data access exception (Table 5-10)
+// DSISR bits for the data access exception (Table 5-10; 604UM Table 4-2 DSI row)
+#define PPC_DSISR_DIRECT   0x80000000u // bit 0: direct-store error (604 — no XIO device answers)
 #define PPC_DSISR_NOTFOUND 0x40000000u // bit 1: no HTEG/BAT translation
 #define PPC_DSISR_PROT     0x08000000u // bit 4: protection violation
+#define PPC_DSISR_ATOMIC   0x04000000u // bit 5: lwarx/stwcx./eciwx/ecowx to a direct-store segment
 #define PPC_DSISR_STORE    0x02000000u // bit 6: access was a store
 
 // === Instruction state ===
@@ -92,14 +112,21 @@ struct ppc {
     uint32_t sdr1;
     uint32_t ear;
     uint32_t pvr; // $00010001, read-only
-    uint32_t hid0, hid1, iabr, dabr, pir; // 601 HID group: store-and-readback
-    uint32_t rtcu, rtcl; // RTC pair (read SPR 4/5, write SPR 20/21)
-    uint32_t batu[4], batl[4]; // 4 unified BAT pairs, 601 format
+    uint32_t hid0, hid1, iabr, dabr, pir; // HID group: store-and-readback (hid1 is 601-only)
+    // 601: RTC pair (read SPR 4/5, write SPR 20/21).  604: TBU/TBL — the
+    // timebase halves at their rebase instant (read via mftb, write SPR
+    // 285/284); same rebase discipline, different tick semantics (§4.4).
+    uint32_t rtcu, rtcl;
+    uint32_t batu[4],
+        batl[4]; // 601: 4 unified BAT pairs, 601 format.  604: the IBATs (SPR 528-535), architected format
+    uint32_t dbatu[4], dbatl[4]; // 604 only: the DBATs (SPR 536-543), architected format
     uint32_t sr[16]; // segment registers
-    // Which segments have T=1 (bit n = sr[n] bit 0) — data accesses
+    // Which segments have T=1 (bit n = sr[n] bit 0) — 601 data accesses
     // consult the segment's T bit even with MSR[DT]=0 (601UM §6.5.2),
     // and this mask keeps that check off the translation-off fast path.
     // Derived from sr[]; maintained by ppc_set_sr/ppc_recompute_sr_t_mask.
+    // Always zero on the 604: with MSR[DR]=0 it runs in real addressing
+    // mode with no segment consult at all (PEM §7.2).
     uint32_t sr_t_mask;
 
     // --- execution state ---
@@ -108,15 +135,18 @@ struct ppc {
     uint32_t reserve_addr;
     uint32_t ext_irq; // level of the external-interrupt line
     uint32_t dec_pending; // latched decrementer exception request
-    int cpu_model; // CPU_MODEL_PPC601
+    int cpu_model; // CPU_MODEL_PPC601 / CPU_MODEL_PPC604 (the model discriminator)
 
-    // --- time derivation (§3.7: exact-rational RTC/DEC) ---
-    // ticks = cycles * tick_mul / tick_div, the reduced 7,833,600/freq
-    // rational; tick_mul == 0 means unbound (unit tests: static SPRs).
-    // rtcu/rtcl/dec above hold the values AT their rebase instant.
+    // --- time derivation (§3.7: exact-rational RTC/TB/DEC) ---
+    // ticks = cycles * tick_mul / tick_div, the reduced tick_hz/freq_hz
+    // rational (601: the 7.8336 MHz RTC input; 604: the timebase rate,
+    // bus/4); tick_mul == 0 means unbound (unit tests: static SPRs).
+    // rtcu/rtcl/dec above hold the values AT their rebase instant.  Per
+    // tick, the 601's RTCL advances 128 ns-units and DEC drops 128 units;
+    // the 604's TB advances 1 and DEC drops 1.
     uint32_t tick_mul, tick_div;
-    uint64_t rtc_base_ticks; // RTC tick count when rtcu/rtcl were written
-    uint64_t dec_base_ticks; // RTC tick count when dec was written
+    uint64_t rtc_base_ticks; // tick count when rtcu/rtcl (601 RTC / 604 TB) were written
+    uint64_t dec_base_ticks; // tick count when dec was written
 
     // NOTE: the MMU/fetch translation caches live as file statics in
     // ppc_mmu.c, NOT here — they embed host pointers, and this struct is
@@ -153,6 +183,36 @@ struct ppc {
 static inline uint32_t ppc_ra0(ppc_t *p, uint32_t iw) {
     uint32_t a = PPC_RA(iw);
     return a ? p->gpr[a] : 0;
+}
+
+// Model discrimination (the cpu.c 68000/030/040 pattern).
+static inline bool ppc_is_604(const ppc_t *p) {
+    return p->cpu_model == CPU_MODEL_PPC604;
+}
+
+// MSR bits the active model implements (mtmsr/rfi/pokes mask to this).
+static inline uint32_t ppc_msr_mask(const ppc_t *p) {
+    return ppc_is_604(p) ? PPC_MSR_MASK_604 : PPC_MSR_MASK;
+}
+
+// MSR bits an exception entry preserves: ME and EP on both models, plus PM
+// on the 604 (unlisted in the 604UM per-exception MSR rows — unaltered).
+static inline uint32_t ppc_msr_exception_keep(const ppc_t *p) {
+    return PPC_MSR_ME | PPC_MSR_EP | (ppc_is_604(p) ? PPC_MSR_PM : 0u);
+}
+
+// True when iw is a floating-point load/store (601: alignment exception in
+// a non-memory-forced T=1 segment, 601UM §5.4.10; 604: the word-alignment
+// requirement, 604UM §4.5.6).
+static inline bool ppc_iw_is_fp_ls(uint32_t iw) {
+    uint32_t op = PPC_OPCD(iw);
+    if (op >= 48 && op <= 55)
+        return true;
+    if (op != 31)
+        return false;
+    uint32_t xo = PPC_XO10(iw);
+    return xo == 535 || xo == 567 || xo == 599 || xo == 631 || xo == 663 || xo == 695 || xo == 727 || xo == 759 ||
+           xo == 983; // stfiwx included (604-only encoding)
 }
 
 // MASK(MB,ME): 1-bits from BE bit MB through BE bit ME, wrapping when
@@ -279,11 +339,13 @@ static inline bool ppc_dxlate(ppc_t *p, uint32_t iw, uint32_t *addr, bool store)
     return ppc_dxlate_slow(p, iw, addr, store);
 }
 
-// Live RTC/DEC derivation (§3.7).  With no time binding these return the
-// stored SPR values unchanged.
+// Live RTC/TB/DEC derivation (§3.7).  With no time binding these return
+// the stored SPR values unchanged.  The RTC pair is 601 semantics; the TB
+// functions are 604 semantics over the same rtcu/rtcl storage.
 uint64_t ppc_ticks_now(ppc_t *p);
 uint32_t ppc_rtcu_now(ppc_t *p);
 uint32_t ppc_rtcl_now(ppc_t *p);
+uint64_t ppc_tb_now(ppc_t *p); // 604: TBU||TBL as one 64-bit counter
 uint32_t ppc_dec_now(ppc_t *p);
 void ppc_dec_arm(ppc_t *p); // (re)schedule the DEC sign-transition event
 
@@ -345,10 +407,19 @@ static inline bool ppc_fp_check(ppc_t *p) {
     return false;
 }
 
+// Scalar access gate shared by the CHKA_LD/CHKA_ST macros (ppc_run.c):
+// per-model alignment rules plus translation.  Returns -1 when an
+// exception was raised (abandon), 0 to proceed with a normal access at
+// *addr, +1 when the access was completed byte-wise here — the 604's
+// hardware-split page-crossing case (604UM §4.5.6): loads deliver the raw
+// big-endian value via *val, stores consumed it.
+int ppc_scalar_gate(ppc_t *p, uint32_t iw, uint32_t *addr, uint32_t size, bool store, uint64_t *val);
+
 // Multi-statement instruction bodies (ppc_run.c) referenced by the OP_
 // one-liner table: branches, divides with their deterministic-undefined
 // results, string transfers, and the store-conditional.
 void ppc_illegal_op(ppc_t *p, uint32_t iw);
+void ppc_do_mftb(ppc_t *p, uint32_t iw); // 604 mftb/mftbu (in ppc.c beside the SPR file)
 void ppc_do_divw(ppc_t *p, uint32_t iw);
 void ppc_do_divwu(ppc_t *p, uint32_t iw);
 void ppc_do_doz(ppc_t *p, uint32_t iw);
@@ -381,6 +452,10 @@ void ppc_do_mtfsf(ppc_t *p, uint32_t iw);
 void ppc_do_mtfsfi(ppc_t *p, uint32_t iw);
 void ppc_do_mtfsb(ppc_t *p, uint32_t iw, bool set);
 void ppc_fp_trap_check(ppc_t *p);
+// 604 optional-FP group (PEM fselx/fresx/frsqrtex pages)
+void ppc_do_fsel(ppc_t *p, uint32_t iw);
+void ppc_do_fres(ppc_t *p, uint32_t iw);
+void ppc_do_frsqrte(ppc_t *p, uint32_t iw);
 
 // The interpreter proper is generated from ppc_decode.h as a static
 // function inside ppc_run.c (single call site, inlined into the sprint

--- a/src/core/cpu/ppc/ppc_mmu.c
+++ b/src/core/cpu/ppc/ppc_mmu.c
@@ -2,9 +2,9 @@
 // Copyright (c) pappadf
 
 // ppc_mmu.c
-// The 601 MMU front end (Phase D, proposal-powerpc-601-pdm.md §3.5):
-// T=1 I/O-controller segments, BAT match, and the hashed page table
-// search, with three software caches in front of the full walk:
+// The 601/604 MMU front end (proposal-powerpc-601-pdm.md §3.5; TNT
+// proposal §4.3): T=1 I/O-controller segments, BAT match, and the hashed
+// page table search, with three software caches in front of the full walk:
 //
 //   1. the user SoA fast path — with MSR[PR]=1 and MSR[DT]=1 the active
 //      maps are g_user_read/write, which hold LOGICAL page fills made
@@ -41,6 +41,22 @@
 //     on exactly that granularity;
 //   - the $00A00 I/O controller error resumes at the FOLLOWING
 //     instruction with DSISR unchanged (Table 5-21).
+//
+// 604-specific rules (604UM Ch. 5, PEM Ch. 7), keyed on cpu_model:
+//   - the ARCHITECTED BAT format — BEPI/BL/Vs/Vp upper, BRPN/WIMG/PP
+//     lower — with four SPLIT pairs each way: instruction translation
+//     consults the IBATs (batu/batl), data the DBATs;
+//   - BATs take precedence over the segment: T=1 is consulted only after
+//     a BAT miss, and with MSR[DR]=0 there is no segment consult at all
+//     (real addressing mode — sr_t_mask stays zero on this model);
+//   - a direct-store access that no BAT claimed takes the DSI/ISI path
+//     (no XIO device exists): DSISR[0] direct-store error (atomics and
+//     external control DSISR[5]), ISI SRR1[3] for fetches — there is no
+//     $00A00 vector on the 604;
+//   - ISI SRR1 for an HTAB miss sets bit 1 alone ($40000000 — no 601
+//     bit-10 companion);
+//   - tlbie invalidates the class selected by EA[14-19] — 64 classes,
+//     both TLBs (604UM §5.4.3.2; the 64-iteration flush idiom).
 
 #include "ppc_internal.h"
 
@@ -83,8 +99,11 @@ static uint32_t g_fill_track[PPC_FILL_TRACK_MAX];
 static int g_fill_track_count;
 static bool g_fill_track_overflow = true; // conservative until first inval
 
-// tlbie congruence class: EA[13-19] = 128 classes (601UM Figure 6-15).
-#define TLBIE_CLASS_MASK 127u
+// tlbie congruence class: 601 EA[13-19] = 128 classes (601UM Figure 6-15);
+// 604 EA[14-19] = 64 classes (604UM §5.4.3.2).
+static inline uint32_t tlbie_class_mask(const ppc_t *p) {
+    return ppc_is_604(p) ? 63u : 127u;
+}
 
 // ============================================================
 // Invalidation
@@ -135,40 +154,44 @@ void ppc_mmu_invalidate_all(ppc_t *p) {
 }
 
 // tlbie: invalidate the EA's congruence class — every cached translation
-// whose page index matches modulo 128.  Over-invalidation relative to
-// the hardware's two-way class is fine; under-invalidation would break
-// the kernel's FlushTLB loop (one tlbie per class over 1 MB).
+// whose page index matches modulo the model's class count (128 on the
+// 601, 64 on the 604).  Over-invalidation relative to the hardware's
+// two-way class is fine; under-invalidation would break the kernel's
+// flush loops (one tlbie per class).
 void ppc_mmu_tlbie(ppc_t *p, uint32_t ea) {
-    (void)p;
-    uint32_t cls = (ea >> PAGE_SHIFT) & TLBIE_CLASS_MASK;
+    uint32_t mask = tlbie_class_mask(p);
+    uint32_t cls = (ea >> PAGE_SHIFT) & mask;
     if (g_fill_track_overflow) {
         user_soa_invalidate_all();
     } else {
         for (int i = 0; i < g_fill_track_count; i++) {
             uint32_t pg = g_fill_track[i];
-            if ((pg & TLBIE_CLASS_MASK) != cls || pg >= g_page_count)
+            if ((pg & mask) != cls || pg >= g_page_count)
                 continue;
             g_user_read[pg] = 0;
             g_user_write[pg] = 0;
         }
     }
     for (int i = 0; i < XTLB_SIZE; i++)
-        if (((g_xtlb[i].tag >> PAGE_SHIFT) & TLBIE_CLASS_MASK) == cls)
+        if (((g_xtlb[i].tag >> PAGE_SHIFT) & mask) == cls)
             g_xtlb[i].tag = 0;
     for (int i = 0; i < FTLB_SIZE; i++)
-        if (((g_ftlb[i].tag >> PAGE_SHIFT) & TLBIE_CLASS_MASK) == cls)
+        if (((g_ftlb[i].tag >> PAGE_SHIFT) & mask) == cls)
             g_ftlb[i].tag = 0;
     g_ppc_fetch.span = 0;
 }
 
 // Recompute the which-segments-have-T=1 mask consulted by the inline
-// translation-off fast path (data accesses reach T=1 segments even with
-// MSR[DT]=0 — 601UM §6.5.2).
+// translation-off fast path (601 data accesses reach T=1 segments even
+// with MSR[DT]=0 — 601UM §6.5.2).  The 604 in real addressing mode never
+// consults a segment (PEM §7.2), so its mask stays zero and the fast path
+// short-circuits every translation-off access.
 void ppc_recompute_sr_t_mask(ppc_t *p) {
     uint32_t m = 0;
-    for (int i = 0; i < 16; i++)
-        if (p->sr[i] & 0x80000000u)
-            m |= 1u << i;
+    if (!ppc_is_604(p))
+        for (int i = 0; i < 16; i++)
+            if (p->sr[i] & 0x80000000u)
+                m |= 1u << i;
     p->sr_t_mask = m;
 }
 
@@ -240,6 +263,44 @@ static bool bat_xlate(ppc_t *p, uint32_t ea, bool user, bool store, xl_out_t *ou
     return false;
 }
 
+// Architected BAT protection (PEM Table 7-16): PP 00 = no access,
+// x1 = read-only, 10 = read/write.  No key participates.
+static inline bool bat604_pp_allows(uint32_t pp, bool store) {
+    if (pp == 0u)
+        return false;
+    if (pp & 1u)
+        return !store;
+    return true;
+}
+
+// 604 BAT match + protection over one of the split files (PEM §7.4.2,
+// Figure 7-13): BATU = BEPI[0:14] | BL[19:29] | Vs[30] | Vp[31]; BATL =
+// BRPN[0:14] | WIMG[25:28] | PP[30:31].  Validity is per-mode (Vs
+// supervisor / Vp user), block sizes 128 KB (BL=0) through 256 MB.
+static bool bat604_xlate(const uint32_t *batu, const uint32_t *batl, uint32_t ea, bool user, bool store, xl_out_t *out,
+                         xl_result_t *res) {
+    for (int i = 0; i < 4; i++) {
+        uint32_t bu = batu[i];
+        if (!(bu & (user ? 1u : 2u)))
+            continue; // Vp / Vs
+        uint32_t cmp_mask = ~((((bu >> 2) & 0x7FFu) << 17) | 0x1FFFFu);
+        if ((ea & cmp_mask) != (bu & 0xFFFE0000u & cmp_mask))
+            continue;
+        uint32_t bl = batl[i];
+        uint32_t pp = bl & 3u;
+        if (!bat604_pp_allows(pp, store)) {
+            *res = XL_PROT;
+            return true;
+        }
+        out->pa = ((bl & 0xFFFE0000u) & cmp_mask) | (ea & ~cmp_mask);
+        out->wimg = (bl >> 4) & 7u; // W/I/M in the shared 3-bit convention (G unmodeled)
+        out->w_ok = bat604_pp_allows(pp, true); // no C bit on BAT mappings
+        *res = XL_OK;
+        return true;
+    }
+    return false;
+}
+
 // Resolve physical RAM/ROM to a host pointer during the table search.
 // The PDM identity page table is the physical resolver of record (it
 // tracks HMC bank moves); HTAB reads must not touch the mode-dependent
@@ -303,22 +364,51 @@ static xl_result_t htab_search(ppc_t *p, uint32_t ea, uint32_t sr, bool user, bo
     return XL_NOTFOUND;
 }
 
-// Full translation for one access.  601 order (Figure 6-4, Table 6-10):
-// the segment's T bit decides first — T=1 prevails over any BAT match —
-// then BAT, then the hashed table.  `translation_on` reflects MSR[DT]
-// (or MSR[IT] for fetches): with it off only T=1 segments translate.
-static xl_result_t xlate(ppc_t *p, uint32_t ea, bool user, bool store, bool translation_on, bool nosideffect,
-                         xl_out_t *out) {
-    uint32_t sr = p->sr[ea >> 28];
-    if (sr & 0x80000000u) { // T=1: I/O controller interface segment
-        if (((sr >> 20) & 0x1FFu) == 0x07Fu) { // memory-forced BUID
-            out->pa = ((sr & 0xFu) << 28) | (ea & 0x0FFFFFFFu);
-            out->wimg = 0x3u; // WIM assumed 011 (§6.10.4)
-            out->w_ok = true; // bypasses all protection
+// The memory-forced direct-store case shared by both models: a T=1
+// segment with BUID $07F maps straight to memory (601UM §6.10.4; PEM
+// §7.8 defines the same encoding architecturally).
+static inline bool tseg_memory_forced(uint32_t sr, uint32_t ea, xl_out_t *out) {
+    if (((sr >> 20) & 0x1FFu) != 0x07Fu)
+        return false;
+    out->pa = ((sr & 0xFu) << 28) | (ea & 0x0FFFFFFFu);
+    out->wimg = 0x3u; // WIM assumed 011 (§6.10.4)
+    out->w_ok = true; // bypasses all protection
+    return true;
+}
+
+// Full translation for one access.  `translation_on` reflects MSR[DT] (or
+// MSR[IT] for fetches); `ifetch` selects the 604's IBAT file over the
+// DBATs (the 601's unified BATs serve both sides).
+//
+// 601 order (Figure 6-4, Table 6-10): the segment's T bit decides first —
+// T=1 prevails over any BAT match — then BAT, then the hashed table; with
+// translation off only T=1 segments translate.
+//
+// 604 order (PEM §7.4/7.5): with translation off, real addressing mode —
+// EA = PA, nothing consulted; with it on, BATs take precedence and the
+// segment (T=1 direct-store, else the hashed table) is reached only on a
+// BAT miss.
+static xl_result_t xlate(ppc_t *p, uint32_t ea, bool user, bool store, bool ifetch, bool translation_on,
+                         bool nosideffect, xl_out_t *out) {
+    if (ppc_is_604(p)) {
+        if (!translation_on) { // real addressing mode
+            out->pa = ea;
+            out->wimg = 1u;
+            out->w_ok = true;
             return XL_OK;
         }
-        return XL_IOSEG;
+        xl_result_t res;
+        if (bat604_xlate(ifetch ? p->batu : p->dbatu, ifetch ? p->batl : p->dbatl, ea, user, store, out, &res))
+            return res;
+        uint32_t sr = p->sr[ea >> 28];
+        if (sr & 0x80000000u)
+            return tseg_memory_forced(sr, ea, out) ? XL_OK : XL_IOSEG;
+        return htab_search(p, ea, sr, user, store, nosideffect, out);
     }
+
+    uint32_t sr = p->sr[ea >> 28];
+    if (sr & 0x80000000u) // T=1: I/O controller interface segment
+        return tseg_memory_forced(sr, ea, out) ? XL_OK : XL_IOSEG;
     if (!translation_on) { // direct translation: EA = PA, no protection
         out->pa = ea;
         out->wimg = 1u; // WIM = 001 (§6.6)
@@ -380,25 +470,16 @@ static void raise_dsi(ppc_t *p, uint32_t ea, uint32_t dsisr) {
     ppc_exception(p, PPC_VEC_DSI, 0, p->instruction_pc);
 }
 
-// True when iw is lwarx/stwcx./lscbx — the three instructions that take
-// a DSI (DSISR bit 5) instead of completing in a T=1 segment.
-static bool iw_is_atomic_class(uint32_t iw) {
+// True when iw takes a DSI with DSISR bit 5 instead of completing in a
+// T=1 segment: lwarx/stwcx./lscbx on the 601; lwarx/stwcx./eciwx/ecowx on
+// the 604 (Table 4-9 — its lscbx is illegal long before memory access).
+static bool iw_is_atomic_class(ppc_t *p, uint32_t iw) {
     if (PPC_OPCD(iw) != 31)
         return false;
     uint32_t xo = PPC_XO10(iw);
-    return xo == 20 || xo == 150 || xo == 277;
-}
-
-// True when iw is a floating-point load/store (alignment exception in a
-// non-memory-forced T=1 segment, 601UM §5.4.10).
-static bool iw_is_fp_ls(uint32_t iw) {
-    uint32_t op = PPC_OPCD(iw);
-    if (op >= 48 && op <= 55)
+    if (xo == 20 || xo == 150)
         return true;
-    if (op != 31)
-        return false;
-    uint32_t xo = PPC_XO10(iw);
-    return xo == 535 || xo == 567 || xo == 599 || xo == 631 || xo == 663 || xo == 695 || xo == 727 || xo == 759;
+    return ppc_is_604(p) ? (xo == 310 || xo == 438) : xo == 277;
 }
 
 // See ppc_internal.h for the contract: on return false *addr is the
@@ -425,18 +506,25 @@ bool ppc_dxlate_slow(ppc_t *p, uint32_t iw, uint32_t *addr, bool store) {
     }
 
     xl_out_t out;
-    xl_result_t res = xlate(p, ea, user, store, dt, false, &out);
+    xl_result_t res = xlate(p, ea, user, store, false, dt, false, &out);
     if (res == XL_IOSEG) {
-        // Non-memory-forced T=1: atomics take a DSI (DSISR bit 5), FP
-        // load/stores the alignment exception; everything else models
-        // the failed bus reply as the 601-only $00A00 I/O controller
-        // error — SRR0 = FOLLOWING instruction, DSISR unchanged
-        // (601UM Table 5-21).  No I/O controller exists on PDM.
-        if (iw_is_atomic_class(iw)) {
-            raise_dsi(p, ea, 0x04000000u | (store ? PPC_DSISR_STORE : 0));
+        // Non-memory-forced T=1: the atomics/external-control class takes
+        // a DSI with DSISR bit 5 on both models.  Past that they diverge:
+        // the 601 gives FP load/stores the alignment exception and models
+        // everything else as the 601-only $00A00 I/O controller error —
+        // SRR0 = FOLLOWING instruction, DSISR unchanged (601UM Table
+        // 5-21); the 604 has no $00A00 and delivers the direct-store
+        // error DSI (DSISR bit 0 — no XIO device ever answers, 604UM
+        // Table 4-9 / Table 4-2 DSI row).
+        if (iw_is_atomic_class(p, iw)) {
+            raise_dsi(p, ea, PPC_DSISR_ATOMIC | (store ? PPC_DSISR_STORE : 0));
             return true;
         }
-        if (iw_is_fp_ls(iw)) {
+        if (ppc_is_604(p)) {
+            raise_dsi(p, ea, PPC_DSISR_DIRECT | (store ? PPC_DSISR_STORE : 0));
+            return true;
+        }
+        if (ppc_iw_is_fp_ls(iw)) {
             ppc_align_exception(p, iw, ea);
             return true;
         }
@@ -482,23 +570,36 @@ bool ppc_dxlate_slow(ppc_t *p, uint32_t iw, uint32_t *addr, bool store) {
     return false;
 }
 
-// dcbz's translated form (601UM Table 6-3): a W=1 or I=1 mapping takes
-// the alignment exception (R already updated by the walk); a
-// non-memory-forced T=1 segment makes it a no-op.  The framebuffer is
-// mapped write-through, so the W case is guest-visible, not a corner.
+// dcbz's translated form (601UM Table 6-3; 604UM §4.5.6): a W=1 or I=1
+// mapping takes the alignment exception (R already updated by the walk);
+// a non-memory-forced T=1 segment makes it a no-op (§6.10.6 / PEM "cache
+// operations to direct-store are no-ops"); the 604 additionally takes the
+// alignment exception with its data cache disabled or locked (HID0[17]
+// clear / HID0[19] set — the reset state until the ROM enables caches).
+// The framebuffer is mapped write-through, so the W case is
+// guest-visible, not a corner.
 // Returns: 0 = proceed (zero at *addr), 1 = exception raised, 2 = no-op.
 int ppc_dxlate_dcbz(ppc_t *p, uint32_t iw, uint32_t *addr) {
     uint32_t ea = *addr;
     bool dt = (p->msr & PPC_MSR_DT) != 0;
+    bool is604 = ppc_is_604(p);
+    if (is604 && (!(p->hid0 & 0x00004000u) || (p->hid0 & 0x00001000u))) { // DCE clear or DCL set
+        ppc_align_exception(p, iw, ea);
+        return 1;
+    }
     if (!dt && !(p->sr_t_mask & (1u << (ea >> 28))))
-        return 0; // direct translation: plain zeroing
+        return 0; // direct translation: plain zeroing (mask covers the 604 unconditionally)
     bool user = (p->msr & PPC_MSR_PR) != 0;
     uint32_t sr = p->sr[ea >> 28];
-    if ((sr & 0x80000000u) && ((sr >> 20) & 0x1FFu) != 0x07Fu)
+    // 601 order: T=1 prevails, so the no-op is decided before any walk.
+    // The 604 checks T only after a BAT miss — the xlate result decides.
+    if (!is604 && (sr & 0x80000000u) && ((sr >> 20) & 0x1FFu) != 0x07Fu)
         return 2; // T=1 I/O controller: no-op (§6.10.6)
 
     xl_out_t out;
-    xl_result_t res = xlate(p, ea, user, true, dt, false, &out);
+    xl_result_t res = xlate(p, ea, user, true, false, dt, false, &out);
+    if (res == XL_IOSEG)
+        return 2; // 604 direct-store after BAT miss: cache-op no-op
     if (res == XL_PROT) {
         raise_dsi(p, ea, PPC_DSISR_PROT | PPC_DSISR_STORE);
         return 1;
@@ -507,10 +608,11 @@ int ppc_dxlate_dcbz(ppc_t *p, uint32_t iw, uint32_t *addr) {
         raise_dsi(p, ea, PPC_DSISR_NOTFOUND | PPC_DSISR_STORE);
         return 1;
     }
-    // Memory-forced T=1 zeroes real memory (WIM 011 describes the bus
-    // attributes; HWInit's RAM work runs through these segments) — the
-    // W/I alignment rule applies to BAT/page mappings only.
-    if (!(sr & 0x80000000u) && (out.wimg & 0x6u)) { // W or I
+    // 601: memory-forced T=1 zeroes real memory (WIM 011 describes the
+    // bus attributes; HWInit's RAM work runs through these segments) —
+    // its W/I alignment rule applies to BAT/page mappings only.  The 604
+    // faults any noncacheable/write-through target (604UM §4.5.6).
+    if ((is604 || !(sr & 0x80000000u)) && (out.wimg & 0x6u)) { // W or I
         ppc_align_exception(p, iw, ea);
         return 1;
     }
@@ -549,11 +651,12 @@ bool ppc_fetch_fill(ppc_t *p, uint32_t pc, uint32_t *iw) {
             return true;
         }
         xl_out_t out;
-        xl_result_t res = xlate(p, pc, user, false, true, false, &out);
+        xl_result_t res = xlate(p, pc, user, false, true, true, false, &out);
         if (res == XL_IOSEG) {
-            // T=1 fetch: ISI with NO SRR1 status bits (601 quirk,
-            // Table 6-3 footnote).
-            ppc_exception(p, PPC_VEC_ISI, 0, pc);
+            // T=1 fetch: the 601 raises ISI with NO SRR1 status bits
+            // (quirk, Table 6-3 footnote); the 604 sets the architected
+            // direct-store-fetch bit SRR1[3] (PEM Table 7-14).
+            ppc_exception(p, PPC_VEC_ISI, ppc_is_604(p) ? 0x10000000u : 0, pc);
             return false;
         }
         if (res == XL_PROT) {
@@ -561,17 +664,19 @@ bool ppc_fetch_fill(ppc_t *p, uint32_t pc, uint32_t *iw) {
             return false;
         }
         if (res != XL_OK) {
-            // HTAB miss: SRR1 bit 1 ONLY ($40000000).  We used to set
-            // bit 10 as well because the nanokernel's InstStorageInt
-            // masks $40200000 — but it does that with `andis. r8,r11,
-            // $4020` followed by `beq` (ROM file offset $311878, the
-            // only such instruction in the image), so either bit alone
-            // satisfies it.  Bit 10 is NOT a page-fault bit, and
-            // Copland's GetFaultInformation reads it as one of the two
-            // hard-error bits ($10200000) and turns an ordinary
-            // instruction page fault into kAccessException — which
-            // panicked its kernel.  Two independent guests only agree
-            // if a 601 leaves bit 10 clear for an HTAB miss.
+            // HTAB miss: SRR1 bit 1 ONLY ($40000000), on BOTH models.
+            // We used to set bit 10 as well on the 601 because the
+            // nanokernel's InstStorageInt masks $40200000 — but it does
+            // that with `andis. r8,r11,$4020` followed by `beq` (ROM
+            // file offset $311878, the only such instruction in the
+            // image), so either bit alone satisfies it.  Bit 10 is NOT
+            // a page-fault bit, and Copland's GetFaultInformation reads
+            // it as one of the two hard-error bits ($10200000) and
+            // turns an ordinary instruction page fault into
+            // kAccessException — which panicked its kernel.  Two
+            // independent guests only agree if a 601 leaves bit 10
+            // clear for an HTAB miss; the 604's architected value is
+            // bit 1 alone anyway.
             ppc_exception(p, PPC_VEC_ISI, 0x40000000u, pc);
             return false;
         }
@@ -626,12 +731,12 @@ uint32_t ppc_mmu_translate_debug(ppc_t *p, uint32_t ea, bool data, bool *ok) {
         return ea; // fetch with IT off is always direct
     bool user = (p->msr & PPC_MSR_PR) != 0;
     xl_out_t out;
-    xl_result_t res = xlate(p, ea, user, false, on, true, &out);
+    xl_result_t res = xlate(p, ea, user, false, !data, on, true, &out);
     if (res == XL_OK)
         return out.pa;
     // Protection failures still resolve for debug reads (retry with the
     // supervisor key); only a true miss reports failure.
-    if (res == XL_PROT && xlate(p, ea, false, false, on, true, &out) == XL_OK)
+    if (res == XL_PROT && xlate(p, ea, false, false, !data, on, true, &out) == XL_OK)
         return out.pa;
     if (ok)
         *ok = false;
@@ -647,10 +752,10 @@ uint32_t ppc_mmu_translate_mac(ppc_t *p, uint32_t ea, bool *ok) {
     xl_out_t out;
     if (ok)
         *ok = true;
-    xl_result_t res = xlate(p, ea, true, false, true, true, &out);
+    xl_result_t res = xlate(p, ea, true, false, false, true, true, &out);
     if (res == XL_OK)
         return out.pa;
-    if (res == XL_PROT && xlate(p, ea, false, false, true, true, &out) == XL_OK)
+    if (res == XL_PROT && xlate(p, ea, false, false, false, true, true, &out) == XL_OK)
         return out.pa;
     if (ok)
         *ok = false;

--- a/src/core/cpu/ppc/ppc_ops.h
+++ b/src/core/cpu/ppc/ppc_ops.h
@@ -2,7 +2,7 @@
 // Copyright (c) pappadf
 
 // ppc_ops.h
-// The PPC (MPC601) emulator's instruction bodies: factored helpers first,
+// The PPC (MPC601/MPC604) emulator's instruction bodies: factored helpers first,
 // then the one-liner OP_ table that overloads the shared decode tree
 // (ppc_decode.h) with execution content — the cpu_ops.h pattern
 // (proposal-heterogeneous-multi-cpu.md §3.3.1).  Included by ppc_run.c
@@ -17,13 +17,19 @@
 #include "ppc_internal.h"
 #include "ppc_softfp.h" // FPSCR bits + the PPC_SF_ op enum
 
-// === Alignment exceptions (601UM §5.4.6) ====================================
+// === Alignment exceptions (601UM §5.4.6; 604UM §4.5.6) ======================
 //
-// With data translation ON (MSR[DT]=1) a scalar operand that spans a 4 KB
-// page boundary takes the alignment exception; with translation OFF only a
-// 256 MB boundary crossing does.  String/multiple accesses fault on any page
-// crossing when unaligned, and on 256 MB crossings even when word-aligned;
-// lscbx faults on any page crossing regardless of alignment.
+// 601: with data translation ON (MSR[DT]=1) a scalar operand that spans a
+// 4 KB page boundary takes the alignment exception; with translation OFF
+// only a 256 MB boundary crossing does.  String/multiple accesses fault on
+// any page crossing when unaligned, and on 256 MB crossings even when
+// word-aligned; lscbx faults on any page crossing regardless of alignment.
+// 604: only FP loads/stores, lmw/stmw, lwarx/stwcx. and eciwx/ecowx that
+// are not word-aligned take the alignment exception — every other
+// misaligned access is split by hardware, which ppc_scalar_gate models
+// byte-wise when a translated access crosses a page.  The string rules are
+// kept 601-shaped on both models (implementation-specific per the PEM;
+// ladder-observable).
 // (ppc_align_exception itself lives in ppc_internal.h — the MMU raises it
 // for dcbz-to-W/I pages and FP accesses to I/O controller segments.)
 
@@ -193,11 +199,20 @@ static inline void ppc_sra_mq_ca(ppc_t *p, uint32_t rot, uint32_t mask, uint32_t
 // slow translation).  `ea` itself stays LOGICAL so the update forms
 // write back the architected EA, and translation happens before any
 // register writeback (a faulted access abandons with no side effects).
-// CHKA_* additionally run the scalar alignment check.
+// M601/M604 reject the other model's encodings with the illegal program
+// exception (TNT proposal §4.2 — decode-tree validity per model).
+// CHKA_* route through ppc_scalar_gate (per-model alignment + the 604's
+// hardware-split page crossings): loads read their value via LDV(bits) —
+// the gate's byte-wise value when it split, a normal access at xa
+// otherwise — and stores capture the value into `sv_` up front so the
+// gate can consume it when it splits.
 #define PRIV()  if (ppc_priv_check(p)) break
 #define FP()    if (ppc_fp_check(p)) break
-#define CHKA_LD(ea, sz) uint32_t xa = ea; if (ppc_check_align_scalar(p, iw, xa, sz) || ppc_dxlate(p, iw, &xa, false)) break
-#define CHKA_ST(ea, sz) uint32_t xa = ea; if (ppc_check_align_scalar(p, iw, xa, sz) || ppc_dxlate(p, iw, &xa, true)) break
+#define M601()  if (ppc_is_604(p)) { ppc_illegal_op(p, iw); break; }
+#define M604()  if (!ppc_is_604(p)) { ppc_illegal_op(p, iw); break; }
+#define CHKA_LD(ea, sz) uint32_t xa = ea; uint64_t lv_ = 0; int lg_ = ppc_scalar_gate(p, iw, &xa, sz, false, &lv_); if (lg_ < 0) break
+#define CHKA_ST(ea, sz, vexpr) uint32_t xa = ea; uint64_t sv_ = (vexpr); if (ppc_scalar_gate(p, iw, &xa, sz, true, &sv_) != 0) break
+#define LDV(bits)       (lg_ ? (uint##bits##_t)lv_ : READ(bits, xa))
 #define XLT_LD(ea)      uint32_t xa = ea; if (ppc_dxlate(p, iw, &xa, false)) break
 #define XLT_ST(ea)      uint32_t xa = ea; if (ppc_dxlate(p, iw, &xa, true)) break
 
@@ -219,7 +234,7 @@ static inline void ppc_sra_mq_ca(ppc_t *p, uint32_t rot, uint32_t mask, uint32_t
 #define OP_TW         OP(if (ppc_trap_cond(RT, GPR(RA), GPR(RB))) ppc_exception(p, PPC_VEC_PROGRAM, PPC_SRR1_PROG_TRAP, p->instruction_pc))
 #define OP_MULLI      OP(GPR(RT) = (uint32_t)((int64_t)(int32_t)GPR(RA) * PPC_SIMM(iw)))
 #define OP_SUBFIC     OP(GPR(RT) = ppc_subf_body(p, GPR(RA), SIMM32, 1, true, false))
-#define OP_DOZI       OP(GPR(RT) = ((int32_t)GPR(RA) > PPC_SIMM(iw)) ? 0u : SIMM32 - GPR(RA))
+#define OP_DOZI       OP(M601(); GPR(RT) = ((int32_t)GPR(RA) > PPC_SIMM(iw)) ? 0u : SIMM32 - GPR(RA))
 #define OP_CMPLI      OP(ppc_cmp_unsigned(p, PPC_CRFD(iw), GPR(RA), UIMM16))
 #define OP_CMPI       OP(ppc_cmp_signed(p, PPC_CRFD(iw), (int32_t)GPR(RA), PPC_SIMM(iw)))
 #define OP_CMPL       OP(ppc_cmp_unsigned(p, PPC_CRFD(iw), GPR(RA), GPR(RB)))
@@ -238,7 +253,10 @@ static inline void ppc_sra_mq_ca(ppc_t *p, uint32_t rot, uint32_t mask, uint32_t
 // 5-22 — the POWER svc field, which §5.4.11's prose calls "undefined"; the
 // table is the specific rule and costs nothing to honour).
 #define OP_SC         OP(ppc_exception(p, PPC_VEC_SYSCALL, (iw & 0xFFFFu) << 16, p->pc))
-#define OP_RFI        OP(PRIV(); p->msr = (p->srr1 & 0x0000FFFFu) & PPC_MSR_MASK; ppc_update_active_maps(p); p->pc = p->srr0 & ~3u)
+// rfi restores MSR[16-31] from SRR1; bits outside that half (the 604's POW)
+// are untouched — identical to the old whole-word form on the 601, whose
+// implemented bits all live in the low half.
+#define OP_RFI        OP(PRIV(); p->msr = ((p->msr & 0xFFFF0000u) | (p->srr1 & 0x0000FFFFu)) & ppc_msr_mask(p); ppc_update_active_maps(p); p->pc = p->srr0 & ~3u)
 #define OP_ISYNC      OP((void)0) // context synchronize; no pipeline to flush
 
 // --- CR logical (601UM XL-forms): a/b are the source CR bits ---
@@ -256,7 +274,7 @@ static inline void ppc_sra_mq_ca(ppc_t *p, uint32_t rot, uint32_t mask, uint32_t
 // --- rotates ---
 #define OP_RLWIMI     OP(uint32_t m_ = ppc_mask(PPC_MB(iw), PPC_ME(iw)); RECA((ppc_rotl(GPR(RT), RB) & m_) | (GPR(RA) & ~m_)))
 #define OP_RLWINM     OP(RECA(ppc_rotl(GPR(RT), RB) & ppc_mask(PPC_MB(iw), PPC_ME(iw))))
-#define OP_RLMI       OP(uint32_t m_ = ppc_mask(PPC_MB(iw), PPC_ME(iw)); RECA((ppc_rotl(GPR(RT), GPR(RB) & 31u) & m_) | (GPR(RA) & ~m_)))
+#define OP_RLMI       OP(M601(); uint32_t m_ = ppc_mask(PPC_MB(iw), PPC_ME(iw)); RECA((ppc_rotl(GPR(RT), GPR(RB) & 31u) & m_) | (GPR(RA) & ~m_)))
 #define OP_RLWNM      OP(RECA(ppc_rotl(GPR(RT), GPR(RB) & 31u) & ppc_mask(PPC_MB(iw), PPC_ME(iw))))
 
 // --- logical immediates ---
@@ -286,13 +304,13 @@ static inline void ppc_sra_mq_ca(ppc_t *p, uint32_t rot, uint32_t mask, uint32_t
 #define OP_DIVWU      OP(ppc_do_divwu(p, iw))
 
 // --- POWER arithmetic holdovers ---
-#define OP_ABS        OP(if (PPC_OE(iw)) ppc_set_ov(p, GPR(RA) == 0x80000000u); RECT(((int32_t)GPR(RA) < 0) ? 0u - GPR(RA) : GPR(RA)))
-#define OP_NABS       OP(if (PPC_OE(iw)) p->xer &= ~PPC_XER_OV; RECT(((int32_t)GPR(RA) < 0) ? GPR(RA) : 0u - GPR(RA))) // never overflows
-#define OP_DOZ        OP(ppc_do_doz(p, iw))
-#define OP_MUL        OP(ppc_do_mul(p, iw))
-#define OP_DIV        OP(ppc_do_div(p, iw))
-#define OP_DIVS       OP(ppc_do_divs(p, iw))
-#define OP_CLCS       OP(RECT(64)) // line size is 64 for every valid rA code
+#define OP_ABS        OP(M601(); if (PPC_OE(iw)) ppc_set_ov(p, GPR(RA) == 0x80000000u); RECT(((int32_t)GPR(RA) < 0) ? 0u - GPR(RA) : GPR(RA)))
+#define OP_NABS       OP(M601(); if (PPC_OE(iw)) p->xer &= ~PPC_XER_OV; RECT(((int32_t)GPR(RA) < 0) ? GPR(RA) : 0u - GPR(RA))) // never overflows
+#define OP_DOZ        OP(M601(); ppc_do_doz(p, iw))
+#define OP_MUL        OP(M601(); ppc_do_mul(p, iw))
+#define OP_DIV        OP(M601(); ppc_do_div(p, iw))
+#define OP_DIVS       OP(M601(); ppc_do_divs(p, iw))
+#define OP_CLCS       OP(M601(); RECT(64)) // line size is 64 for every valid rA code
 
 // --- logical ---
 #define OP_AND        OP(RECA(GPR(RT) & GPR(RB)))
@@ -314,24 +332,24 @@ static inline void ppc_sra_mq_ca(ppc_t *p, uint32_t rot, uint32_t mask, uint32_t
 #define OP_SRAWI      OP(uint32_t n_ = RB, s_ = GPR(RT); ppc_set_ca(p, ((int32_t)s_ < 0) && n_ != 0 && (s_ & ((1u << n_) - 1u)) != 0); RECA((uint32_t)((int32_t)s_ >> n_)))
 
 // --- POWER shift-with-MQ family (601UM chapter-10 POWER pages) ---
-#define OP_MASKG      OP(RECA(ppc_mask(GPR(RT) & 31u, GPR(RB) & 31u)))
-#define OP_MASKIR     OP(RECA((GPR(RA) & ~GPR(RB)) | (GPR(RT) & GPR(RB))))
-#define OP_RRIB       OP(RECA((GPR(RA) & ~(0x80000000u >> (GPR(RB) & 31u))) | ((GPR(RT) & 0x80000000u) >> (GPR(RB) & 31u))))
-#define OP_SLE        OP(uint32_t n_ = GPR(RB) & 31u, r_ = ppc_rotl(GPR(RT), n_); p->mq = r_; RECA(r_ & (0xFFFFFFFFu << n_)))
-#define OP_SLEQ       OP(uint32_t n_ = GPR(RB) & 31u, r_ = ppc_rotl(GPR(RT), n_), m_ = 0xFFFFFFFFu << n_; uint32_t v_ = (r_ & m_) | (p->mq & ~m_); p->mq = r_; RECA(v_))
-#define OP_SLIQ       OP(uint32_t n_ = RB, r_ = ppc_rotl(GPR(RT), n_); p->mq = r_; RECA(r_ & (0xFFFFFFFFu << n_)))
-#define OP_SLLIQ      OP(uint32_t n_ = RB, r_ = ppc_rotl(GPR(RT), n_), m_ = 0xFFFFFFFFu << n_; uint32_t v_ = (r_ & m_) | (p->mq & ~m_); p->mq = r_; RECA(v_))
-#define OP_SLLQ       OP(uint32_t n_ = GPR(RB) & 31u, m_ = 0xFFFFFFFFu << n_; RECA((GPR(RB) & 0x20u) ? (p->mq & m_) : ((ppc_rotl(GPR(RT), n_) & m_) | (p->mq & ~m_)))) // MQ unaltered
-#define OP_SLQ        OP(uint32_t n_ = GPR(RB) & 31u, r_ = ppc_rotl(GPR(RT), n_); p->mq = r_; RECA((GPR(RB) & 0x20u) ? 0 : (r_ & (0xFFFFFFFFu << n_))))
-#define OP_SRQ        OP(uint32_t n_ = GPR(RB) & 31u, r_ = ppc_rotl(GPR(RT), 32u - n_); p->mq = r_; RECA((GPR(RB) & 0x20u) ? 0 : (r_ & (0xFFFFFFFFu >> n_))))
-#define OP_SRE        OP(uint32_t n_ = GPR(RB) & 31u, r_ = ppc_rotl(GPR(RT), 32u - n_); p->mq = r_; RECA(r_ & (0xFFFFFFFFu >> n_)))
-#define OP_SRIQ       OP(uint32_t n_ = RB, r_ = ppc_rotl(GPR(RT), 32u - n_); p->mq = r_; RECA(r_ & (0xFFFFFFFFu >> n_)))
-#define OP_SRLQ       OP(uint32_t n_ = GPR(RB) & 31u, m_ = 0xFFFFFFFFu >> n_; RECA((GPR(RB) & 0x20u) ? (p->mq & m_) : ((ppc_rotl(GPR(RT), 32u - n_) & m_) | (p->mq & ~m_)))) // MQ unaltered
-#define OP_SREQ       OP(uint32_t n_ = GPR(RB) & 31u, r_ = ppc_rotl(GPR(RT), 32u - n_), m_ = 0xFFFFFFFFu >> n_; uint32_t v_ = (r_ & m_) | (p->mq & ~m_); p->mq = r_; RECA(v_))
-#define OP_SRLIQ      OP(uint32_t n_ = RB, r_ = ppc_rotl(GPR(RT), 32u - n_), m_ = 0xFFFFFFFFu >> n_; uint32_t v_ = (r_ & m_) | (p->mq & ~m_); p->mq = r_; RECA(v_))
-#define OP_SRAQ       OP(uint32_t n_ = GPR(RB) & 31u, r_ = ppc_rotl(GPR(RT), 32u - n_); uint32_t m_ = (GPR(RB) & 0x20u) ? 0u : (0xFFFFFFFFu >> n_); uint32_t s_ = GPR(RT); p->mq = r_; ppc_sra_mq_ca(p, r_, m_, s_); RECA((r_ & m_) | (((uint32_t)((int32_t)s_ >> 31)) & ~m_)))
-#define OP_SRAIQ      OP(uint32_t n_ = RB, r_ = ppc_rotl(GPR(RT), 32u - n_), m_ = 0xFFFFFFFFu >> n_; uint32_t s_ = GPR(RT); p->mq = r_; ppc_sra_mq_ca(p, r_, m_, s_); RECA((r_ & m_) | (((uint32_t)((int32_t)s_ >> 31)) & ~m_)))
-#define OP_SREA       OP(uint32_t n_ = GPR(RB) & 31u, r_ = ppc_rotl(GPR(RT), 32u - n_), m_ = 0xFFFFFFFFu >> n_; uint32_t s_ = GPR(RT); p->mq = r_; ppc_sra_mq_ca(p, r_, m_, s_); RECA((r_ & m_) | (((uint32_t)((int32_t)s_ >> 31)) & ~m_)))
+#define OP_MASKG      OP(M601(); RECA(ppc_mask(GPR(RT) & 31u, GPR(RB) & 31u)))
+#define OP_MASKIR     OP(M601(); RECA((GPR(RA) & ~GPR(RB)) | (GPR(RT) & GPR(RB))))
+#define OP_RRIB       OP(M601(); RECA((GPR(RA) & ~(0x80000000u >> (GPR(RB) & 31u))) | ((GPR(RT) & 0x80000000u) >> (GPR(RB) & 31u))))
+#define OP_SLE        OP(M601(); uint32_t n_ = GPR(RB) & 31u, r_ = ppc_rotl(GPR(RT), n_); p->mq = r_; RECA(r_ & (0xFFFFFFFFu << n_)))
+#define OP_SLEQ       OP(M601(); uint32_t n_ = GPR(RB) & 31u, r_ = ppc_rotl(GPR(RT), n_), m_ = 0xFFFFFFFFu << n_; uint32_t v_ = (r_ & m_) | (p->mq & ~m_); p->mq = r_; RECA(v_))
+#define OP_SLIQ       OP(M601(); uint32_t n_ = RB, r_ = ppc_rotl(GPR(RT), n_); p->mq = r_; RECA(r_ & (0xFFFFFFFFu << n_)))
+#define OP_SLLIQ      OP(M601(); uint32_t n_ = RB, r_ = ppc_rotl(GPR(RT), n_), m_ = 0xFFFFFFFFu << n_; uint32_t v_ = (r_ & m_) | (p->mq & ~m_); p->mq = r_; RECA(v_))
+#define OP_SLLQ       OP(M601(); uint32_t n_ = GPR(RB) & 31u, m_ = 0xFFFFFFFFu << n_; RECA((GPR(RB) & 0x20u) ? (p->mq & m_) : ((ppc_rotl(GPR(RT), n_) & m_) | (p->mq & ~m_)))) // MQ unaltered
+#define OP_SLQ        OP(M601(); uint32_t n_ = GPR(RB) & 31u, r_ = ppc_rotl(GPR(RT), n_); p->mq = r_; RECA((GPR(RB) & 0x20u) ? 0 : (r_ & (0xFFFFFFFFu << n_))))
+#define OP_SRQ        OP(M601(); uint32_t n_ = GPR(RB) & 31u, r_ = ppc_rotl(GPR(RT), 32u - n_); p->mq = r_; RECA((GPR(RB) & 0x20u) ? 0 : (r_ & (0xFFFFFFFFu >> n_))))
+#define OP_SRE        OP(M601(); uint32_t n_ = GPR(RB) & 31u, r_ = ppc_rotl(GPR(RT), 32u - n_); p->mq = r_; RECA(r_ & (0xFFFFFFFFu >> n_)))
+#define OP_SRIQ       OP(M601(); uint32_t n_ = RB, r_ = ppc_rotl(GPR(RT), 32u - n_); p->mq = r_; RECA(r_ & (0xFFFFFFFFu >> n_)))
+#define OP_SRLQ       OP(M601(); uint32_t n_ = GPR(RB) & 31u, m_ = 0xFFFFFFFFu >> n_; RECA((GPR(RB) & 0x20u) ? (p->mq & m_) : ((ppc_rotl(GPR(RT), 32u - n_) & m_) | (p->mq & ~m_)))) // MQ unaltered
+#define OP_SREQ       OP(M601(); uint32_t n_ = GPR(RB) & 31u, r_ = ppc_rotl(GPR(RT), 32u - n_), m_ = 0xFFFFFFFFu >> n_; uint32_t v_ = (r_ & m_) | (p->mq & ~m_); p->mq = r_; RECA(v_))
+#define OP_SRLIQ      OP(M601(); uint32_t n_ = RB, r_ = ppc_rotl(GPR(RT), 32u - n_), m_ = 0xFFFFFFFFu >> n_; uint32_t v_ = (r_ & m_) | (p->mq & ~m_); p->mq = r_; RECA(v_))
+#define OP_SRAQ       OP(M601(); uint32_t n_ = GPR(RB) & 31u, r_ = ppc_rotl(GPR(RT), 32u - n_); uint32_t m_ = (GPR(RB) & 0x20u) ? 0u : (0xFFFFFFFFu >> n_); uint32_t s_ = GPR(RT); p->mq = r_; ppc_sra_mq_ca(p, r_, m_, s_); RECA((r_ & m_) | (((uint32_t)((int32_t)s_ >> 31)) & ~m_)))
+#define OP_SRAIQ      OP(M601(); uint32_t n_ = RB, r_ = ppc_rotl(GPR(RT), 32u - n_), m_ = 0xFFFFFFFFu >> n_; uint32_t s_ = GPR(RT); p->mq = r_; ppc_sra_mq_ca(p, r_, m_, s_); RECA((r_ & m_) | (((uint32_t)((int32_t)s_ >> 31)) & ~m_)))
+#define OP_SREA       OP(M601(); uint32_t n_ = GPR(RB) & 31u, r_ = ppc_rotl(GPR(RT), 32u - n_), m_ = 0xFFFFFFFFu >> n_; uint32_t s_ = GPR(RT); p->mq = r_; ppc_sra_mq_ca(p, r_, m_, s_); RECA((r_ & m_) | (((uint32_t)((int32_t)s_ >> 31)) & ~m_)))
 
 // --- CR / MSR / SPR / SR moves ---
 #define OP_MFCR       OP(GPR(RT) = p->cr)
@@ -340,12 +358,14 @@ static inline void ppc_sra_mq_ca(ppc_t *p, uint32_t rot, uint32_t mask, uint32_t
 #define OP_MFSPR      OP(ppc_mfspr(p, iw))
 #define OP_MTSPR      OP(ppc_mtspr(p, iw))
 #define OP_MFMSR      OP(PRIV(); GPR(RT) = p->msr)
-#define OP_MTMSR      OP(PRIV(); p->msr = GPR(RT) & PPC_MSR_MASK; ppc_update_active_maps(p))
+#define OP_MTMSR      OP(PRIV(); p->msr = GPR(RT) & ppc_msr_mask(p); ppc_update_active_maps(p))
 #define OP_MFSR       OP(PRIV(); GPR(RT) = p->sr[(iw >> 16) & 0xFu])
 #define OP_MTSR       OP(PRIV(); ppc_set_sr(p, (iw >> 16) & 0xFu, GPR(RT)))
 #define OP_MFSRIN     OP(PRIV(); GPR(RT) = p->sr[GPR(RB) >> 28])
 #define OP_MTSRIN     OP(PRIV(); ppc_set_sr(p, GPR(RB) >> 28, GPR(RT)))
 #define OP_TLBIE      OP(PRIV(); ppc_mmu_tlbie(p, GPR(RB)))
+#define OP_MFTB       OP(M604(); ppc_do_mftb(p, iw)) // user-readable (PEM §2.2.1)
+#define OP_TLBSYNC    OP(M604(); PRIV()) // ordering only: tlbie takes effect synchronously here (604UM §5.4.3.2)
 
 // --- storage control (no cache model; semantics per proposal §3.8) ---
 #define OP_SYNC       OP((void)0)
@@ -359,42 +379,42 @@ static inline void ppc_sra_mq_ca(ppc_t *p, uint32_t rot, uint32_t mask, uint32_t
 #define OP_DCBZ       OP(EA_X(); ea &= ~31u; uint32_t xa = ea; int r_ = ppc_dxlate_dcbz(p, iw, &xa); if (r_) break; for (int i_ = 0; i_ < 8; i_++) WRITE(32, xa + 4u * (uint32_t)i_, 0)) // really zeroes the block (§3.8); W/I + T=1 rules in ppc_mmu.c
 
 // --- D-form loads/stores ---
-#define OP_LWZ        OP(EA_D();  CHKA_LD(ea, 4); GPR(RT) = READ(32, xa))
-#define OP_LWZU       OP(EA_DU(); CHKA_LD(ea, 4); UPD(); GPR(RT) = READ(32, xa))
+#define OP_LWZ        OP(EA_D();  CHKA_LD(ea, 4); GPR(RT) = LDV(32))
+#define OP_LWZU       OP(EA_DU(); CHKA_LD(ea, 4); UPD(); GPR(RT) = LDV(32))
 #define OP_LBZ        OP(EA_D();  XLT_LD(ea); GPR(RT) = READ(8, xa))
 #define OP_LBZU       OP(EA_DU(); XLT_LD(ea); UPD(); GPR(RT) = READ(8, xa))
-#define OP_STW        OP(EA_D();  CHKA_ST(ea, 4); WRITE(32, xa, GPR(RT)))
-#define OP_STWU       OP(EA_DU(); CHKA_ST(ea, 4); WRITE(32, xa, GPR(RT)); UPD())  // store before update: rS==rA stores the pre-update value
+#define OP_STW        OP(EA_D();  CHKA_ST(ea, 4, GPR(RT)); WRITE(32, xa, (uint32_t)sv_))
+#define OP_STWU       OP(EA_DU(); CHKA_ST(ea, 4, GPR(RT)); WRITE(32, xa, (uint32_t)sv_); UPD())  // store before update: rS==rA stores the pre-update value
 #define OP_STB        OP(EA_D();  XLT_ST(ea); WRITE(8, xa, (uint8_t)GPR(RT)))
 #define OP_STBU       OP(EA_DU(); XLT_ST(ea); WRITE(8, xa, (uint8_t)GPR(RT)); UPD())
-#define OP_LHZ        OP(EA_D();  CHKA_LD(ea, 2); GPR(RT) = READ(16, xa))
-#define OP_LHZU       OP(EA_DU(); CHKA_LD(ea, 2); UPD(); GPR(RT) = READ(16, xa))
-#define OP_LHA        OP(EA_D();  CHKA_LD(ea, 2); GPR(RT) = (uint32_t)(int32_t)(int16_t)READ(16, xa))
-#define OP_LHAU       OP(EA_DU(); CHKA_LD(ea, 2); UPD(); GPR(RT) = (uint32_t)(int32_t)(int16_t)READ(16, xa))
-#define OP_STH        OP(EA_D();  CHKA_ST(ea, 2); WRITE(16, xa, (uint16_t)GPR(RT)))
-#define OP_STHU       OP(EA_DU(); CHKA_ST(ea, 2); WRITE(16, xa, (uint16_t)GPR(RT)); UPD())
+#define OP_LHZ        OP(EA_D();  CHKA_LD(ea, 2); GPR(RT) = LDV(16))
+#define OP_LHZU       OP(EA_DU(); CHKA_LD(ea, 2); UPD(); GPR(RT) = LDV(16))
+#define OP_LHA        OP(EA_D();  CHKA_LD(ea, 2); GPR(RT) = (uint32_t)(int32_t)(int16_t)LDV(16))
+#define OP_LHAU       OP(EA_DU(); CHKA_LD(ea, 2); UPD(); GPR(RT) = (uint32_t)(int32_t)(int16_t)LDV(16))
+#define OP_STH        OP(EA_D();  CHKA_ST(ea, 2, GPR(RT)); WRITE(16, xa, (uint16_t)sv_))
+#define OP_STHU       OP(EA_DU(); CHKA_ST(ea, 2, GPR(RT)); WRITE(16, xa, (uint16_t)sv_); UPD())
 #define OP_LMW        OP(ppc_do_lmw(p, iw))
 #define OP_STMW       OP(ppc_do_stmw(p, iw))
 
 // --- indexed loads/stores ---
-#define OP_LWZX       OP(EA_X();  CHKA_LD(ea, 4); GPR(RT) = READ(32, xa))
-#define OP_LWZUX      OP(EA_XU(); CHKA_LD(ea, 4); UPD(); GPR(RT) = READ(32, xa))
+#define OP_LWZX       OP(EA_X();  CHKA_LD(ea, 4); GPR(RT) = LDV(32))
+#define OP_LWZUX      OP(EA_XU(); CHKA_LD(ea, 4); UPD(); GPR(RT) = LDV(32))
 #define OP_LBZX       OP(EA_X();  XLT_LD(ea); GPR(RT) = READ(8, xa))
 #define OP_LBZUX      OP(EA_XU(); XLT_LD(ea); UPD(); GPR(RT) = READ(8, xa))
-#define OP_LHZX       OP(EA_X();  CHKA_LD(ea, 2); GPR(RT) = READ(16, xa))
-#define OP_LHZUX      OP(EA_XU(); CHKA_LD(ea, 2); UPD(); GPR(RT) = READ(16, xa))
-#define OP_LHAX       OP(EA_X();  CHKA_LD(ea, 2); GPR(RT) = (uint32_t)(int32_t)(int16_t)READ(16, xa))
-#define OP_LHAUX      OP(EA_XU(); CHKA_LD(ea, 2); UPD(); GPR(RT) = (uint32_t)(int32_t)(int16_t)READ(16, xa))
-#define OP_STWX       OP(EA_X();  CHKA_ST(ea, 4); WRITE(32, xa, GPR(RT)))
-#define OP_STWUX      OP(EA_XU(); CHKA_ST(ea, 4); WRITE(32, xa, GPR(RT)); UPD())  // store before update: rS==rA stores the pre-update value
+#define OP_LHZX       OP(EA_X();  CHKA_LD(ea, 2); GPR(RT) = LDV(16))
+#define OP_LHZUX      OP(EA_XU(); CHKA_LD(ea, 2); UPD(); GPR(RT) = LDV(16))
+#define OP_LHAX       OP(EA_X();  CHKA_LD(ea, 2); GPR(RT) = (uint32_t)(int32_t)(int16_t)LDV(16))
+#define OP_LHAUX      OP(EA_XU(); CHKA_LD(ea, 2); UPD(); GPR(RT) = (uint32_t)(int32_t)(int16_t)LDV(16))
+#define OP_STWX       OP(EA_X();  CHKA_ST(ea, 4, GPR(RT)); WRITE(32, xa, (uint32_t)sv_))
+#define OP_STWUX      OP(EA_XU(); CHKA_ST(ea, 4, GPR(RT)); WRITE(32, xa, (uint32_t)sv_); UPD())  // store before update: rS==rA stores the pre-update value
 #define OP_STBX       OP(EA_X();  XLT_ST(ea); WRITE(8, xa, (uint8_t)GPR(RT)))
 #define OP_STBUX      OP(EA_XU(); XLT_ST(ea); WRITE(8, xa, (uint8_t)GPR(RT)); UPD())
-#define OP_STHX       OP(EA_X();  CHKA_ST(ea, 2); WRITE(16, xa, (uint16_t)GPR(RT)))
-#define OP_STHUX      OP(EA_XU(); CHKA_ST(ea, 2); WRITE(16, xa, (uint16_t)GPR(RT)); UPD())
-#define OP_LWBRX      OP(EA_X();  CHKA_LD(ea, 4); GPR(RT) = __builtin_bswap32(READ(32, xa)))
-#define OP_LHBRX      OP(EA_X();  CHKA_LD(ea, 2); GPR(RT) = __builtin_bswap16(READ(16, xa)))
-#define OP_STWBRX     OP(EA_X();  CHKA_ST(ea, 4); WRITE(32, xa, __builtin_bswap32(GPR(RT))))
-#define OP_STHBRX     OP(EA_X();  CHKA_ST(ea, 2); WRITE(16, xa, (uint16_t)__builtin_bswap16((uint16_t)GPR(RT))))
+#define OP_STHX       OP(EA_X();  CHKA_ST(ea, 2, GPR(RT)); WRITE(16, xa, (uint16_t)sv_))
+#define OP_STHUX      OP(EA_XU(); CHKA_ST(ea, 2, GPR(RT)); WRITE(16, xa, (uint16_t)sv_); UPD())
+#define OP_LWBRX      OP(EA_X();  CHKA_LD(ea, 4); GPR(RT) = __builtin_bswap32(LDV(32)))
+#define OP_LHBRX      OP(EA_X();  CHKA_LD(ea, 2); GPR(RT) = __builtin_bswap16(LDV(16)))
+#define OP_STWBRX     OP(EA_X();  CHKA_ST(ea, 4, __builtin_bswap32(GPR(RT))); WRITE(32, xa, (uint32_t)sv_))
+#define OP_STHBRX     OP(EA_X();  CHKA_ST(ea, 2, (uint16_t)__builtin_bswap16((uint16_t)GPR(RT))); WRITE(16, xa, (uint16_t)sv_))
 
 // --- atomics ---
 // A misaligned EA is NOT an alignment exception by itself: §5.4.6.1.1 fires
@@ -403,39 +423,43 @@ static inline void ppc_sra_mq_ca(ppc_t *p, uint32_t rot, uint32_t mask, uint32_t
 // alignment exception handler will be invoked if the word loaded crosses a
 // page boundary, or the results may be undefined").  So these run the same
 // scalar check as every other word access.
-#define OP_LWARX      OP(EA_X(); CHKA_LD(ea, 4); p->reserve = 1; p->reserve_addr = xa; GPR(RT) = READ(32, xa))
+#define OP_LWARX      OP(EA_X(); CHKA_LD(ea, 4); p->reserve = 1; p->reserve_addr = xa; GPR(RT) = LDV(32))
 #define OP_STWCX_DOT  OP(ppc_do_stwcx(p, iw))
 
-// --- external control (EAR-gated, 601UM eciwx/ecowx pages) ---
-#define OP_ECIWX      OP(EA_X(); if (!(p->ear & 0x80000000u)) { ppc_ecx_fault(p, ea, false); break; } XLT_LD(ea); GPR(RT) = READ(32, xa))
-#define OP_ECOWX      OP(EA_X(); if (!(p->ear & 0x80000000u)) { ppc_ecx_fault(p, ea, true); break; } XLT_ST(ea); WRITE(32, xa, GPR(RT)))
+// --- external control (EAR-gated, 601UM eciwx/ecowx pages; the 604 adds
+//     the word-alignment requirement — 604UM §4.5.6) ---
+#define ECX_ALIGN()   if (ppc_is_604(p) && (ea & 3u)) { ppc_align_exception(p, iw, ea); break; }
+#define OP_ECIWX      OP(EA_X(); ECX_ALIGN(); if (!(p->ear & 0x80000000u)) { ppc_ecx_fault(p, ea, false); break; } XLT_LD(ea); GPR(RT) = READ(32, xa))
+#define OP_ECOWX      OP(EA_X(); ECX_ALIGN(); if (!(p->ear & 0x80000000u)) { ppc_ecx_fault(p, ea, true); break; } XLT_ST(ea); WRITE(32, xa, GPR(RT)))
 
 // --- strings ---
 #define OP_LSWI       OP(ppc_do_lswi(p, iw))
 #define OP_LSWX       OP(ppc_do_lswx(p, iw))
 #define OP_STSWI      OP(ppc_do_stswi(p, iw))
 #define OP_STSWX      OP(ppc_do_stswx(p, iw))
-#define OP_LSCBX      OP(ppc_do_lscbx(p, iw))
+#define OP_LSCBX      OP(M601(); ppc_do_lscbx(p, iw))
 
 // --- FP loads/stores (FPR file lives; conversions in ppc_fpu.c) ---
-#define FPR_LOAD64(a)  (((uint64_t)READ(32, a) << 32) | READ(32, (a) + 4))
-#define FPR_STORE64(a) do { WRITE(32, a, (uint32_t)(p->fpr[RT] >> 32)); WRITE(32, (a) + 4, (uint32_t)p->fpr[RT]); } while (0)
-#define OP_LFS        OP(FP(); EA_D();  CHKA_LD(ea, 4); p->fpr[RT] = ppc_f32_to_f64(READ(32, xa)))
-#define OP_LFSU       OP(FP(); EA_DU(); CHKA_LD(ea, 4); UPD(); p->fpr[RT] = ppc_f32_to_f64(READ(32, xa)))
-#define OP_LFD        OP(FP(); EA_D();  CHKA_LD(ea, 8); p->fpr[RT] = FPR_LOAD64(xa))
-#define OP_LFDU       OP(FP(); EA_DU(); CHKA_LD(ea, 8); UPD(); p->fpr[RT] = FPR_LOAD64(xa))
-#define OP_STFS       OP(FP(); EA_D();  CHKA_ST(ea, 4); WRITE(32, xa, ppc_f64_to_f32_store(p->fpr[RT])))
-#define OP_STFSU      OP(FP(); EA_DU(); CHKA_ST(ea, 4); UPD(); WRITE(32, xa, ppc_f64_to_f32_store(p->fpr[RT])))
-#define OP_STFD       OP(FP(); EA_D();  CHKA_ST(ea, 8); FPR_STORE64(xa))
-#define OP_STFDU      OP(FP(); EA_DU(); CHKA_ST(ea, 8); UPD(); FPR_STORE64(xa))
-#define OP_LFSX       OP(FP(); EA_X();  CHKA_LD(ea, 4); p->fpr[RT] = ppc_f32_to_f64(READ(32, xa)))
-#define OP_LFSUX      OP(FP(); EA_XU(); CHKA_LD(ea, 4); UPD(); p->fpr[RT] = ppc_f32_to_f64(READ(32, xa)))
-#define OP_LFDX       OP(FP(); EA_X();  CHKA_LD(ea, 8); p->fpr[RT] = FPR_LOAD64(xa))
-#define OP_LFDUX      OP(FP(); EA_XU(); CHKA_LD(ea, 8); UPD(); p->fpr[RT] = FPR_LOAD64(xa))
-#define OP_STFSX      OP(FP(); EA_X();  CHKA_ST(ea, 4); WRITE(32, xa, ppc_f64_to_f32_store(p->fpr[RT])))
-#define OP_STFSUX     OP(FP(); EA_XU(); CHKA_ST(ea, 4); UPD(); WRITE(32, xa, ppc_f64_to_f32_store(p->fpr[RT])))
-#define OP_STFDX      OP(FP(); EA_X();  CHKA_ST(ea, 8); FPR_STORE64(xa))
-#define OP_STFDUX     OP(FP(); EA_XU(); CHKA_ST(ea, 8); UPD(); FPR_STORE64(xa))
+#define FPR_LOAD64()   (lg_ ? lv_ : (((uint64_t)READ(32, xa) << 32) | READ(32, xa + 4)))
+#define FPR_STORE64()  do { WRITE(32, xa, (uint32_t)(sv_ >> 32)); WRITE(32, xa + 4, (uint32_t)sv_); } while (0)
+#define OP_LFS        OP(FP(); EA_D();  CHKA_LD(ea, 4); p->fpr[RT] = ppc_f32_to_f64(LDV(32)))
+#define OP_LFSU       OP(FP(); EA_DU(); CHKA_LD(ea, 4); UPD(); p->fpr[RT] = ppc_f32_to_f64(LDV(32)))
+#define OP_LFD        OP(FP(); EA_D();  CHKA_LD(ea, 8); p->fpr[RT] = FPR_LOAD64())
+#define OP_LFDU       OP(FP(); EA_DU(); CHKA_LD(ea, 8); UPD(); p->fpr[RT] = FPR_LOAD64())
+#define OP_STFS       OP(FP(); EA_D();  CHKA_ST(ea, 4, ppc_f64_to_f32_store(p->fpr[RT])); WRITE(32, xa, (uint32_t)sv_))
+#define OP_STFSU      OP(FP(); EA_DU(); CHKA_ST(ea, 4, ppc_f64_to_f32_store(p->fpr[RT])); UPD(); WRITE(32, xa, (uint32_t)sv_))
+#define OP_STFD       OP(FP(); EA_D();  CHKA_ST(ea, 8, p->fpr[RT]); FPR_STORE64())
+#define OP_STFDU      OP(FP(); EA_DU(); CHKA_ST(ea, 8, p->fpr[RT]); UPD(); FPR_STORE64())
+#define OP_LFSX       OP(FP(); EA_X();  CHKA_LD(ea, 4); p->fpr[RT] = ppc_f32_to_f64(LDV(32)))
+#define OP_LFSUX      OP(FP(); EA_XU(); CHKA_LD(ea, 4); UPD(); p->fpr[RT] = ppc_f32_to_f64(LDV(32)))
+#define OP_LFDX       OP(FP(); EA_X();  CHKA_LD(ea, 8); p->fpr[RT] = FPR_LOAD64())
+#define OP_LFDUX      OP(FP(); EA_XU(); CHKA_LD(ea, 8); UPD(); p->fpr[RT] = FPR_LOAD64())
+#define OP_STFSX      OP(FP(); EA_X();  CHKA_ST(ea, 4, ppc_f64_to_f32_store(p->fpr[RT])); WRITE(32, xa, (uint32_t)sv_))
+#define OP_STFSUX     OP(FP(); EA_XU(); CHKA_ST(ea, 4, ppc_f64_to_f32_store(p->fpr[RT])); UPD(); WRITE(32, xa, (uint32_t)sv_))
+#define OP_STFDX      OP(FP(); EA_X();  CHKA_ST(ea, 8, p->fpr[RT]); FPR_STORE64())
+#define OP_STFDUX     OP(FP(); EA_XU(); CHKA_ST(ea, 8, p->fpr[RT]); UPD(); FPR_STORE64())
+// stfiwx (604): store the FPR's low word untouched (PEM stfiwx page).
+#define OP_STFIWX     OP(M604(); FP(); EA_X(); CHKA_ST(ea, 4, (uint32_t)p->fpr[RT]); WRITE(32, xa, (uint32_t)sv_))
 
 // --- FP moves / FPSCR / compares (bodies in ppc_fpu.c); CR1 record on Rc ---
 #define REC1()        if (PPC_RC(iw)) ppc_set_cr_field(p, 1, p->fpscr >> 28)
@@ -472,6 +496,11 @@ static inline void ppc_sra_mq_ca(ppc_t *p, uint32_t rot, uint32_t mask, uint32_t
 #define OP_FMADDS     OP(FP(); ppc_fp_arith(p, iw, PPC_SF_MADD, true))
 #define OP_FNMSUBS    OP(FP(); ppc_fp_arith(p, iw, PPC_SF_NMSUB, true))
 #define OP_FNMADDS    OP(FP(); ppc_fp_arith(p, iw, PPC_SF_NMADD, true))
+
+// --- 604 optional-FP group (fsqrt stays illegal: not implemented on 604) ---
+#define OP_FSEL       OP(M604(); FP(); ppc_do_fsel(p, iw))
+#define OP_FRES       OP(M604(); FP(); ppc_do_fres(p, iw))
+#define OP_FRSQRTE    OP(M604(); FP(); ppc_do_frsqrte(p, iw))
 
 #define OP_ILLEGAL    OP(ppc_illegal_op(p, iw))
 

--- a/src/core/cpu/ppc/ppc_run.c
+++ b/src/core/cpu/ppc/ppc_run.c
@@ -2,7 +2,7 @@
 // Copyright (c) pappadf
 
 // ppc_run.c
-// The PPC (MPC601) interpreter: instantiates the shared decode tree
+// The PPC (MPC601/MPC604) interpreter: instantiates the shared decode tree
 // (ppc_decode.h) with the execution OP_ table (ppc_ops.h) to generate
 // ppc_execute(), and wraps it in the main-CPU sprint loop.  Fixed-width
 // 32-bit fetch through the global fast-path memory accessors — this core
@@ -233,12 +233,78 @@ void ppc_do_sraw(ppc_t *p, uint32_t iw) {
         ppc_record_cr0(p, r);
 }
 
+// === The scalar access gate =================================================
+
+// 604UM §4.5.6 word-alignment classes routed through CHKA_*: the FP
+// loads/stores and lwarx (stwcx./eciwx/ecowx check at their own sites).
+static bool iw_requires_word_align_604(uint32_t iw) {
+    if (ppc_iw_is_fp_ls(iw))
+        return true;
+    return PPC_OPCD(iw) == 31 && PPC_XO10(iw) == 20; // lwarx
+}
+
+// The 604's hardware-split page-crossing access, modeled byte-wise so
+// discontiguously translated pages behave (the string-transfer precedent).
+// A mid-transfer fault abandons with the store partially done — the 604UM
+// documents exactly that ("the instruction may complete partially").
+// Returns true when an exception was raised.
+static bool ppc_split_access(ppc_t *p, uint32_t iw, uint32_t ea, uint32_t size, bool store, uint64_t *val) {
+    if (store) {
+        for (uint32_t i = 0; i < size; i++) {
+            uint32_t xa = ea + i;
+            if (ppc_dxlate(p, iw, &xa, true))
+                return true;
+            memory_write_uint8(xa, (uint8_t)(*val >> (8u * (size - 1u - i))));
+        }
+    } else {
+        uint64_t v = 0;
+        for (uint32_t i = 0; i < size; i++) {
+            uint32_t xa = ea + i;
+            if (ppc_dxlate(p, iw, &xa, false))
+                return true;
+            v = (v << 8) | memory_read_uint8(xa);
+        }
+        *val = v;
+    }
+    return false;
+}
+
+// See ppc_internal.h for the contract (-1 exception / 0 proceed at *addr /
+// +1 completed byte-wise).  The 601 path is the classic §5.4.6 boundary
+// check plus one translation; the 604 path is the word-alignment rule for
+// its fault-prone classes plus the hardware split.
+int ppc_scalar_gate(ppc_t *p, uint32_t iw, uint32_t *addr, uint32_t size, bool store, uint64_t *val) {
+    uint32_t ea = *addr;
+    if (!ppc_is_604(p)) {
+        if (ppc_check_align_scalar(p, iw, ea, size))
+            return -1;
+        return ppc_dxlate(p, iw, addr, store) ? -1 : 0;
+    }
+    if ((ea & 3u) && iw_requires_word_align_604(iw)) {
+        ppc_align_exception(p, iw, ea);
+        return -1;
+    }
+    // With translation off the identity map is contiguous and the normal
+    // access handles any misalignment; translated page crossings go
+    // byte-wise (pages need not be physically adjacent).
+    if (size > 1 && (p->msr & PPC_MSR_DT) && ppc_crosses_page(ea, size))
+        return ppc_split_access(p, iw, ea, size, store, val) ? -1 : 1;
+    return ppc_dxlate(p, iw, addr, store) ? -1 : 0;
+}
+
 // === Multiples and strings ==================================================
 
 void ppc_do_lmw(ppc_t *p, uint32_t iw) {
     uint32_t rt = PPC_RT(iw), ra = PPC_RA(iw);
     uint32_t ea = (ra ? p->gpr[ra] : 0u) + (uint32_t)PPC_SIMM(iw);
-    if (ppc_check_align_string(p, iw, ea, 4u * (32u - rt), false))
+    // 604: multiples must be word-aligned (604UM §4.5.6); aligned ones are
+    // split per word below, so no further boundary rule applies.
+    if (ppc_is_604(p)) {
+        if (ea & 3u) {
+            ppc_align_exception(p, iw, ea);
+            return;
+        }
+    } else if (ppc_check_align_string(p, iw, ea, 4u * (32u - rt), false))
         return;
     // Word-aligned multiples may cross pages, and HTAB pages need not be
     // physically contiguous: translate per word.  A mid-transfer fault
@@ -256,7 +322,12 @@ void ppc_do_lmw(ppc_t *p, uint32_t iw) {
 void ppc_do_stmw(ppc_t *p, uint32_t iw) {
     uint32_t rt = PPC_RT(iw), ra = PPC_RA(iw);
     uint32_t ea = (ra ? p->gpr[ra] : 0u) + (uint32_t)PPC_SIMM(iw);
-    if (ppc_check_align_string(p, iw, ea, 4u * (32u - rt), false))
+    if (ppc_is_604(p)) {
+        if (ea & 3u) {
+            ppc_align_exception(p, iw, ea);
+            return;
+        }
+    } else if (ppc_check_align_string(p, iw, ea, 4u * (32u - rt), false))
         return;
     for (uint32_t reg = rt; reg < 32; reg++, ea += 4) {
         uint32_t xa = ea;
@@ -391,7 +462,11 @@ void ppc_do_lscbx(ppc_t *p, uint32_t iw) {
 
 void ppc_do_stwcx(ppc_t *p, uint32_t iw) {
     uint32_t ea = (PPC_RA(iw) ? p->gpr[PPC_RA(iw)] : 0u) + p->gpr[PPC_RB(iw)];
-    if (ppc_check_align_scalar(p, iw, ea, 4)) // misalignment alone is not a fault; see OP_LWARX
+    if (ppc_is_604(p) && (ea & 3u)) { // 604: word alignment required (604UM §4.5.6)
+        ppc_align_exception(p, iw, ea);
+        return;
+    }
+    if (ppc_check_align_scalar(p, iw, ea, 4)) // 601: misalignment alone is not a fault; see OP_LWARX
         return;
     uint32_t xa = ea;
     if (ppc_dxlate(p, iw, &xa, true))
@@ -482,13 +557,22 @@ void ppc_run(ppc_t *restrict p, uint32_t *instructions) {
         if (*instructions > 0) // saturating (I/O penalty may have zeroed it)
             (*instructions)--;
     }
-    // Deferred data/fetch fault → machine check (601UM §5.4.2: the TEA
-    // path; the PDM family's AMIC/BART bus errors arrive this way).
+    // Deferred data/fetch fault → machine check (601UM §5.4.2 / 604UM
+    // §4.5.2: the TEA path; the bus errors of the PDM family's AMIC/BART —
+    // and the TNT family's Bandit windows — arrive this way).
     if (__builtin_expect(g_bus_error_pending, 0)) {
         g_bus_error_pending = false;
         p->dar = g_bus_error_address;
         LOG(3, "machine check: addr $%08X pc $%08X r24 $%08X", g_bus_error_address, p->instruction_pc, p->gpr[24]);
-        ppc_exception(p, PPC_VEC_MCHECK, 0, p->instruction_pc);
+        if (ppc_is_604(p)) {
+            // 604UM Table 4-8: SRR1[13] flags the TEA cause, SRR1[30] (the
+            // RI copy) reads zero, and the exception clears MSR[ME].
+            ppc_exception(p, PPC_VEC_MCHECK, 0x00040000u, p->instruction_pc);
+            p->srr1 &= ~PPC_MSR_RI;
+            p->msr &= ~PPC_MSR_ME;
+        } else {
+            ppc_exception(p, PPC_VEC_MCHECK, 0, p->instruction_pc);
+        }
     }
     *instructions = 0;
 }

--- a/src/core/cpu/ppc/ppc_softfp.c
+++ b/src/core/cpu/ppc/ppc_softfp.c
@@ -770,6 +770,132 @@ int ppc_sf_frsp(uint64_t b, uint32_t *fpscr, uint64_t *frt) {
     return 1;
 }
 
+// fres (604; PEM fresx page): single-precision reciprocal estimate,
+// architected envelope 2^-8 relative, value implementation-defined.  This
+// model's constant choice: the CORRECTLY-ROUNDED single-precision quotient
+// 1.0/frB from the division kernel — deterministic and well inside the
+// envelope.  Architected FPSCR effects only: FPRF, FX, OX, UX, ZX, VXSNAN;
+// FR/FI are "undefined" and read cleared; XX is NOT an fres effect and the
+// quotient's inexactness is masked off.
+int ppc_sf_fres(uint64_t b, uint32_t *fpscr, uint64_t *frt) {
+    uint32_t f0 = *fpscr;
+    uint32_t f = f0;
+    uint64_t r;
+    int wrote = ppc_sf_arith(PPC_SF_DIV, 0x3FF0000000000000ull /* 1.0 */, b, 0, 1, &f, &r);
+    // Rebuild the FPSCR from the pre-instruction image plus the allowed
+    // newly-raised stickies; FX follows only those (the raise rule).
+    const uint32_t allowed = PPC_FPSCR_OX | PPC_FPSCR_UX | PPC_FPSCR_ZX | PPC_FPSCR_VXSNAN;
+    uint32_t newly = f & ~f0 & allowed;
+    uint32_t nf = (f0 & ~(PPC_FPSCR_FPRF | PPC_FPSCR_FR | PPC_FPSCR_FI)) | newly;
+    nf |= (wrote ? f : f0) & PPC_FPSCR_FPRF; // suppressed delivery leaves FPRF unchanged
+    if (newly)
+        nf |= PPC_FPSCR_FX;
+    *fpscr = ppc_fpscr_derive(nf);
+    if (wrote)
+        *frt = r;
+    return wrote;
+}
+
+// Integer square root: floor(sqrt(a)) for a < 2^126 (the frsqrte scaling
+// keeps the root's MSB at bit 62).  Classic bit-pair method, maintaining
+// rem = prefix(a) - root^2.
+static uint64_t sf_isqrt128(unsigned __int128 a) {
+    unsigned __int128 rem = 0, root = 0;
+    for (int i = 62; i >= 0; i--) {
+        rem = (rem << 2) | ((a >> (2 * i)) & 3u);
+        unsigned __int128 cand = (root << 2) | 1u;
+        root <<= 1;
+        if (rem >= cand) {
+            rem -= cand;
+            root |= 1u;
+        }
+    }
+    return (uint64_t)root;
+}
+
+// frsqrte (604; PEM frsqrtex page): double-precision reciprocal square
+// root estimate, architected envelope 2^-5 relative, value implementation-
+// defined.  This model's constant choice: divide 1.0 by the 62-bit
+// truncated integer square root of the significand and round to nearest —
+// relative error < 2^-61.  Architected FPSCR effects only: FPRF, FX, ZX,
+// VXSNAN, VXSQRT; FR/FI read cleared; no OX/UX/XX.
+int ppc_sf_frsqrte(uint64_t b, uint32_t *fpscr, uint64_t *frt) {
+    sf_val_t vb = sf_unpack(b);
+    uint32_t f = *fpscr & ~(PPC_FPSCR_FR | PPC_FPSCR_FI);
+    uint64_t result;
+
+    if (sf_is_nan(&vb)) {
+        if (vb.cls == SF_SNAN) {
+            f = ppc_fpscr_raise(f, PPC_FPSCR_VXSNAN);
+            if (f & PPC_FPSCR_VE) {
+                *fpscr = ppc_fpscr_derive(f);
+                return 0;
+            }
+        }
+        result = sf_quiet(b);
+    } else if (vb.cls == SF_ZERO) {
+        // ±0 → ±inf with ZX (no result when ZE enabled).
+        f = ppc_fpscr_raise(f, PPC_FPSCR_ZX);
+        if (f & PPC_FPSCR_ZE) {
+            *fpscr = ppc_fpscr_derive(f);
+            return 0;
+        }
+        result = ((uint64_t)vb.sign << 63) | 0x7FF0000000000000ull;
+    } else if (vb.sign) {
+        // Negative (incl. -inf) → default QNaN with VXSQRT.
+        f = ppc_fpscr_raise(f, PPC_FPSCR_VXSQRT);
+        if (f & PPC_FPSCR_VE) {
+            *fpscr = ppc_fpscr_derive(f);
+            return 0;
+        }
+        result = SF_DEFAULT_QNAN;
+    } else if (vb.cls == SF_INF) {
+        result = 0; // +inf → +0
+    } else {
+        // Positive finite: value = m2 * 2^e2 with e2 even and the
+        // significand at bit 62 (bit 63 for the odd-exponent double).
+        int32_t e2 = vb.exp;
+        uint64_t sig_a = vb.sig;
+        if (e2 & 1) {
+            sig_a <<= 1; // m2 = 2m in [2,4)
+            e2 -= 1;
+        }
+        // S = floor(sqrt(m2) * 2^62), in [2^62, 2^63).
+        uint64_t s = sf_isqrt128((unsigned __int128)sig_a << 62);
+        // Q = floor(2^124 / S) ≈ (1/sqrt(m2)) * 2^62, in (2^61, 2^62].
+        unsigned __int128 n = (unsigned __int128)1 << 124;
+        uint64_t q = (uint64_t)(n / s);
+        uint64_t rem = (uint64_t)(n % s);
+        int32_t exp = -(e2 >> 1);
+        if ((q & (1ull << 62)) == 0) {
+            // MSB at 61: shift up one quotient bit (the sf_div refinement).
+            q <<= 1;
+            unsigned __int128 r2 = (unsigned __int128)rem << 1;
+            if (r2 >= s) {
+                q += 1;
+                r2 -= s;
+            }
+            rem = (uint64_t)r2;
+            exp -= 1;
+        }
+        int sticky = rem != 0 || ((unsigned __int128)s * s != (unsigned __int128)sig_a << 62);
+        // Round through the shared packer, then strip the non-architected
+        // status its rounding raised (frsqrte reports no OX/UX/XX and its
+        // FR/FI are "undefined" → cleared); only FPRF survives from it.
+        uint32_t fr = f;
+        result = sf_round_pack(0, exp, q, sticky, 0, &fr);
+        f = (f & ~PPC_FPSCR_FPRF) | (fr & PPC_FPSCR_FPRF);
+        *fpscr = ppc_fpscr_derive(f);
+        *frt = result;
+        return 1;
+    }
+
+    f = sf_set_fprf(f, result);
+    *fpscr = ppc_fpscr_derive(f);
+    *frt = result;
+    return 1;
+}
+
 int ppc_sf_fctiw(uint64_t b, int round_to_zero, uint32_t *fpscr, uint64_t *frt) {
     sf_val_t vb = sf_unpack(b);
     uint32_t f = *fpscr & ~(PPC_FPSCR_FR | PPC_FPSCR_FI);

--- a/src/core/cpu/ppc/ppc_softfp.h
+++ b/src/core/cpu/ppc/ppc_softfp.h
@@ -128,4 +128,12 @@ int ppc_sf_frsp(uint64_t b, uint32_t *fpscr, uint64_t *frt);
 // round_to_zero selects fctiwz.  The 601 stores $FFF80000 in the high word.
 int ppc_sf_fctiw(uint64_t b, int round_to_zero, uint32_t *fpscr, uint64_t *frt);
 
+// The 604's optional estimate instructions (PEM fresx/frsqrtex pages).
+// Both deliver a value far inside the architected error envelope (2^-8 /
+// 2^-5 relative) — see the implementation notes for the exact constants —
+// and report only their architected FPSCR effects (no XX; FR/FI read
+// cleared for "undefined").  Same return convention as ppc_sf_arith.
+int ppc_sf_fres(uint64_t b, uint32_t *fpscr, uint64_t *frt);
+int ppc_sf_frsqrte(uint64_t b, uint32_t *fpscr, uint64_t *frt);
+
 #endif // GS_CPU_PPC_SOFTFP_H

--- a/src/core/machine_profile.h
+++ b/src/core/machine_profile.h
@@ -53,10 +53,11 @@ typedef enum mmu_kind {
     MMU_LISA_SEGMENT, // Apple Lisa custom segment MMU
     MMU_68040, // Motorola 68040 integrated MMU (URP/SRP, fixed 3-level walk)
     MMU_PPC_601, // MPC601 integrated MMU (BAT + segment + hashed page table)
+    MMU_PPC_604, // MPC604 integrated MMU (architected split I/D BATs + hashed page table)
 } mmu_kind_t;
 
 // Wire string for an mmu_kind_t ("none" / "68030_pmmu" / "lisa_segment" /
-// "68040" / "ppc_601").
+// "68040" / "ppc_601" / "ppc_604").
 const char *mmu_kind_to_string(mmu_kind_t kind);
 
 // Main-CPU architecture of a machine (PPC proposal §3.9a).  The tagged
@@ -68,12 +69,15 @@ typedef enum cpu_arch {
     CPU_ARCH_PPC, // PowerPC — MPC601 (src/core/cpu/ppc/)
 } cpu_arch_t;
 
-// PowerPC 601 model id for hw_profile_t.cpu_model (the 68K ids live in cpu.h).
+// PowerPC model ids for hw_profile_t.cpu_model (the 68K ids live in cpu.h).
+// Both are models of the one `ppc` module (src/core/cpu/ppc/), discriminated
+// by ppc_t.cpu_model the way cpu.c discriminates 68000/030/040.
 #define CPU_MODEL_PPC601 601
+#define CPU_MODEL_PPC604 604
 
 // Main-CPU architecture implied by a profile's cpu_model.
 static inline cpu_arch_t cpu_arch_for_model(int cpu_model) {
-    return cpu_model == CPU_MODEL_PPC601 ? CPU_ARCH_PPC : CPU_ARCH_M68K;
+    return (cpu_model == CPU_MODEL_PPC601 || cpu_model == CPU_MODEL_PPC604) ? CPU_ARCH_PPC : CPU_ARCH_M68K;
 }
 
 // How a machine attaches a hard-disk image.  Every Mac hangs its HD off the

--- a/src/machines/machine.c
+++ b/src/machines/machine.c
@@ -72,6 +72,8 @@ const char *mmu_kind_to_string(mmu_kind_t kind) {
         return "68040";
     case MMU_PPC_601:
         return "ppc_601";
+    case MMU_PPC_604:
+        return "ppc_604";
     }
     return "none";
 }

--- a/src/machines/pdm/pdm.c
+++ b/src/machines/pdm/pdm.c
@@ -276,13 +276,14 @@ static void pdm_init(config_t *cfg, checkpoint_t *cp) {
     // core code registers on the bus map — a NuBus card's VRAM and
     // declaration ROM — are filled through our own page filler.
     g_mem_host_fill = pdm_fill_page;
-    cfg->ppc = ppc_init(cp);
+    cfg->ppc = ppc_init(cp, cfg->machine->cpu_model);
     assert(cfg->ppc != NULL);
     sched_cpu_if_t cpu_if = ppc_sched_if(cfg->ppc);
     cfg->scheduler = scheduler_init(&cpu_if, cp);
     scheduler_set_frequency(cfg->scheduler, cfg->machine->freq);
     scheduler_set_cpi(cfg->scheduler, 1);
-    ppc_bind_time(cfg->ppc, cfg->scheduler, cfg->machine->freq);
+    // The 601's RTC input: 7.8336 MHz on every PDM board (601 proposal §3.7).
+    ppc_bind_time(cfg->ppc, cfg->scheduler, cfg->machine->freq, 7833600u);
 
     cfg->rtc = rtc_init(cfg->scheduler, cp, true);
 

--- a/tests/unit/suites/ppc/test.c
+++ b/tests/unit/suites/ppc/test.c
@@ -104,9 +104,12 @@ static void step1_valid(uint32_t iw) {
     step1(iw);
 }
 
-// Reset to a clean supervisor state with EP cleared so exception vectors
-// land at $00000xxx (mapped RAM), translation off, FP on.
+// Reset to a clean 601 supervisor state with EP cleared so exception
+// vectors land at $00000xxx (mapped RAM), translation off, FP on.  The
+// model is pinned explicitly: ppc_reset preserves cpu_model, and the 604
+// section below flips it.
 static void fresh(void) {
+    P->cpu_model = CPU_MODEL_PPC601;
     ppc_reset(P);
     P->msr = PPC_MSR_ME | PPC_MSR_FP;
     ppc_update_active_maps(P);
@@ -1205,6 +1208,369 @@ static void test_mq_spr(void) {
     CHECK_EQ(P->gpr[3], 0x13579BDFu);
 }
 
+// === The 604 model (TNT proposal §4; 604UM/PEM citations inline) ============
+
+// Reset into the 604 model with EP cleared (vectors at $000xxxxx) and FP
+// on — the 604-side counterpart of fresh().  cpu_model survives ppc_reset.
+static void fresh604(void) {
+    P->cpu_model = CPU_MODEL_PPC604;
+    ppc_reset(P);
+    P->msr = PPC_MSR_ME | PPC_MSR_FP;
+    ppc_update_active_maps(P);
+}
+
+// Execute one word under the 604 and expect the illegal-instruction
+// program exception at the low vector.  (No disassembler cross-check:
+// SPR-number-level traps — undefined SPRs, bad TBR fields — still render
+// as instructions; the model-validity view is pinned in suites/ppc_disasm.)
+static void expect_illegal_604(uint32_t iw) {
+    fresh604();
+    memory_write_uint32(0x1000, iw);
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x00000700u);
+    CHECK_EQ(P->srr0, 0x1000u);
+    CHECK(P->srr1 & PPC_SRR1_PROG_ILLEGAL);
+}
+
+static void test_604_reset_state(void) {
+    P->cpu_model = CPU_MODEL_PPC604;
+    ppc_reset(P);
+    CHECK_EQ(P->msr, 0x00000040u); // IP alone (604UM §8.8.4)
+    CHECK_EQ(P->pc, 0xFFF00100u);
+    CHECK_EQ(P->pvr, 0x00040103u);
+    CHECK_EQ(P->hid0, 0); // caches/BHT disabled at HRESET
+}
+
+// Every POWER holdover and 601-only SPR encoding takes the program
+// exception on the 604 (604UM §4.5.7; TNT proposal §4.2).
+static void test_604_holdover_rejection(void) {
+    // One representative per holdover family plus every MQ/RTC SPR move,
+    // built from the encoders.
+    expect_illegal_604(e_xo(3, 4, 5, 0, 360, 0)); // abs
+    expect_illegal_604(e_xo(3, 4, 5, 0, 488, 0)); // nabs
+    expect_illegal_604(e_xo(3, 4, 5, 0, 264, 0)); // doz
+    expect_illegal_604(e_d(9, 3, 4, 5)); // dozi
+    expect_illegal_604(e_xo(3, 4, 5, 0, 107, 0)); // mul
+    expect_illegal_604(e_xo(3, 4, 5, 0, 331, 0)); // div
+    expect_illegal_604(e_xo(3, 4, 5, 0, 363, 0)); // divs
+    expect_illegal_604(e_x(3, 4, 0, 531, 0)); // clcs
+    expect_illegal_604(e_x(4, 3, 5, 29, 0)); // maskg
+    expect_illegal_604(e_x(4, 3, 5, 541, 0)); // maskir
+    expect_illegal_604(e_x(4, 3, 5, 537, 0)); // rrib
+    expect_illegal_604(e_x(4, 3, 5, 153, 0)); // sle
+    expect_illegal_604(e_x(4, 3, 5, 217, 0)); // sleq
+    expect_illegal_604(e_x(4, 3, 5, 184, 0)); // sliq
+    expect_illegal_604(e_x(4, 3, 5, 248, 0)); // slliq
+    expect_illegal_604(e_x(4, 3, 5, 216, 0)); // sllq
+    expect_illegal_604(e_x(4, 3, 5, 152, 0)); // slq
+    expect_illegal_604(e_x(4, 3, 5, 664, 0)); // srq
+    expect_illegal_604(e_x(4, 3, 5, 665, 0)); // sre
+    expect_illegal_604(e_x(4, 3, 5, 696, 0)); // sriq
+    expect_illegal_604(e_x(4, 3, 5, 728, 0)); // srlq
+    expect_illegal_604(e_x(4, 3, 5, 729, 0)); // sreq
+    expect_illegal_604(e_x(4, 3, 5, 760, 0)); // srliq
+    expect_illegal_604(e_x(4, 3, 5, 920, 0)); // sraq
+    expect_illegal_604(e_x(4, 3, 5, 952, 0)); // sraiq
+    expect_illegal_604(e_x(4, 3, 5, 921, 0)); // srea
+    expect_illegal_604(e_rlw(22, 4, 3, 5, 0, 31, 0)); // rlmi
+    expect_illegal_604(e_x(3, 4, 5, 277, 0)); // lscbx
+    // 601-only SPR encodings trap as illegal (supervisor mode)
+    expect_illegal_604(e_spr(3, 0, 0)); // mfspr mq
+    expect_illegal_604(e_spr(3, 0, 1)); // mtspr mq
+    expect_illegal_604(e_spr(3, 4, 0)); // mfspr rtcu
+    expect_illegal_604(e_spr(3, 5, 0)); // mfspr rtcl
+    expect_illegal_604(e_spr(3, 6, 0)); // mfspr dec (POWER user encoding)
+    expect_illegal_604(e_spr(3, 20, 1)); // mtspr rtcu
+    expect_illegal_604(e_spr(3, 21, 1)); // mtspr rtcl
+    expect_illegal_604(e_spr(3, 1009, 0)); // mfspr hid1 (601-only)
+    expect_illegal_604(e_spr(3, 100, 0)); // fully-undefined SPR: the 604 decodes and traps
+    // fsqrt stays illegal on both models (not implemented on the 604)
+    expect_illegal_604(e_x63(3, 0, 4, 22, 0));
+}
+
+// MSR: the 604 mask admits POW/BE/PM/RI; exception entry clears POW/RI
+// and keeps ME/EP/PM; rfi restores only MSR[16-31].
+static void test_604_msr_bits(void) {
+    // A 604-only bit set (keeping PR/IT/DT/EE clear so the test keeps
+    // running untranslated in supervisor mode).
+    const uint32_t v = PPC_MSR_POW | PPC_MSR_BE | PPC_MSR_PM | PPC_MSR_RI | PPC_MSR_ME | PPC_MSR_FP;
+    fresh604();
+    P->gpr[4] = v;
+    step1_valid(e_x(4, 0, 0, 146, 0)); // mtmsr r4
+    CHECK_EQ(P->msr, v); // every implemented bit stored (POW is a no-op hint)
+    step1_valid(e_x(3, 0, 0, 83, 0)); // mfmsr r3
+    CHECK_EQ(P->gpr[3], v);
+    // sc from that state: POW/FP/BE/RI cleared, ME+PM kept (EP stays 0)
+    memory_write_uint32(0x1000, 0x44000002u); // sc
+    run_at(0x1000, 1);
+    CHECK_EQ(P->msr, PPC_MSR_ME | PPC_MSR_PM);
+    CHECK_EQ(P->pc, 0x00000C00u);
+    // On the 601 the same mtmsr masks the 604-only bits away
+    fresh();
+    P->gpr[4] = v;
+    step1_valid(e_x(4, 0, 0, 146, 0));
+    CHECK_EQ(P->msr, PPC_MSR_ME | PPC_MSR_FP);
+    // rfi on the 604 restores the low half only (POW outside it survives)
+    fresh604();
+    P->msr |= PPC_MSR_POW;
+    ppc_update_active_maps(P);
+    P->srr0 = 0x2000u;
+    P->srr1 = PPC_MSR_ME | PPC_MSR_FP | PPC_MSR_RI;
+    memory_write_uint32(0x1000, (19u << 26) | (50u << 1)); // rfi
+    memory_write_uint32(0x2000, 0x60000000u); // nop at the target
+    run_at(0x1000, 2);
+    CHECK_EQ(P->pc, 0x2004u);
+    CHECK_EQ(P->msr, PPC_MSR_POW | PPC_MSR_ME | PPC_MSR_FP | PPC_MSR_RI);
+}
+
+// Timebase: mftb/mftbu read the 64-bit counter (user-readable); TBL/TBU
+// write via SPR 284/285 (supervisor); the rebase keeps the other half.
+static void test_604_timebase(void) {
+    fresh604();
+    // Unbound (tick_mul = 0): the stored halves read back directly.
+    P->rtcu = 0x00000012u; // TBU storage
+    P->rtcl = 0x89ABCDEFu; // TBL storage
+    step1_valid(e_spr(3, 268, 0) + (32u << 1)); // mftb r3 (xo 371 = 339+32)
+    CHECK_EQ(P->gpr[3], 0x89ABCDEFu);
+    step1_valid(e_spr(3, 269, 0) + (32u << 1)); // mftbu r3
+    CHECK_EQ(P->gpr[3], 0x00000012u);
+    // mftb is user-readable
+    P->msr |= PPC_MSR_PR;
+    ppc_update_active_maps(P);
+    memory_write_uint32(0x1000, e_spr(4, 268, 0) + (32u << 1));
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x1004u);
+    CHECK_EQ(P->gpr[4], 0x89ABCDEFu);
+    // TB writes are supervisor-only
+    memory_write_uint32(0x1000, e_spr(4, 284, 1)); // mtspr tbl from user mode
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x00000700u);
+    CHECK(P->srr1 & PPC_SRR1_PROG_PRIV);
+    // Supervisor TB writes rebase one half, keeping the other
+    fresh604();
+    P->rtcu = 0x11111111u;
+    P->rtcl = 0x22222222u;
+    P->gpr[4] = 0xAAAAAAAAu;
+    step1_valid(e_spr(4, 284, 1)); // mtspr tbl,r4
+    CHECK_EQ(P->rtcl, 0xAAAAAAAAu);
+    CHECK_EQ(P->rtcu, 0x11111111u);
+    step1_valid(e_spr(4, 285, 1)); // mtspr tbu,r4
+    CHECK_EQ(P->rtcu, 0xAAAAAAAAu);
+    CHECK_EQ(P->rtcl, 0xAAAAAAAAu);
+    // mfspr of the TB write encodings is undefined → illegal (reads go
+    // through mftb only, PEM §2.3.1)
+    expect_illegal_604(e_spr(3, 284, 0));
+    // mftb with an undefined TBR field traps
+    expect_illegal_604(e_spr(3, 270, 0) + (32u << 1));
+    // The 601 rejects the whole mftb opcode (existing behavior, re-pinned)
+    fresh();
+    memory_write_uint32(0x1000, e_spr(3, 268, 0) + (32u << 1));
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x00000700u);
+}
+
+// The 604 SPR file: split BATs, PM stubs, PIR/DABR/IABR/HID0 survive.
+static void test_604_sprs(void) {
+    fresh604();
+    P->gpr[4] = 0xAA55AA55u;
+    step1_valid(e_spr(4, 534, 1)); // mtspr ibat3u
+    CHECK_EQ(P->batu[3], 0xAA55AA55u);
+    step1_valid(e_spr(4, 543, 1)); // mtspr dbat3l
+    CHECK_EQ(P->dbatl[3], 0xAA55AA55u);
+    step1_valid(e_spr(3, 543, 0)); // mfspr r3,dbat3l
+    CHECK_EQ(P->gpr[3], 0xAA55AA55u);
+    // Performance monitor group: read-zero / write-ignore stubs
+    step1_valid(e_spr(4, 952, 1)); // mtspr mmcr0
+    step1_valid(e_spr(3, 952, 0)); // mfspr r3,mmcr0
+    CHECK_EQ(P->gpr[3], 0);
+    step1_valid(e_spr(3, 953, 0)); // pmc1
+    CHECK_EQ(P->gpr[3], 0);
+    step1_valid(e_spr(3, 955, 0)); // sia
+    CHECK_EQ(P->gpr[3], 0);
+    // tlbsync: supervisor no-op; from user mode it is privileged
+    step1_valid(e_x(0, 0, 0, 566, 0));
+    CHECK_EQ(P->pc, 0x1004u);
+    P->msr |= PPC_MSR_PR;
+    ppc_update_active_maps(P);
+    memory_write_uint32(0x1000, e_x(0, 0, 0, 566, 0));
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x00000700u);
+    CHECK(P->srr1 & PPC_SRR1_PROG_PRIV);
+    // DEC via SPR 22 works; the POWER user encoding (SPR 6) trapped above
+    fresh604();
+    P->gpr[4] = 0x00123456u;
+    step1_valid(e_spr(4, 22, 1));
+    CHECK_EQ(P->dec, 0x00123456u);
+    step1_valid(e_spr(3, 22, 0));
+    CHECK_EQ(P->gpr[3], 0x00123456u);
+}
+
+// 604 alignment rules (604UM §4.5.6): FP/lmw/stmw/lwarx/stwcx./eciwx
+// not word-aligned → alignment exception; a misaligned integer access
+// crossing a page with translation on is split by hardware.
+static void test_604_alignment(void) {
+    fresh604();
+    P->gpr[4] = 0x2002u; // halfword-aligned only
+    memory_write_uint32(0x1000, e_d(50, 3, 4, 0)); // lfd f3,0(r4)
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x00000600u);
+    CHECK_EQ(P->dar, 0x2002u);
+    fresh604();
+    P->gpr[4] = 0x2001u;
+    memory_write_uint32(0x1000, e_d(48, 3, 4, 0)); // lfs f3,0(r4)
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x00000600u);
+    fresh604();
+    P->gpr[4] = 0x2002u;
+    memory_write_uint32(0x1000, e_d(46, 29, 4, 0)); // lmw r29,0(r4)
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x00000600u);
+    fresh604();
+    P->gpr[4] = 0x2002u;
+    memory_write_uint32(0x1000, e_d(47, 29, 4, 0)); // stmw
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x00000600u);
+    fresh604();
+    P->gpr[4] = 0x2002u;
+    P->gpr[5] = 0;
+    memory_write_uint32(0x1000, e_x(3, 4, 5, 20, 0)); // lwarx
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x00000600u);
+    fresh604();
+    P->gpr[4] = 0x2002u;
+    P->gpr[5] = 0;
+    memory_write_uint32(0x1000, e_x(3, 4, 5, 150, 1)); // stwcx.
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x00000600u);
+    // The 601 allows all of these when no page/segment boundary is crossed
+    fresh();
+    P->gpr[4] = 0x2002u;
+    memory_write_uint32(0x2002, 0x40490FDBu);
+    memory_write_uint32(0x2006, 0x54442D18u);
+    memory_write_uint32(0x1000, e_d(50, 3, 4, 0)); // lfd on the 601
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x1004u);
+    // Misaligned word-aligned-integer accesses stay legal on the 604 and
+    // read the straddling bytes (identity map: contiguous)
+    fresh604();
+    memory_write_uint32(0x2000, 0x11223344u);
+    memory_write_uint32(0x2004, 0x55667788u);
+    P->gpr[4] = 0x2002u;
+    step1_valid(e_d(32, 3, 4, 0)); // lwz r3,0(r4)
+    CHECK_EQ(P->gpr[3], 0x33445566u);
+}
+
+// TEA machine check on the 604: SRR1[13] set, SRR1[30] cleared, MSR[ME]
+// cleared on entry (604UM Tables 4-2/4-8).
+static void test_604_machine_check(void) {
+    fresh604();
+    P->msr |= PPC_MSR_RI;
+    ppc_update_active_maps(P);
+    memory_write_uint32(0x1000, 0x60000000u); // nop
+    g_bus_error_pending = true; // a device window signalled TEA
+    g_bus_error_address = 0xF2000000u;
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x00000200u);
+    CHECK(P->srr1 & 0x00040000u); // SRR1[13]: TEA
+    CHECK(!(P->srr1 & PPC_MSR_RI)); // SRR1[30] reads zero
+    CHECK(!(P->msr & PPC_MSR_ME)); // ME cleared (checkstop-on-repeat semantics)
+    CHECK_EQ(P->dar, 0xF2000000u);
+}
+
+// The optional-FP group: fsel/fres/frsqrte/stfiwx execute on the 604 and
+// trap on the 601 (PEM instruction pages; TNT proposal §4.2).
+static void test_604_optional_fp(void) {
+    // fsel: frA >= 0 (incl. -0) picks frC; negative and NaN pick frB
+    fresh604();
+    P->fpr[10] = 0x3FF0000000000000ull; // 1.0
+    P->fpr[11] = 0x4000000000000000ull; // 2.0 (frC)
+    P->fpr[12] = 0x4008000000000000ull; // 3.0 (frB)
+    memory_write_uint32(0x1000, (63u << 26) | (3u << 21) | (10u << 16) | (12u << 11) | (11u << 6) | (23u << 1));
+    run_at(0x1000, 1); // fsel f3,f10,f11,f12
+    CHECK_EQ((uint32_t)(P->fpr[3] >> 32), 0x40000000u); // 2.0: frA positive
+    P->fpr[10] = 0x8000000000000000ull; // -0.0 counts as >= 0
+    run_at(0x1000, 1);
+    CHECK_EQ((uint32_t)(P->fpr[3] >> 32), 0x40000000u);
+    P->fpr[10] = 0xBFF0000000000000ull; // -1.0
+    run_at(0x1000, 1);
+    CHECK_EQ((uint32_t)(P->fpr[3] >> 32), 0x40080000u); // 3.0: frB
+    P->fpr[10] = 0x7FF8000000000000ull; // QNaN
+    run_at(0x1000, 1);
+    CHECK_EQ((uint32_t)(P->fpr[3] >> 32), 0x40080000u); // NaN → frB
+    CHECK_EQ(P->fpscr, 0); // fsel never touches the FPSCR
+
+    // fres: correctly-rounded single reciprocal (documented constant)
+    fresh604();
+    P->fpr[5] = 0x4000000000000000ull; // 2.0
+    memory_write_uint32(0x1000, (59u << 26) | (3u << 21) | (5u << 11) | (24u << 1)); // fres f3,f5
+    run_at(0x1000, 1);
+    CHECK_EQ((uint32_t)(P->fpr[3] >> 32), 0x3FE00000u); // 0.5 exact
+    CHECK_EQ((uint32_t)P->fpr[3], 0);
+    CHECK(!(P->fpscr & PPC_FPSCR_XX)); // inexactness is never reported
+    P->fpr[5] = 0x4008000000000000ull; // 3.0 → 1/3 rounded to single
+    run_at(0x1000, 1);
+    CHECK_EQ(P->fpr[3], 0x3FD5555560000000ull); // single 0x3EAAAAAB widened
+    CHECK(!(P->fpscr & PPC_FPSCR_XX));
+    P->fpr[5] = 0; // 1/+0 → +inf with ZX
+    run_at(0x1000, 1);
+    CHECK_EQ(P->fpr[3], 0x7FF0000000000000ull);
+    CHECK(P->fpscr & PPC_FPSCR_ZX);
+
+    // frsqrte: near-exact double reciprocal square root (documented)
+    fresh604();
+    P->fpr[5] = 0x4010000000000000ull; // 4.0
+    memory_write_uint32(0x1000, (63u << 26) | (3u << 21) | (5u << 11) | (26u << 1)); // frsqrte f3,f5
+    run_at(0x1000, 1);
+    CHECK_EQ(P->fpr[3], 0x3FE0000000000000ull); // 0.5 exact
+    P->fpr[5] = 0x3FF0000000000000ull; // 1.0
+    run_at(0x1000, 1);
+    CHECK_EQ(P->fpr[3], 0x3FF0000000000000ull);
+    P->fpr[5] = 0x4000000000000000ull; // 2.0 → 1/sqrt(2)
+    run_at(0x1000, 1);
+    CHECK_EQ(P->fpr[3], 0x3FE6A09E667F3BCDull); // correctly-rounded double
+    P->fpr[5] = 0xBFF0000000000000ull; // negative → default QNaN + VXSQRT
+    run_at(0x1000, 1);
+    CHECK_EQ(P->fpr[3], 0x7FF8000000000000ull);
+    CHECK(P->fpscr & PPC_FPSCR_VXSQRT);
+    fresh604();
+    P->fpr[5] = 0x8000000000000000ull; // -0 → -inf with ZX
+    memory_write_uint32(0x1000, (63u << 26) | (3u << 21) | (5u << 11) | (26u << 1));
+    run_at(0x1000, 1);
+    CHECK_EQ(P->fpr[3], 0xFFF0000000000000ull);
+    CHECK(P->fpscr & PPC_FPSCR_ZX);
+    P->fpr[5] = 0x7FF0000000000000ull; // +inf → +0
+    run_at(0x1000, 1);
+    CHECK_EQ(P->fpr[3], 0);
+
+    // stfiwx stores the low FPR word verbatim
+    fresh604();
+    P->fpr[3] = 0x123456789ABCDEF0ull;
+    P->gpr[4] = 0x2000u;
+    P->gpr[5] = 4;
+    step1_valid(e_x(3, 4, 5, 983, 0)); // stfiwx f3,r4,r5
+    CHECK_EQ(memory_read_uint32(0x2004u), 0x9ABCDEF0u);
+
+    // All four are illegal on the 601
+    static const uint32_t group[] = {
+        (63u << 26) | (3u << 21) | (10u << 16) | (12u << 11) | (11u << 6) | (23u << 1), // fsel
+        (59u << 26) | (3u << 21) | (5u << 11) | (24u << 1), // fres
+        (63u << 26) | (3u << 21) | (5u << 11) | (26u << 1), // frsqrte
+    };
+    for (unsigned i = 0; i < sizeof(group) / sizeof(group[0]); i++) {
+        fresh();
+        memory_write_uint32(0x1000, group[i]);
+        run_at(0x1000, 1);
+        CHECK_EQ(P->pc, 0x00000700u);
+        CHECK(P->srr1 & PPC_SRR1_PROG_ILLEGAL);
+    }
+    fresh();
+    P->gpr[4] = 0x2000u;
+    P->gpr[5] = 4;
+    memory_write_uint32(0x1000, e_x(3, 4, 5, 983, 0)); // stfiwx on the 601
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x00000700u);
+}
+
 int main(void) {
     // 32-bit address space: 8 MB RAM at 0, 128 KB ROM at $40800000 (the
     // canonical OS base) — the harness's own init is Plus-shaped (24-bit),
@@ -1246,6 +1612,17 @@ int main(void) {
     test_fp_surface();
     test_mq_spr();
     test_conformance_regressions();
+
+    // The 604 model matrix (TNT proposal §4.5) — these flip P's cpu_model
+    // and run last so every 601 test above sees an untouched 601.
+    test_604_reset_state();
+    test_604_holdover_rejection();
+    test_604_msr_bits();
+    test_604_timebase();
+    test_604_sprs();
+    test_604_alignment();
+    test_604_machine_check();
+    test_604_optional_fp();
 
     ppc_delete(P);
     printf("ppc: %d checks, %d failures\n", checks, failures);

--- a/tests/unit/suites/ppc/test.c
+++ b/tests/unit/suites/ppc/test.c
@@ -1218,7 +1218,7 @@ int main(void) {
     memory_populate_pages(ctx->memory, 0x40800000u, 0x40820000u);
     test_set_active_context(ctx);
 
-    P = ppc_init(NULL);
+    P = ppc_init(NULL, CPU_MODEL_PPC601);
     if (!P) {
         printf("FAIL: ppc_init\n");
         return 1;

--- a/tests/unit/suites/ppc_disasm/test.c
+++ b/tests/unit/suites/ppc_disasm/test.c
@@ -203,11 +203,23 @@ static const struct {
     {0x00001000u, 0xFC032040u, "fcmpo cr0,f3,f4"        },
     {0x00001000u, 0xFC60048Eu, "mffs f3"                },
     {0x00001000u, 0xFDFE058Eu, "mtfsf 255,f0"           },
-    {0x00001000u, 0x7C6C42E6u, ".long $7C6C42E6"        },
-    {0x00001000u, 0xFC4D34EEu, ".long $FC4D34EE"        },
-    {0x00001000u, 0x7C0007A4u, ".long $7C0007A4"        },
+    {0x00001000u, 0x7C6C42E6u, "mftb r3"                }, // 604 encoding (union view)
+    {0x00001000u, 0xFC4D34EEu, "fsel f2,f13,f19,f6"     }, // 604 encoding (union view)
+    {0x00001000u, 0x7C0007A4u, ".long $7C0007A4"        }, // tlbld: 603-only, no model here
     {0x00001000u, 0x00000000u, ".long $00000000"        },
     {0x00001000u, 0xFFFFFFFFu, "fnmadd. f31,f31,f31,f31"},
+    // 604 additions (decoded by the union view, flagged is_604)
+    {0x00001000u, 0x7C8C42E6u, "mftb r4"                },
+    {0x00001000u, 0x7C8D42E6u, "mftbu r4"               },
+    {0x00001000u, 0x7C00046Cu, "tlbsync"                },
+    {0x00001000u, 0x7C6427AEu, "stfiwx f3,r4,r4"        },
+    {0x00001000u, 0xEC403030u, "fres f2,f6"             },
+    {0x00001000u, 0xFC403034u, "frsqrte f2,f6"          },
+    {0x00001000u, 0xFC413034u, ".long $FC413034"        }, // frsqrte with FRA set: invalid form
+    {0x00001000u, 0xFC40302Cu, ".long $FC40302C"        }, // fsqrt: neither model implements it
+    {0x00001000u, 0x7C7C43A6u, "mtspr tbl,r3"           }, // SPR 284 (604 write encoding)
+    {0x00001000u, 0x7C9883A6u, "mtspr dbat0u,r4"        }, // SPR 536
+    {0x00001000u, 0x7C78EAA6u, "mfspr r3,mmcr0"         }, // SPR 952
 };
 
 // Branch-target metadata checks
@@ -244,11 +256,62 @@ static void test_power_flag(void) {
     }
 }
 
+// One model-filtered expectation: status + (for OK) the rendered text.
+static void expect_model(uint32_t word, int model, int want_invalid, const char *flag_name) {
+    ppc_insn ins;
+    ppc_disassemble_model(word, 0x1000u, model, &ins);
+    checks++;
+    if ((ins.status == PPC_DIS_INVALID) != want_invalid) {
+        printf("FAIL %08X under %d: want %s, got \"%s\"\n", word, model, want_invalid ? "invalid" : flag_name,
+               ins.text);
+        failures++;
+    }
+}
+
+// Model validity: each model's exclusives render .long under the other
+// (matching the runtime program exception and objdump -m powerpc:<model>).
+static void test_model_validity(void) {
+    ppc_insn ins;
+    // 604-only encodings: OK under 604 (flagged is_604), invalid under 601.
+    static const uint32_t only604[] = {
+        0x7C6C42E6u, // mftb r3
+        0x7C00046Cu, // tlbsync
+        0x7C6427AEu, // stfiwx
+        0xFC4D34EEu, // fsel
+        0xEC403030u, // fres
+        0xFC403034u, // frsqrte
+    };
+    for (unsigned i = 0; i < sizeof(only604) / sizeof(only604[0]); i++) {
+        expect_model(only604[i], 604, 0, "ok");
+        expect_model(only604[i], 601, 1, "ok");
+        ppc_disassemble(only604[i], 0x1000u, &ins);
+        checks++;
+        if (!ins.is_604) {
+            printf("FAIL: %08X not flagged is_604\n", only604[i]);
+            failures++;
+        }
+    }
+    // 601-only encodings: OK under 601, invalid under 604.
+    static const uint32_t only601[] = {
+        0x7C6402D0u, // abs
+        0x7C6402A6u, // mfspr r3,rtcu (SPR 4 read encoding: is_power)
+        0x7C6428D6u, // mul r3,r4,r5
+    };
+    for (unsigned i = 0; i < sizeof(only601) / sizeof(only601[0]); i++) {
+        expect_model(only601[i], 601, 0, "ok");
+        expect_model(only601[i], 604, 1, "ok");
+    }
+    // Shared encodings stay OK under both.
+    expect_model(0x7C642A14u, 601, 0, "ok"); // add
+    expect_model(0x7C642A14u, 604, 0, "ok");
+}
+
 int main(void) {
     for (unsigned i = 0; i < sizeof(vectors) / sizeof(vectors[0]); i++)
         expect(vectors[i].addr, vectors[i].word, vectors[i].text);
     test_targets();
     test_power_flag();
+    test_model_validity();
     printf("ppc_disasm: %d checks, %d failures\n", checks, failures);
     return failures ? 1 : 0;
 }

--- a/tests/unit/suites/ppc_fpu/fpu_corpus.h
+++ b/tests/unit/suites/ppc_fpu/fpu_corpus.h
@@ -86,7 +86,7 @@ static uint64_t ppc_fpu_corpus_hash(void) {
         }
     }
 
-    // frsp / fctiw over the edges and each mode.
+    // frsp / fctiw / the 604 estimates over the edges and each mode.
     for (uint32_t rn = 0; rn < 4; rn++) {
         for (unsigned i = 0; i < CORPUS_N_EDGES; i++) {
             uint32_t fpscr = rn;
@@ -95,6 +95,14 @@ static uint64_t ppc_fpu_corpus_hash(void) {
             h = corpus_mix(h, fpscr);
             fpscr = rn;
             wrote = ppc_sf_fctiw(corpus_edges[i], (int)(rn & 1u), &fpscr, &frt);
+            h = corpus_mix(h, wrote ? frt : 0xDEADull);
+            h = corpus_mix(h, fpscr);
+            fpscr = rn;
+            wrote = ppc_sf_fres(corpus_edges[i], &fpscr, &frt);
+            h = corpus_mix(h, wrote ? frt : 0xDEADull);
+            h = corpus_mix(h, fpscr);
+            fpscr = rn;
+            wrote = ppc_sf_frsqrte(corpus_edges[i], &fpscr, &frt);
             h = corpus_mix(h, wrote ? frt : 0xDEADull);
             h = corpus_mix(h, fpscr);
         }

--- a/tests/unit/suites/ppc_fpu/test.c
+++ b/tests/unit/suites/ppc_fpu/test.c
@@ -671,7 +671,7 @@ int main(void) {
     memory_populate_pages(ctx->memory, 0x40800000u, 0x40820000u);
     test_set_active_context(ctx);
 
-    P = ppc_init(NULL);
+    P = ppc_init(NULL, CPU_MODEL_PPC601);
     if (!P) {
         printf("FAIL: ppc_init\n");
         return 1;

--- a/tests/unit/suites/ppc_fpu/test.c
+++ b/tests/unit/suites/ppc_fpu/test.c
@@ -539,6 +539,100 @@ static void test_host_oracle(void) {
     printf("oracle-s: %d comparisons\n", compared);
 }
 
+// === 2b. The 604 estimate kernels (PEM fresx/frsqrtex pages) ================
+
+// Directed status semantics: only the architected FPSCR effects appear —
+// no XX ever, FR/FI read cleared — and the VE/ZE suppression cases return
+// 0 with the target untouched.
+static void test_estimates_directed(void) {
+    uint64_t frt;
+    uint32_t f;
+
+    // fres: an inexact reciprocal raises nothing (XX is not an effect)
+    f = 0;
+    CHECK(ppc_sf_fres(0x4008000000000000ull /* 3.0 */, &f, &frt) == 1);
+    CHECK_EQ64(frt, 0x3FD5555560000000ull); // single 1/3, widened
+    CHECK_EQ32(f & ~PPC_FPSCR_FPRF, 0); // no XX, no FR/FI, no FX
+    // 1/±0: ZX (+FX), per-sign infinity; suppressed under ZE
+    f = 0;
+    CHECK(ppc_sf_fres(0x8000000000000000ull, &f, &frt) == 1);
+    CHECK_EQ64(frt, 0xFFF0000000000000ull);
+    CHECK(f & PPC_FPSCR_ZX);
+    CHECK(f & PPC_FPSCR_FX);
+    f = PPC_FPSCR_ZE;
+    CHECK(ppc_sf_fres(0x0000000000000000ull, &f, &frt) == 0);
+    CHECK((f & (PPC_FPSCR_ZX | PPC_FPSCR_FEX)) == (PPC_FPSCR_ZX | PPC_FPSCR_FEX));
+    // SNaN: VXSNAN, quieted delivery; suppressed under VE
+    f = 0;
+    CHECK(ppc_sf_fres(0x7FF0000000000001ull, &f, &frt) == 1);
+    CHECK(f & PPC_FPSCR_VXSNAN);
+    f = PPC_FPSCR_VE;
+    CHECK(ppc_sf_fres(0x7FF0000000000001ull, &f, &frt) == 0);
+    // ±inf → ±0, no status
+    f = 0;
+    CHECK(ppc_sf_fres(0xFFF0000000000000ull, &f, &frt) == 1);
+    CHECK_EQ64(frt, 0x8000000000000000ull);
+    CHECK_EQ32(f & ~PPC_FPSCR_FPRF, 0);
+
+    // frsqrte specials (PEM table): the sign/class ladder
+    f = 0;
+    CHECK(ppc_sf_frsqrte(0x7FF0000000000000ull, &f, &frt) == 1); // +inf → +0
+    CHECK_EQ64(frt, 0);
+    f = 0;
+    CHECK(ppc_sf_frsqrte(0xBFF0000000000000ull, &f, &frt) == 1); // -1 → QNaN + VXSQRT
+    CHECK_EQ64(frt, 0x7FF8000000000000ull);
+    CHECK(f & PPC_FPSCR_VXSQRT);
+    f = PPC_FPSCR_VE;
+    CHECK(ppc_sf_frsqrte(0xFFF0000000000000ull, &f, &frt) == 0); // -inf suppressed
+    CHECK(f & PPC_FPSCR_VXSQRT);
+    f = 0;
+    CHECK(ppc_sf_frsqrte(0x8000000000000000ull, &f, &frt) == 1); // -0 → -inf + ZX
+    CHECK_EQ64(frt, 0xFFF0000000000000ull);
+    CHECK(f & PPC_FPSCR_ZX);
+    f = 0;
+    CHECK(ppc_sf_frsqrte(0x7FF8000000000042ull, &f, &frt) == 1); // QNaN propagates
+    CHECK_EQ64(frt, 0x7FF8000000000042ull);
+    CHECK_EQ32(f & ~PPC_FPSCR_FPRF, 0);
+    // A denormal input normalizes through the unpack
+    f = 0;
+    CHECK(ppc_sf_frsqrte(0x0008000000000000ull /* 2^-1023 */, &f, &frt) == 1);
+    CHECK_EQ64(frt, 0x5FE6A09E667F3BCDull); // 2^511.5 = sqrt(2)*2^511 (deterministic)
+    CHECK_EQ32(f & ~PPC_FPSCR_FPRF, 0); // inexact never reported
+}
+
+// The architected error envelopes over a random sweep, with the host's
+// double arithmetic as the (amply precise) reference: fres within 2^-8
+// relative, frsqrte within 2^-5 (PEM pages; ours are near-exact, so a
+// tight 2^-23 / 2^-52-ish bound would also hold — the envelope is what
+// the architecture promises, so the envelope is what is pinned).
+static void test_estimates_envelope(void) {
+    uint64_t rng = 0x604E57117A7E5EEDull;
+    int compared = 0;
+    for (int n = 0; n < 20000; n++) {
+        uint64_t frt;
+        uint32_t f = 0;
+        // fres: exponent held inside the single-result range
+        uint64_t a = corpus_rng(&rng);
+        a = (a & ~0xFFF0000000000000ull) | ((uint64_t)(0x390 + (corpus_rng(&rng) % 0xE0)) << 52);
+        CHECK(ppc_sf_fres(a, &f, &frt) == 1);
+        double x = u2d(a), r = u2d(frt);
+        double want = 1.0 / x;
+        CHECK(fabs((r - want) / want) <= 1.0 / 256.0);
+        CHECK(!(f & (PPC_FPSCR_XX | PPC_FPSCR_FR | PPC_FPSCR_FI)));
+        // frsqrte: any positive normal-ish operand
+        f = 0;
+        uint64_t b = corpus_rng(&rng);
+        b = (b & ~0xFFF0000000000000ull) | ((uint64_t)(0x010 + (corpus_rng(&rng) % 0x7D0)) << 52);
+        CHECK(ppc_sf_frsqrte(b, &f, &frt) == 1);
+        double y = u2d(b), s = u2d(frt);
+        double want2 = 1.0 / sqrt(y);
+        CHECK(fabs((s - want2) / want2) <= 1.0 / 32.0);
+        CHECK(!(f & (PPC_FPSCR_XX | PPC_FPSCR_FR | PPC_FPSCR_FI)));
+        compared += 2;
+    }
+    printf("estimate-envelope: %d comparisons\n", compared);
+}
+
 // === 3. Ops-level integration (interpreter, CR1, trap) ======================
 
 static ppc_t *P;
@@ -687,6 +781,8 @@ int main(void) {
     test_frsp();
     test_fctiw();
     test_host_oracle();
+    test_estimates_directed();
+    test_estimates_envelope();
     test_interpreter_integration();
 
     // The cross-host corpus digest: `make wasm-check` compares this line

--- a/tests/unit/suites/ppc_mmu/test.c
+++ b/tests/unit/suites/ppc_mmu/test.c
@@ -63,9 +63,11 @@ static void run_at(uint32_t addr, int n) {
     ppc_run(P, &budget);
 }
 
-// Reset to a clean supervisor state with EP cleared so exception vectors
-// land at $00000xxx (mapped RAM), translation off.
+// Reset to a clean 601 supervisor state with EP cleared so exception
+// vectors land at $00000xxx (mapped RAM), translation off.  The model is
+// pinned: ppc_reset preserves cpu_model and the 604 section flips it.
 static void fresh(void) {
+    P->cpu_model = CPU_MODEL_PPC601;
     ppc_reset(P);
     P->msr = PPC_MSR_ME | PPC_MSR_FP;
     ppc_update_active_maps(P);
@@ -473,6 +475,332 @@ static void test_ioseg_error(void) {
     CHECK_EQ(P->dar, 0x10000000u);
 }
 
+// === The 604 model (TNT proposal §4.3; PEM Ch. 7 / 604UM Ch. 5) ============
+
+// Reset into the 604 model, low vectors, translation off.
+static void fresh604(void) {
+    P->cpu_model = CPU_MODEL_PPC604;
+    ppc_reset(P);
+    P->msr = PPC_MSR_ME | PPC_MSR_FP;
+    ppc_update_active_maps(P);
+}
+
+// Architected-BAT encoders (PEM Figure 7-13): BEPI/BL/Vs/Vp upper,
+// BRPN/WIMG/PP lower.
+static uint32_t bat604u(uint32_t bepi, uint32_t bl, int vs, int vp) {
+    return (bepi & 0xFFFE0000u) | ((bl & 0x7FFu) << 2) | (vs ? 2u : 0u) | (vp ? 1u : 0u);
+}
+static uint32_t bat604l(uint32_t brpn, uint32_t wimg, uint32_t pp) {
+    return (brpn & 0xFFFE0000u) | ((wimg & 0xFu) << 3) | (pp & 3u);
+}
+
+// Split I/D BATs: data goes through the DBATs, fetch through the IBATs,
+// and each side misses mappings that exist only on the other.
+static void test_604_split_bats(void) {
+    fresh604();
+    wipe_htab();
+    P->sdr1 = SDR1_VAL; // empty table behind the BATs
+    // DBAT0: EA $00400000 (128 KB) → PA $00300000, read/write
+    P->dbatu[0] = bat604u(0x00400000u, 0, 1, 0);
+    P->dbatl[0] = bat604l(0x00300000u, 0, 2);
+    memory_write_uint32(0x00300123u & ~3u, 0xD0DAD0DAu);
+    P->msr |= PPC_MSR_DT;
+    ppc_update_active_maps(P);
+    ppc_mmu_invalidate_all(P);
+    P->gpr[4] = 0x00400000u;
+    memory_write_uint32(0x1000, e_d(32, 3, 4, 0x120)); // lwz through the DBAT
+    run_at(0x1000, 1);
+    CHECK_EQ(P->gpr[3], 0xD0DAD0DAu);
+    // A store through PP=10 works and lands physically
+    P->gpr[3] = 0x600D600Du;
+    memory_write_uint32(0x1000, e_d(36, 3, 4, 0x200)); // stw
+    run_at(0x1000, 1);
+    CHECK_EQ(memory_read_uint32(0x00300200u), 0x600D600Du);
+    // Instruction translation ignores the DBATs: an IT-on fetch from the
+    // DBAT-only region walks the (empty) table → ISI with SRR1 bit 1 ONLY
+    // (the 604 has no 601 bit-10 companion).  The redirect consumes the
+    // budget on the handler's first instruction, so plant a nop there.
+    memory_write_uint32(0x400, 0x60000000u); // nop at the ISI vector
+    P->msr |= PPC_MSR_IT;
+    ppc_update_active_maps(P);
+    run_at(0x00400400u, 1);
+    CHECK_EQ(P->pc, 0x00000404u);
+    CHECK_EQ(P->srr0, 0x00400400u);
+    CHECK_EQ(P->srr1 & 0xFFFF0000u, 0x40000000u);
+    // IBAT0 makes the same fetch work
+    fresh604();
+    P->sdr1 = SDR1_VAL;
+    P->batu[0] = bat604u(0x00400000u, 0, 1, 0);
+    P->batl[0] = bat604l(0x00300000u, 0, 1); // PP=01 read-only suffices for fetch
+    P->msr |= PPC_MSR_IT;
+    ppc_update_active_maps(P);
+    ppc_mmu_invalidate_all(P);
+    memory_write_uint32(0x00300400u, 0x38600042u); // li r3,0x42
+    run_at(0x00400400u, 1);
+    CHECK_EQ(P->gpr[3], 0x42u);
+    CHECK_EQ(P->pc, 0x00400404u);
+    // ...while a DATA access through the IBAT-only region misses
+    P->msr |= PPC_MSR_DT;
+    P->msr &= (uint32_t)~PPC_MSR_IT;
+    ppc_update_active_maps(P);
+    P->gpr[4] = 0x00400000u;
+    memory_write_uint32(0x1000, e_d(32, 3, 4, 0));
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x00000300u);
+    CHECK_EQ(P->dsisr, PPC_DSISR_NOTFOUND);
+}
+
+// Architected BAT format: BL block sizing, Vs/Vp validity, PP protection.
+static void test_604_bat_format(void) {
+    fresh604();
+    wipe_htab();
+    P->sdr1 = SDR1_VAL;
+    // BL=1: a 256 KB block — offset +128 KB still matches, +256 KB misses
+    P->dbatu[0] = bat604u(0x00400000u, 1, 1, 0);
+    P->dbatl[0] = bat604l(0x00200000u, 0, 2);
+    P->msr |= PPC_MSR_DT;
+    ppc_update_active_maps(P);
+    ppc_mmu_invalidate_all(P);
+    memory_write_uint32(0x00220000u, 0x22222222u); // PA of EA +128 KB
+    P->gpr[4] = 0x00420000u;
+    memory_write_uint32(0x1000, e_d(32, 3, 4, 0));
+    run_at(0x1000, 1);
+    CHECK_EQ(P->gpr[3], 0x22222222u);
+    P->gpr[4] = 0x00440000u; // +256 KB: outside the block → table miss DSI
+    memory_write_uint32(0x1000, e_d(32, 3, 4, 0));
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x00000300u);
+    CHECK_EQ(P->dsisr, PPC_DSISR_NOTFOUND);
+    // Vs-only BAT is invisible to user mode (Vp clear): user access misses
+    // (SRs are all zero after the reset — VSID 0, T=0)
+    fresh604();
+    P->sdr1 = SDR1_VAL;
+    P->dbatu[0] = bat604u(0x00400000u, 0, 1, 0); // supervisor-valid only
+    P->dbatl[0] = bat604l(0x00300000u, 0, 2);
+    P->msr |= PPC_MSR_DT | PPC_MSR_PR;
+    ppc_update_active_maps(P);
+    ppc_mmu_invalidate_all(P);
+    P->gpr[4] = 0x00400000u;
+    memory_write_uint32(0x1000, e_d(32, 3, 4, 0));
+    // (user-mode FETCH at $1000 is IT-off: untranslated)
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc & 0xFFFu, 0x300u);
+    CHECK_EQ(P->dsisr, PPC_DSISR_NOTFOUND);
+    // PP=01 read-only: load ok, store takes the protection DSI
+    fresh604();
+    P->sdr1 = SDR1_VAL;
+    P->dbatu[0] = bat604u(0x00400000u, 0, 1, 0);
+    P->dbatl[0] = bat604l(0x00300000u, 0, 1);
+    P->msr |= PPC_MSR_DT;
+    ppc_update_active_maps(P);
+    ppc_mmu_invalidate_all(P);
+    memory_write_uint32(0x00300040u, 0x0BADF00Du);
+    P->gpr[4] = 0x00400000u;
+    memory_write_uint32(0x1000, e_d(32, 3, 4, 0x40));
+    run_at(0x1000, 1);
+    CHECK_EQ(P->gpr[3], 0x0BADF00Du);
+    memory_write_uint32(0x1000, e_d(36, 3, 4, 0x40));
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x00000300u);
+    CHECK_EQ(P->dsisr, PPC_DSISR_PROT | PPC_DSISR_STORE);
+    // PP=00: no access at all
+    fresh604();
+    P->sdr1 = SDR1_VAL;
+    P->dbatu[0] = bat604u(0x00400000u, 0, 1, 0);
+    P->dbatl[0] = bat604l(0x00300000u, 0, 0);
+    P->msr |= PPC_MSR_DT;
+    ppc_update_active_maps(P);
+    ppc_mmu_invalidate_all(P);
+    P->gpr[4] = 0x00400000u;
+    memory_write_uint32(0x1000, e_d(32, 3, 4, 0));
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x00000300u);
+    CHECK_EQ(P->dsisr, PPC_DSISR_PROT);
+}
+
+// 604 ordering and direct-store delivery: BATs beat T=1; with no BAT a
+// direct-store access is a DSI (bit 0; atomics bit 5) / ISI (SRR1[3]);
+// real mode never consults the segment at all.
+static void test_604_tseg(void) {
+    // Real addressing mode: a memory-forced T=1 SR is IGNORED with DT=0
+    // (the 601 would rewrite the segment; §6.5.2 is 601-only).
+    fresh604();
+    P->sr[0] = 0x87F00003u; // memory-forced → physical segment 3 on a 601
+    ppc_recompute_sr_t_mask(P);
+    memory_write_uint32(0x00002000u, 0x0000C0DEu); // identity target (RAM)
+    P->gpr[4] = 0x00002000u;
+    memory_write_uint32(0x1000, e_d(32, 3, 4, 0));
+    run_at(0x1000, 1);
+    CHECK_EQ(P->gpr[3], 0x0000C0DEu); // read the EA, not segment 3
+    CHECK_EQ(P->sr_t_mask, 0); // the 604 mask stays clear by design
+    // DT=1, T=1 non-memory-forced, no BAT: plain load → DSI bit 0
+    fresh604();
+    P->sr[1] = 0x80100000u; // T=1, BUID $001
+    P->msr |= PPC_MSR_DT;
+    ppc_update_active_maps(P);
+    ppc_mmu_invalidate_all(P);
+    P->gpr[4] = 0x10002000u;
+    memory_write_uint32(0x1000, e_d(32, 3, 4, 0));
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x00000300u);
+    CHECK_EQ(P->dsisr, PPC_DSISR_DIRECT);
+    CHECK_EQ(P->dar, 0x10002000u);
+    // ...store adds the store bit
+    memory_write_uint32(0x1000, e_d(36, 3, 4, 0));
+    P->msr |= PPC_MSR_DT;
+    ppc_update_active_maps(P);
+    run_at(0x1000, 1);
+    CHECK_EQ(P->dsisr, PPC_DSISR_DIRECT | PPC_DSISR_STORE);
+    // ...lwarx takes the atomic-class DSI instead
+    memory_write_uint32(0x1000, e_x(3, 4, 0, 20, 0));
+    P->msr |= PPC_MSR_DT;
+    ppc_update_active_maps(P);
+    run_at(0x1000, 1);
+    CHECK_EQ(P->dsisr, PPC_DSISR_ATOMIC);
+    // ...and a BAT covering the same EA takes precedence over T=1
+    fresh604();
+    P->sr[1] = 0x80100000u;
+    P->dbatu[0] = bat604u(0x10000000u, 0, 1, 0);
+    P->dbatl[0] = bat604l(0x00300000u, 0, 2);
+    P->msr |= PPC_MSR_DT;
+    ppc_update_active_maps(P);
+    ppc_mmu_invalidate_all(P);
+    memory_write_uint32(0x00302000u, 0xBA7BEA75u);
+    P->gpr[4] = 0x10002000u;
+    memory_write_uint32(0x1000, e_d(32, 3, 4, 0));
+    run_at(0x1000, 1);
+    CHECK_EQ(P->gpr[3], 0xBA7BEA75u);
+    // T=1 fetch (no IBAT): ISI with the architected SRR1[3]
+    fresh604();
+    P->sr[1] = 0x80100000u;
+    memory_write_uint32(0x400, 0x60000000u); // nop at the ISI vector
+    P->msr |= PPC_MSR_IT;
+    ppc_update_active_maps(P);
+    ppc_mmu_invalidate_all(P);
+    run_at(0x10002000u, 1);
+    CHECK_EQ(P->pc, 0x00000404u);
+    CHECK_EQ(P->srr0, 0x10002000u);
+    CHECK_EQ(P->srr1 & 0xFFFF0000u, 0x10000000u);
+}
+
+// The 604's hardware-split page crossing: a misaligned word access whose
+// two pages translate DISCONTIGUOUSLY reads/writes the straddling bytes
+// with no exception (the 601 would take the alignment exception).
+static void test_604_split_access(void) {
+    fresh604();
+    wipe_htab();
+    // EA $00200000 → PA $00300000; EA $00201000 → PA $00280000
+    put_pte(0, 0x00200000u, 0x00300000u, 0, 0, 0, 2);
+    put_pte(0, 0x00201000u, 0x00280000u, 0, 0, 0, 2);
+    memory_write_uint32(0x00300FFCu, 0x1122AABBu); // last word of page 1
+    memory_write_uint32(0x00280000u, 0xCCDD3344u); // first word of page 2
+    enter_dt();
+    P->gpr[4] = 0x00200FFEu; // crosses the page boundary
+    memory_write_uint32(0x1000, e_d(32, 3, 4, 0)); // lwz
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x1004u); // no exception
+    CHECK_EQ(P->gpr[3], 0xAABBCCDDu);
+    // The split store lands its halves on both physical pages
+    P->gpr[3] = 0x55667788u;
+    memory_write_uint32(0x1000, e_d(36, 3, 4, 0)); // stw
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x1004u);
+    P->msr &= (uint32_t)~PPC_MSR_DT;
+    ppc_update_active_maps(P);
+    CHECK_EQ(memory_read_uint32(0x00300FFCu), 0x11225566u);
+    CHECK_EQ(memory_read_uint32(0x00280000u), 0x77883344u);
+    // The same access on the 601 is an alignment exception
+    fresh();
+    wipe_htab();
+    put_pte(0, 0x00200000u, 0x00300000u, 0, 0, 0, 2);
+    put_pte(0, 0x00201000u, 0x00280000u, 0, 0, 0, 2);
+    enter_dt();
+    P->gpr[4] = 0x00200FFEu;
+    memory_write_uint32(0x1000, e_d(32, 3, 4, 0));
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x00000600u);
+    CHECK_EQ(P->dar, 0x00200FFEu);
+}
+
+// Per-class tlbie on the 604: invalidating the EA drops the cached
+// translation so the next access re-walks the (rewritten) table.
+static void test_604_tlbie(void) {
+    fresh604();
+    wipe_htab();
+    uint32_t pte = put_pte(0, 0x00200000u, 0x00300000u, 0, 0, 0, 2);
+    memory_write_uint32(0x00300010u, 0x0DDBA115u);
+    memory_write_uint32(0x00280010u, 0x0FADEDA7u);
+    enter_dt();
+    P->gpr[4] = 0x00200000u;
+    memory_write_uint32(0x1000, e_d(32, 3, 4, 0x10));
+    run_at(0x1000, 1);
+    CHECK_EQ(P->gpr[3], 0x0DDBA115u);
+    // Repoint the PTE and tlbie the EA: the stale cached translation dies
+    memory_write_uint32(pte + 4, 0x00280000u | 2u);
+    P->gpr[5] = 0x00200000u;
+    memory_write_uint32(0x1000, e_x(0, 0, 5, 306, 0)); // tlbie r5
+    memory_write_uint32(0x1004, e_d(32, 3, 4, 0x10)); // reload
+    run_at(0x1000, 2);
+    CHECK_EQ(P->gpr[3], 0x0FADEDA7u);
+}
+
+// dcbz on the 604: alignment with the data cache disabled (the HRESET
+// state) or locked; zeroes through a DBAT once HID0[DCE] is on; W=1 or
+// I=1 targets fault; direct-store targets are no-ops.
+static void test_604_dcbz(void) {
+    fresh604();
+    CHECK_EQ(P->hid0, 0); // HRESET: caches disabled
+    P->gpr[4] = 0x00002000u;
+    memory_write_uint32(0x2000, 0xFFFFFFFFu);
+    memory_write_uint32(0x1000, e_x(0, 0, 4, 1014, 0)); // dcbz 0,r4
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x00000600u); // cache disabled → alignment (604UM §4.5.6)
+    CHECK_EQ(memory_read_uint32(0x2000), 0xFFFFFFFFu);
+    // DCE on: the block zeroes
+    fresh604();
+    P->hid0 = 0x00004000u; // DCE
+    P->gpr[4] = 0x00002000u;
+    memory_write_uint32(0x2000, 0xFFFFFFFFu);
+    memory_write_uint32(0x201C, 0xFFFFFFFFu);
+    memory_write_uint32(0x1000, e_x(0, 0, 4, 1014, 0));
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x1004u);
+    CHECK_EQ(memory_read_uint32(0x2000), 0);
+    CHECK_EQ(memory_read_uint32(0x201C), 0);
+    // DCL set: locked → alignment again
+    fresh604();
+    P->hid0 = 0x00004000u | 0x00001000u;
+    P->gpr[4] = 0x00002000u;
+    memory_write_uint32(0x1000, e_x(0, 0, 4, 1014, 0));
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x00000600u);
+    // I=1 DBAT mapping: alignment
+    fresh604();
+    wipe_htab();
+    P->hid0 = 0x00004000u;
+    P->sdr1 = SDR1_VAL;
+    P->dbatu[0] = bat604u(0x00400000u, 0, 1, 0);
+    P->dbatl[0] = bat604l(0x00300000u, 0x4u /* I */, 2);
+    P->msr |= PPC_MSR_DT;
+    ppc_update_active_maps(P);
+    ppc_mmu_invalidate_all(P);
+    P->gpr[4] = 0x00400000u;
+    memory_write_uint32(0x1000, e_x(0, 0, 4, 1014, 0));
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x00000600u);
+    // Direct-store target: no-op, no exception
+    fresh604();
+    P->hid0 = 0x00004000u;
+    P->sr[1] = 0x80100000u; // T=1 non-memory-forced
+    P->msr |= PPC_MSR_DT;
+    ppc_update_active_maps(P);
+    ppc_mmu_invalidate_all(P);
+    P->gpr[4] = 0x10002000u;
+    memory_write_uint32(0x1000, e_x(0, 0, 4, 1014, 0));
+    run_at(0x1000, 1);
+    CHECK_EQ(P->pc, 0x1004u);
+}
+
 int main(void) {
     // 32-bit address space: 8 MB RAM at 0, 128 KB ROM at $40800000 (the
     // ppc-suite context shape).
@@ -503,6 +831,15 @@ int main(void) {
     test_dcbz_wimg();
     test_fetch_translation();
     test_ioseg_error();
+
+    // The 604 model (TNT proposal §4.3): split BATs, architected format,
+    // ordering/direct-store, hardware-split crossings, tlbie, dcbz.
+    test_604_split_bats();
+    test_604_bat_format();
+    test_604_tseg();
+    test_604_split_access();
+    test_604_tlbie();
+    test_604_dcbz();
 
     ppc_delete(P);
     printf("ppc_mmu: %d checks, %d failures\n", checks, failures);

--- a/tests/unit/suites/ppc_mmu/test.c
+++ b/tests/unit/suites/ppc_mmu/test.c
@@ -485,7 +485,7 @@ int main(void) {
     memory_populate_pages(ctx->memory, 0x40800000u, 0x40820000u);
     test_set_active_context(ctx);
 
-    P = ppc_init(NULL); // reserves the user SoA arrays and wipes them
+    P = ppc_init(NULL, CPU_MODEL_PPC601); // reserves the user SoA arrays and wipes them
     if (!P) {
         printf("FAIL: ppc_init\n");
         return 1;

--- a/tests/unit/suites/ppc_vectors/test.c
+++ b/tests/unit/suites/ppc_vectors/test.c
@@ -45,6 +45,7 @@
 #include "harness.h"
 #include "memory.h"
 
+#include <dirent.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -52,6 +53,12 @@
 
 // The runner's CLI, renamed by the Makefile so this file can own main().
 int ppc_runner_main(int argc, char **argv);
+
+// Which model the custom backend builds (TNT proposal §4.5): the corpus is
+// generated from the sail 601 model, and main() below replays it twice —
+// once as the 601 (every file), once as the 604 with the 601-divergent
+// mnemonics filtered out.
+static int g_backend_model = CPU_MODEL_PPC601;
 
 // 8 MB of RAM at 0: the vectors' 64 KiB test window ($00100000, recorded in
 // each file's provenance) has to be ordinary read/write memory.  ROM sits
@@ -82,7 +89,7 @@ static int custom_open(ppc_backend *self, char *err, size_t errlen) {
     memory_populate_pages(CTX->memory, 0x40800000u, 0x40820000u); // plants the RAM/ROM page tables
     test_set_active_context(CTX);
 
-    P = ppc_init(NULL, CPU_MODEL_PPC601);
+    P = ppc_init(NULL, g_backend_model);
     if (!P) {
         snprintf(err, errlen, "ppc_init failed");
         return -1;
@@ -306,6 +313,48 @@ static const char *find_vectors_dir(void) {
     return NULL;
 }
 
+// Mnemonic files whose replay legitimately diverges under the 604 model
+// (TNT proposal §4.5: "the 601-only encodings masked out"): the POWER
+// holdovers and MQ/RTC SPR moves trap; mtmsr/rfi mask differently; the
+// word-alignment classes and dcbz's cache-disabled rule fault where the
+// sail 601 model completes.  Everything else must replay bit-identically.
+static const char *const skip_604[] = {
+    // POWER holdovers (program exception on the 604)
+    "abs", "clcs", "div", "divs", "doz", "dozi", "lscbx", "maskg", "maskir", "mul", "nabs", "rlmi", "rrib", "sle",
+    "sleq", "sliq", "slliq", "sllq", "slq", "sraiq", "sraq", "sre", "srea", "sreq", "sriq", "srliq", "srlq", "srq",
+    // per-model SPR map / MSR mask
+    "mfspr", "mtspr", "mtmsr", "rfi",
+    // 604 word-alignment classes (604UM §4.5.6)
+    "lfd", "lfdu", "lfdux", "lfdx", "lfs", "lfsu", "lfsux", "lfsx", "stfd", "stfdu", "stfdux", "stfdx", "stfs", "stfsu",
+    "stfsux", "stfsx", "lmw", "stmw", "lwarx", "stwcx_dot", "eciwx", "ecowx",
+    // dcbz gates on HID0[DCE] (cleared in the vectors' fixed HID0)
+    "dcbz"};
+
+static int skip_under_604(const char *name) {
+    for (size_t i = 0; i < sizeof skip_604 / sizeof skip_604[0]; i++)
+        if (strcmp(name, skip_604[i]) == 0)
+            return 1;
+    return 0;
+}
+
+// Run one pass of the runner over `files` (count `nfiles`), passing the
+// caller's extra argv through.
+static int run_pass(char *argv0, int argc, char **argv, char **files, int nfiles) {
+    char **av = calloc((size_t)argc + (size_t)nfiles + 4, sizeof *av);
+    int n = 0;
+    av[n++] = argv0;
+    av[n++] = (char *)"--backend";
+    av[n++] = (char *)"custom";
+    for (int i = 1; i < argc; i++)
+        av[n++] = argv[i];
+    for (int i = 0; i < nfiles; i++)
+        av[n++] = files[i];
+    av[n] = NULL;
+    int rc = ppc_runner_main(n, av);
+    free(av);
+    return rc;
+}
+
 int main(int argc, char **argv) {
     const char *dir = find_vectors_dir();
     if (!dir) {
@@ -315,20 +364,49 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    // Prepend the backend selection and append the tier, so hand-driven
-    // invocations can still pass runner flags:
-    //   tests/unit/build/ppc_vectors --verbose --filter add
-    char **av = calloc((size_t)argc + 5, sizeof *av);
-    int n = 0;
-    av[n++] = argv[0];
-    av[n++] = (char *)"--backend";
-    av[n++] = (char *)"custom";
-    for (int i = 1; i < argc; i++)
-        av[n++] = argv[i];
-    av[n++] = (char *)dir;
-    av[n] = NULL;
+    // Pass 1 — the 601 over the whole tier (hand-driven invocations can
+    // still pass runner flags: tests/unit/build/ppc_vectors --verbose
+    // --filter add).
+    g_backend_model = CPU_MODEL_PPC601;
+    char *tier[1] = {(char *)dir};
+    printf("[ppc_vectors] 601 pass\n");
+    int rc = run_pass(argv[0], argc, argv, tier, 1);
+    if (rc != 0)
+        return rc;
 
-    int rc = ppc_runner_main(n, av);
-    free(av);
+    // Pass 2 — the 604 over the model-shared subset.
+    DIR *dp = opendir(dir);
+    if (!dp) {
+        fprintf(stderr, "[ppc_vectors] cannot enumerate %s\n", dir);
+        return 1;
+    }
+    char **files = NULL;
+    int nfiles = 0, cap = 0;
+    struct dirent *de;
+    while ((de = readdir(dp)) != NULL) {
+        const char *suffix = strstr(de->d_name, ".json");
+        if (!suffix)
+            continue;
+        char base[128];
+        snprintf(base, sizeof base, "%.*s", (int)(suffix - de->d_name), de->d_name);
+        if (skip_under_604(base))
+            continue;
+        if (nfiles == cap) {
+            cap = cap ? cap * 2 : 64;
+            files = realloc(files, (size_t)cap * sizeof *files);
+        }
+        char *path = malloc(strlen(dir) + strlen(de->d_name) + 2);
+        sprintf(path, "%s/%s", dir, de->d_name);
+        files[nfiles++] = path;
+    }
+    closedir(dp);
+
+    g_backend_model = CPU_MODEL_PPC604;
+    printf("[ppc_vectors] 604 pass (%d files; %d model-divergent mnemonics skipped)\n", nfiles,
+           (int)(sizeof skip_604 / sizeof skip_604[0]));
+    rc = run_pass(argv[0], argc, argv, files, nfiles);
+    for (int i = 0; i < nfiles; i++)
+        free(files[i]);
+    free(files);
     return rc;
 }

--- a/tests/unit/suites/ppc_vectors/test.c
+++ b/tests/unit/suites/ppc_vectors/test.c
@@ -82,7 +82,7 @@ static int custom_open(ppc_backend *self, char *err, size_t errlen) {
     memory_populate_pages(CTX->memory, 0x40800000u, 0x40820000u); // plants the RAM/ROM page tables
     test_set_active_context(CTX);
 
-    P = ppc_init(NULL);
+    P = ppc_init(NULL, CPU_MODEL_PPC601);
     if (!P) {
         snprintf(err, errlen, "ppc_init failed");
         return -1;

--- a/tools/disasm/disasm.c
+++ b/tools/disasm/disasm.c
@@ -4,7 +4,7 @@
 // disasm.c
 // Standalone disassembler tool for binary files: 68000/68030 (default,
 // via the core cpu_disasm.c decoder), DSP3210 (--arch dsp3210), or PowerPC
-// 601 (--arch ppc).  Minimal dependencies in every mode.
+// 601/604 (--arch ppc / ppc604).  Minimal dependencies in every mode.
 
 #include "annotate_disasm.h"
 #include "cpu.h"
@@ -43,7 +43,7 @@ static void print_usage(const char *progname) {
             "  -l, --length <bytes>          Number of bytes to disassemble. Default: entire file from offset\n"
             "  -a, --address-offset <addr>   Base address for display (hex). Default: 0\n"
             "  -n, --count <n>               Maximum number of instructions to disassemble\n"
-            "  -A, --arch <name>             Instruction set: m68k (default), dsp3210, or ppc\n"
+            "  -A, --arch <name>             Instruction set: m68k (default), dsp3210, ppc (alias ppc601), or ppc604\n"
             "  -h, --help                    Show this help message\n",
             progname);
 }
@@ -98,9 +98,12 @@ int main(int argc, char *argv[]) {
     }
 
     bool arch_dsp3210 = strcmp(arch, "dsp3210") == 0;
-    bool arch_ppc = strcmp(arch, "ppc") == 0;
+    // "ppc"/"ppc601" apply the 601's validity view, "ppc604" the 604's
+    // (the two models trap each other's exclusive encodings).
+    bool arch_ppc = strcmp(arch, "ppc") == 0 || strcmp(arch, "ppc601") == 0 || strcmp(arch, "ppc604") == 0;
+    int ppc_model = strcmp(arch, "ppc604") == 0 ? 604 : 601;
     if (!arch_dsp3210 && !arch_ppc && strcmp(arch, "m68k") != 0) {
-        fprintf(stderr, "Error: unknown --arch '%s' (want m68k, dsp3210, or ppc).\n", arch);
+        fprintf(stderr, "Error: unknown --arch '%s' (want m68k, dsp3210, ppc, or ppc604).\n", arch);
         return 1;
     }
 
@@ -173,7 +176,7 @@ int main(int argc, char *argv[]) {
             const uint8_t *bp = raw_buf + (size_t)pos * 4;
             uint32_t w = (uint32_t)bp[0] << 24 | (uint32_t)bp[1] << 16 | (uint32_t)bp[2] << 8 | bp[3];
             ppc_insn ins;
-            ppc_disassemble(w, addr, &ins);
+            ppc_disassemble_model(w, addr, ppc_model, &ins);
             // "mnemonic\toperands" -> single aligned column pair
             char mnem[32], ops[64];
             const char *tab = strchr(ins.text, '\t');


### PR DESCRIPTION
## PowerPC 604 CPU model (TNT proposal, Phase A / "PR 1")

The `ppc` module now implements **two** CPU models — `CPU_MODEL_PPC601` (unchanged, the PDM machines) and the new `CPU_MODEL_PPC604` — discriminated on the pre-existing `ppc_t.cpu_model` field, exactly the way `cpu.c` discriminates 68000/030/040. The 604 is **dead code on every shipping machine** until the `tnt` family lands (PR 2).

### Commits

- **ppc: 604 model core — split BATs, timebase, per-model SPR/decode validity**
  Model enum + `cpu_arch_for_model` membership; `MMU_PPC_604`; per-model decode-tree validity (601-only leaves trap on the 604 and vice versa); timebase/`mftb` + DEC at the TB rate via the generalized `ppc_bind_time`; architected split I/D BATs; per-EA-class `tlbie` + `tlbsync`; 604 MSR bits (POW/BE/PM/RI), PVR/HID0, machine-check TEA image, `$00D00`/`$00F00` vectors; SPR dispatch tightening per model; the 604 hardware-split misaligned-access gate; the optional-FP group (`fsel`/`fres`/`frsqrte`/`stfiwx`, integer-only softfloat kernels with architected status masking); disassembler model-awareness (`ppc_disassemble_model`, `tools/disasm --arch ppc604`).

- **ppc: 604 unit matrix, dual-model vectors replay, docs**
  `test_604_*` matrices in the `ppc`/`ppc_mmu` suites; estimate directed + envelope tests in `ppc_fpu`; 604 mnemonic and model-validity rows in `ppc_disasm`; the dual-model sail-vectors replay; the 604 section in `docs/core/cpu/ppc.md`; AGENTS.md object-model note.

### Verification

| Check | Result |
|---|---|
| `tests/unit/suites/ppc` | 612 checks, 0 failures (601 suite + new `test_604_*` matrix) |
| `tests/unit/suites/ppc_mmu` | 104 checks, 0 failures (601 + new 604 section) |
| `tests/unit/suites/ppc_fpu` | 609,486 checks, 0 failures (incl. 40k estimate-envelope comparisons) |
| `tests/unit/suites/ppc_disasm` | 195 checks, 0 failures (604 mnemonics + model-validity views) |
| `tests/unit/suites/ppc_vectors` | dual-model: 4612 sail vectors pass as 601, 3400 as 604, 0 failures |
| Full `make -C tests/unit run` | all suites pass |
| `make integration-test TIER=unit` | all 41 tests pass, incl. `pdm-rom-ladder` at rung L20 with byte-exact chime WAV and screen goldens |
| Builds | WASM (`make`), headless (`make -f Makefile.headless`), `tools/disasm` all clean |

The PDM/601 ladder passing with byte-identical goldens is the regression proof that matters most: the refactor touched the 601's hot load/store path (the 604 hardware-split gate) and nothing moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
