### PR TITLE
Four of the open bug tickets: device-page logpoints, the machine.boot wedge, pacing across a rebuild, and an interruptible run

### DIFF
--- a/.agents/skills/headless-debug/SKILL.md
+++ b/.agents/skills/headless-debug/SKILL.md
@@ -125,7 +125,15 @@ with `grep -v '^#'` if you don't want them.
 
 **Disconnect cancels a run.** If the driving client disconnects mid-run,
 the daemon detects EOF and stops the scheduler instead of burning the
-budget.
+budget — and cancels the script it was running, so a shell loop around
+the run stops with it rather than starting the next iteration.
+
+**A run inside a shell loop is stoppable too.** A `while` loop that
+calls `scheduler.run` is one statement to the daemon, so a second
+connection cannot reach the shell until the loop ends. It is answered
+out of band instead: `stop` (or `scheduler.stop` / `shell.interrupt` /
+`quit`) on that connection ends the run and cancels the loop, and
+anything else is refused with `# busy: ...` rather than executed.
 
 ## 4. The shell grammar
 
@@ -390,6 +398,10 @@ Arguments: `addr` (required), `mode` (`pc` default / `read` / `write`
 for read/write), `value` (fire only on matching value), `space`
 (`logical`/`physical`).
 
+**Device registers are covered.** A logpoint on an I/O address (say
+VIA1 port B at physical `$50F00000`) fires on every CPU access the
+device answers, the same as one on RAM.
+
 **Memory logpoints only see CPU accesses.** They hook the CPU
 read/write path, so they do **not** fire on bus-master DMA or other
 device-engine writes (e.g. the IIfx SCSI DMA writes straight to host
@@ -468,8 +480,13 @@ scheduler.run                                         # unbounded (until breakpo
 scheduler.run 1000000                                 # instruction-budgeted
 scheduler.stop                                        # halt; safe to send on a
                                                       # second connection mid-run
-scheduler.mode                                        # max / realtime / hardware
+scheduler.mode                                        # paced / accelerated / turbo
+scheduler.mode = "turbo"                              # writable
 ```
+
+`scheduler.mode` reflects the daemon's `--speed=` flag and survives
+`machine.boot`, so a daemon launched `--speed=max` still reads `turbo`
+after a script's own `machine.boot`.
 
 `debug.step N` is sugar for "run N instructions, then stop".
 

--- a/docs/core/memory/memory.md
+++ b/docs/core/memory/memory.md
@@ -174,6 +174,14 @@ implementation must not slow down unrelated accesses, so the design is:
 - When a logpoint is removed, `memory_logpoint_uninstall()` decrements the
   refcount; if it reaches zero, the SoA entry is rebuilt from the cold-path
   page entry (or left zero so the next access re-fills via MMU).
+- **Device pages are covered too.** A page that dispatches to a device has no
+  host backing, so the route above — which reads through `pe->host_base` —
+  cannot see it. The device dispatch sites therefore go through the
+  `dev_read8/16/32` / `dev_write8/16/32` wrappers, which notify the hook with
+  the value the device answered (or was given). Device pages never sit in the
+  SoA fast path anyway, so this costs the nothing-armed load and nothing more.
+  Without it a logpoint on an I/O register reported zero events forever, which
+  reads exactly like "the guest never touches this register".
 
 The fast-path inline accessors in `memory.h` are unchanged — there are no extra
 branches or memory loads on the hot path. Only pages with active logpoints
@@ -183,6 +191,7 @@ Hooks and helpers:
 - `g_mem_logpoint_page_count` — per-page refcount (in `memory.h`)
 - `g_mem_logpoint_hook` — function pointer set by debug.c (`debug_memory_logpoint_hook`)
 - `memory_logpoint_install(start_page, end_page)` / `..._uninstall(...)` — page refcount helpers
+- `dev_read8/16/32`, `dev_write8/16/32` (memory.c) — device dispatch + hook notify
 
 ## Key Files
 

--- a/docs/core/scheduler/scheduler.md
+++ b/docs/core/scheduler/scheduler.md
@@ -876,7 +876,7 @@ The scheduler is an object-model citizen (`scheduler.*` paths in the typed shell
 |-----------------------------|------------------------------------------------------------|
 | `scheduler.run [N]`         | Start execution; optionally stop after N instructions.     |
 | `scheduler.stop`            | Stop execution immediately.                                |
-| `scheduler.mode`            | Pacing mode: `"paced"` \| `"accelerated"` \| `"turbo"` (writable; legacy aliases `real`/`hw` → paced, `max` → turbo, `accel` → accelerated). |
+| `scheduler.mode`            | Pacing mode: `"paced"` \| `"accelerated"` \| `"turbo"` (writable; legacy aliases `real`/`hw` → paced, `max` → turbo, `accel` → accelerated). Survives `machine.boot` / `machine.restart`: pacing is the host harness's setting (`--speed=`), not part of the machine's boot document, so the rebuild re-asserts it on the new machine's scheduler. |
 | `scheduler.cpi`             | Per-machine CPI constant; writable as a debug override (1..255). |
 | `scheduler.speed`           | Accelerated-mode multiplier in force (live). Write `0` for auto (adaptive governor) or 1.0 .. 8.0 to pin; persisted, but only takes effect in mode `accelerated`. |
 | `scheduler.speed_auto`      | RO: true while the adaptive governor is choosing the speed (`speed = 0`). |

--- a/docs/machines/tnt/tnt.md
+++ b/docs/machines/tnt/tnt.md
@@ -510,10 +510,24 @@ goes to ttya regardless, which is why the boot chatter appears on the
 serial port even when the console does not.
 
 Apple documents the alternative and it is `setenv`. The integration rows do
-exactly that, once, on the machine's own keyboard, and cold-boot; the Grand
-Central NVRAM part is non-volatile and the setting sticks for the same
-reason it does on the real machine. `tests/integration/lib/ans.script`
-wraps it.
+exactly that, once, on the machine's own keyboard, and cold-boot with
+`machine.restart`; the Grand Central NVRAM part is non-volatile and the
+setting sticks for the same reason it does on the real machine.
+`tests/integration/lib/ans.script` wraps it.
+
+**Which rebuild the store survives.** The carry follows the power switch:
+`machine.restart` rebuilds *this* machine, so the soldered part comes back
+with it, while `machine.boot` builds a *new* machine and hands it a virgin
+store (proposal-boot-vs-reset §2 — a machine inherits nothing it was not
+given). That is not bookkeeping. A run stopped part-way through Open
+Firmware's format of a virgin store — a bounded `scheduler.run`, a client
+that walked away mid-run — leaves the store torn, and a machine built on a
+torn store never reaches a boot: it sits in the ROM's serial-console read
+loop behind a black screen. Carrying such a store into the next
+`machine.boot` made that look like a broken model or an unbootable disk.
+A row that wants the same chip across two cold boots says so with
+`machine.restart` (ans-diag-floppy's DIMM table, `ans_boot_serial`'s
+console setting); `machine.board.clear_nvram()` is still the battery pull.
 
 The 54M30 also answers the **legacy** VGA I/O block (`$3B0`-`$3DF`) rather
 than its relocatable BAR, because this board installs no pull-down on MD51

--- a/src/core/machine_config.h
+++ b/src/core/machine_config.h
@@ -161,6 +161,13 @@ void machine_config_object_init(struct object *machine_obj);
 // old machine still running — on rejection.
 value_t machine_boot_apply(const boot_config_t *doc);
 
+// True while machine_boot_apply is rebuilding the SAME machine for
+// machine.restart (a power-cycle), false while it is building a NEW machine
+// for machine.boot.  Non-volatile hardware that outlives the power switch —
+// the mounted media, the Caps Lock latch, the TNT's soldered NVRAM part —
+// is carried across a restart only; a machine.boot inherits nothing (§2).
+bool machine_boot_is_restart(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/core/memory/memory.c
+++ b/src/core/memory/memory.c
@@ -269,6 +269,50 @@ static inline bool logpoint_lookup(uint32_t addr, uint8_t **host_out, bool *writ
     return logpoint_lookup_armed(addr, host_out, writable_out);
 }
 
+// Notify the hook for an access that a DEVICE answered.  The RAM/ROM route
+// above reads through a host pointer, which a device page does not have, so
+// without this a logpoint on an I/O register never fires — and reports zero
+// events, which reads exactly like "the guest never touches this register".
+// Device pages never sit in the SoA fast path, so the notify costs the
+// nothing-armed load and nothing more.
+static inline void logpoint_notify_device(uint32_t addr, unsigned size, uint32_t value, bool is_write) {
+    uint8_t *host;
+    bool writable;
+    if (g_mem_logpoint_hook && logpoint_lookup(addr, &host, &writable))
+        g_mem_logpoint_hook(addr, size, value, is_write);
+}
+
+// Device dispatch + logpoint notify, one wrapper per access width.  `addr` is
+// the access address the logpoint matches against (logical or physical, as
+// the caller resolved it); `off` is the device-relative offset it dispatches.
+static inline uint8_t dev_read8(const page_entry_t *pe, uint32_t addr, uint32_t off) {
+    uint8_t v = pe->dev->read_uint8(pe->dev_context, off);
+    logpoint_notify_device(addr, 1, v, false);
+    return v;
+}
+static inline uint16_t dev_read16(const page_entry_t *pe, uint32_t addr, uint32_t off) {
+    uint16_t v = pe->dev->read_uint16(pe->dev_context, off);
+    logpoint_notify_device(addr, 2, v, false);
+    return v;
+}
+static inline uint32_t dev_read32(const page_entry_t *pe, uint32_t addr, uint32_t off) {
+    uint32_t v = pe->dev->read_uint32(pe->dev_context, off);
+    logpoint_notify_device(addr, 4, v, false);
+    return v;
+}
+static inline void dev_write8(const page_entry_t *pe, uint32_t addr, uint32_t off, uint8_t value) {
+    pe->dev->write_uint8(pe->dev_context, off, value);
+    logpoint_notify_device(addr, 1, value, true);
+}
+static inline void dev_write16(const page_entry_t *pe, uint32_t addr, uint32_t off, uint16_t value) {
+    pe->dev->write_uint16(pe->dev_context, off, value);
+    logpoint_notify_device(addr, 2, value, true);
+}
+static inline void dev_write32(const page_entry_t *pe, uint32_t addr, uint32_t off, uint32_t value) {
+    pe->dev->write_uint32(pe->dev_context, off, value);
+    logpoint_notify_device(addr, 4, value, true);
+}
+
 // Decide whether a device registered at this logical page should be
 // dispatched directly, or whether the access must instead fall through to the
 // MMU table walk.
@@ -362,7 +406,7 @@ uint8_t memory_read_uint8_slow(uint32_t addr) {
     // → $00xxxxxx) falls through to the MMU walk below so the translated RAM
     // is read instead of returning ROM bytes from the $40000000 device window.
     if (pe->dev && dispatch_device_at_logical(addr, g_active_read == g_supervisor_read))
-        return pe->dev->read_uint8(pe->dev_context, addr - pe->base_addr);
+        return dev_read8(pe, addr, addr - pe->base_addr);
     // When MMU is enabled, dispatch via PHYSICAL address (after table walk),
     // not via the logical page-table entry — otherwise a user-virtual address
     // whose upper byte coincides with a host-machine MMIO range (e.g. virtual
@@ -376,7 +420,7 @@ uint8_t memory_read_uint8_slow(uint32_t addr) {
     if (g_mmu && g_mmu->enabled) {
         bool supervisor = g_active_read == g_supervisor_read;
         if (pe->dev && mmu_check_tt(g_mmu, addr, false, supervisor))
-            return pe->dev->read_uint8(pe->dev_context, addr - pe->base_addr);
+            return dev_read8(pe, addr, addr - pe->base_addr);
         if (mmu_handle_fault(g_mmu, addr, false, supervisor)) {
             uintptr_t base = g_active_read[addr >> PAGE_SHIFT];
             if (base != 0)
@@ -389,7 +433,7 @@ uint8_t memory_read_uint8_slow(uint32_t addr) {
             if ((int)phys_page < g_page_count) {
                 page_entry_t *phys_pe = &g_page_table[phys_page];
                 if (phys_pe->dev)
-                    return phys_pe->dev->read_uint8(phys_pe->dev_context, phys - phys_pe->base_addr);
+                    return dev_read8(phys_pe, addr, phys - phys_pe->base_addr);
             }
             // Re-check the logpoint now that mmu_handle_fault has run
             // (physical-space logpoints suppress the fill and require
@@ -416,7 +460,7 @@ uint8_t memory_read_uint8_slow(uint32_t addr) {
     }
     // MMU disabled: logical == physical, dispatch by logical page-table entry.
     if (pe->dev)
-        return pe->dev->read_uint8(pe->dev_context, addr - pe->base_addr);
+        return dev_read8(pe, addr, addr - pe->base_addr);
     // Unmapped physical memory returns $FF (floating bus, pull-up resistors).
     // This matches real 68k Mac hardware behavior and is critical for:
     //   - ROM RAM sizing (write pattern / read-back $FF → detects boundary)
@@ -453,7 +497,7 @@ uint16_t memory_read_uint16_slow(uint32_t addr) {
     // dispatch_device_at_logical above).
     if (pe->dev && (addr & PAGE_MASK) <= MEM_PAGE_SIZE - 2 &&
         dispatch_device_at_logical(addr, g_active_read == g_supervisor_read))
-        return pe->dev->read_uint16(pe->dev_context, addr - pe->base_addr);
+        return dev_read16(pe, addr, addr - pe->base_addr);
 
     // When MMU is enabled, dispatch via PHYSICAL address (see write_uint8_slow
     // comment for the rationale).  Cross-page accesses fall through to byte
@@ -461,7 +505,7 @@ uint16_t memory_read_uint16_slow(uint32_t addr) {
     if (g_mmu && g_mmu->enabled && (addr & PAGE_MASK) <= MEM_PAGE_SIZE - 2) {
         bool supervisor = g_active_read == g_supervisor_read;
         if (pe->dev && mmu_check_tt(g_mmu, addr, false, supervisor))
-            return pe->dev->read_uint16(pe->dev_context, addr - pe->base_addr);
+            return dev_read16(pe, addr, addr - pe->base_addr);
         if (mmu_handle_fault(g_mmu, addr, false, supervisor)) {
             uintptr_t base = g_active_read[addr >> PAGE_SHIFT];
             if (base != 0)
@@ -471,7 +515,7 @@ uint16_t memory_read_uint16_slow(uint32_t addr) {
             if ((int)phys_page < g_page_count) {
                 page_entry_t *phys_pe = &g_page_table[phys_page];
                 if (phys_pe->dev)
-                    return phys_pe->dev->read_uint16(phys_pe->dev_context, phys - phys_pe->base_addr);
+                    return dev_read16(phys_pe, addr, phys - phys_pe->base_addr);
             }
             if (logpoint_lookup(addr, &lp_host, &lp_writable) && lp_host) {
                 uint16_t v = LOAD_BE16(lp_host);
@@ -494,7 +538,7 @@ uint16_t memory_read_uint16_slow(uint32_t addr) {
 
     // MMU-off fallback: dispatch device on logical page-table entry.
     if (pe->dev && (addr & PAGE_MASK) <= MEM_PAGE_SIZE - 2)
-        return pe->dev->read_uint16(pe->dev_context, addr - pe->base_addr);
+        return dev_read16(pe, addr, addr - pe->base_addr);
 
     // Cross-page or host memory at page boundary: split into two byte reads
     uint16_t hi = memory_read_uint8(addr);
@@ -530,7 +574,7 @@ uint32_t memory_read_uint32_slow(uint32_t addr) {
     // Gate logical-device dispatch (24-bit Mac OS master-pointer fix).
     if (pe->dev && (addr & PAGE_MASK) <= MEM_PAGE_SIZE - 4 &&
         dispatch_device_at_logical(addr, g_active_read == g_supervisor_read)) {
-        uint32_t v = pe->dev->read_uint32(pe->dev_context, addr - pe->base_addr);
+        uint32_t v = dev_read32(pe, addr, addr - pe->base_addr);
         return v;
     }
 
@@ -539,7 +583,7 @@ uint32_t memory_read_uint32_slow(uint32_t addr) {
     if (g_mmu && g_mmu->enabled && (addr & PAGE_MASK) <= MEM_PAGE_SIZE - 4) {
         bool supervisor = g_active_read == g_supervisor_read;
         if (pe->dev && mmu_check_tt(g_mmu, addr, false, supervisor))
-            return pe->dev->read_uint32(pe->dev_context, addr - pe->base_addr);
+            return dev_read32(pe, addr, addr - pe->base_addr);
         if (mmu_handle_fault(g_mmu, addr, false, supervisor)) {
             uintptr_t base = g_active_read[addr >> PAGE_SHIFT];
             if (base != 0)
@@ -549,7 +593,7 @@ uint32_t memory_read_uint32_slow(uint32_t addr) {
             if ((int)phys_page < g_page_count) {
                 page_entry_t *phys_pe = &g_page_table[phys_page];
                 if (phys_pe->dev)
-                    return phys_pe->dev->read_uint32(phys_pe->dev_context, phys - phys_pe->base_addr);
+                    return dev_read32(phys_pe, addr, phys - phys_pe->base_addr);
             }
             if (logpoint_lookup(addr, &lp_host, &lp_writable) && lp_host) {
                 uint32_t v = LOAD_BE32(lp_host);
@@ -572,7 +616,7 @@ uint32_t memory_read_uint32_slow(uint32_t addr) {
 
     // MMU-off fallback: dispatch device on logical page-table entry.
     if (pe->dev && (addr & PAGE_MASK) <= MEM_PAGE_SIZE - 4) {
-        uint32_t v = pe->dev->read_uint32(pe->dev_context, addr - pe->base_addr);
+        uint32_t v = dev_read32(pe, addr, addr - pe->base_addr);
         return v;
     }
 
@@ -842,7 +886,7 @@ void memory_write_uint8_slow(uint32_t addr, uint8_t value) {
     // Gate logical-device dispatch (24-bit Mac OS master-pointer fix — see
     // dispatch_device_at_logical above).
     if (pe->dev && dispatch_device_at_logical(addr, g_active_write == g_supervisor_write)) {
-        pe->dev->write_uint8(pe->dev_context, addr - pe->base_addr, value);
+        dev_write8(pe, addr, addr - pe->base_addr, value);
         return;
     }
     // When MMU is enabled, the page-table device lookup must use the PHYSICAL
@@ -858,7 +902,7 @@ void memory_write_uint8_slow(uint32_t addr, uint8_t value) {
         // Fast path: TT match means logical = physical, so the logical pe->dev
         // IS the correct dispatch — skip the table walk.
         if (pe->dev && mmu_check_tt(g_mmu, addr, true, supervisor)) {
-            pe->dev->write_uint8(pe->dev_context, addr - pe->base_addr, value);
+            dev_write8(pe, addr, addr - pe->base_addr, value);
             return;
         }
         if (mmu_handle_fault(g_mmu, addr, true, supervisor)) {
@@ -875,7 +919,7 @@ void memory_write_uint8_slow(uint32_t addr, uint8_t value) {
             if ((int)phys_page < g_page_count) {
                 page_entry_t *phys_pe = &g_page_table[phys_page];
                 if (phys_pe->dev) {
-                    phys_pe->dev->write_uint8(phys_pe->dev_context, phys - phys_pe->base_addr, value);
+                    dev_write8(phys_pe, addr, phys - phys_pe->base_addr, value);
                     return;
                 }
             }
@@ -903,7 +947,7 @@ void memory_write_uint8_slow(uint32_t addr, uint8_t value) {
     }
     // MMU disabled: logical == physical, dispatch by logical page-table entry.
     if (pe->dev) {
-        pe->dev->write_uint8(pe->dev_context, addr - pe->base_addr, value);
+        dev_write8(pe, addr, addr - pe->base_addr, value);
         return;
     }
 }
@@ -941,7 +985,7 @@ void memory_write_uint16_slow(uint32_t addr, uint16_t value) {
     // Gate logical-device dispatch (24-bit Mac OS master-pointer fix).
     if (pe->dev && (addr & PAGE_MASK) <= MEM_PAGE_SIZE - 2 &&
         dispatch_device_at_logical(addr, g_active_write == g_supervisor_write)) {
-        pe->dev->write_uint16(pe->dev_context, addr - pe->base_addr, value);
+        dev_write16(pe, addr, addr - pe->base_addr, value);
         return;
     }
 
@@ -950,7 +994,7 @@ void memory_write_uint16_slow(uint32_t addr, uint16_t value) {
     if (g_mmu && g_mmu->enabled && (addr & PAGE_MASK) <= MEM_PAGE_SIZE - 2) {
         bool supervisor = g_active_write == g_supervisor_write;
         if (pe->dev && mmu_check_tt(g_mmu, addr, true, supervisor)) {
-            pe->dev->write_uint16(pe->dev_context, addr - pe->base_addr, value);
+            dev_write16(pe, addr, addr - pe->base_addr, value);
             return;
         }
         if (mmu_handle_fault(g_mmu, addr, true, supervisor)) {
@@ -964,7 +1008,7 @@ void memory_write_uint16_slow(uint32_t addr, uint16_t value) {
             if ((int)phys_page < g_page_count) {
                 page_entry_t *phys_pe = &g_page_table[phys_page];
                 if (phys_pe->dev) {
-                    phys_pe->dev->write_uint16(phys_pe->dev_context, phys - phys_pe->base_addr, value);
+                    dev_write16(phys_pe, addr, phys - phys_pe->base_addr, value);
                     return;
                 }
             }
@@ -989,7 +1033,7 @@ void memory_write_uint16_slow(uint32_t addr, uint16_t value) {
 
     // MMU-off fallback: dispatch device on logical page-table entry.
     if (pe->dev && (addr & PAGE_MASK) <= MEM_PAGE_SIZE - 2) {
-        pe->dev->write_uint16(pe->dev_context, addr - pe->base_addr, value);
+        dev_write16(pe, addr, addr - pe->base_addr, value);
         return;
     }
 
@@ -1031,7 +1075,7 @@ void memory_write_uint32_slow(uint32_t addr, uint32_t value) {
     // Gate logical-device dispatch (24-bit Mac OS master-pointer fix).
     if (pe->dev && (addr & PAGE_MASK) <= MEM_PAGE_SIZE - 4 &&
         dispatch_device_at_logical(addr, g_active_write == g_supervisor_write)) {
-        pe->dev->write_uint32(pe->dev_context, addr - pe->base_addr, value);
+        dev_write32(pe, addr, addr - pe->base_addr, value);
         return;
     }
 
@@ -1040,7 +1084,7 @@ void memory_write_uint32_slow(uint32_t addr, uint32_t value) {
     if (g_mmu && g_mmu->enabled && (addr & PAGE_MASK) <= MEM_PAGE_SIZE - 4) {
         bool supervisor = g_active_write == g_supervisor_write;
         if (pe->dev && mmu_check_tt(g_mmu, addr, true, supervisor)) {
-            pe->dev->write_uint32(pe->dev_context, addr - pe->base_addr, value);
+            dev_write32(pe, addr, addr - pe->base_addr, value);
             return;
         }
         if (mmu_handle_fault(g_mmu, addr, true, supervisor)) {
@@ -1054,7 +1098,7 @@ void memory_write_uint32_slow(uint32_t addr, uint32_t value) {
             if ((int)phys_page < g_page_count) {
                 page_entry_t *phys_pe = &g_page_table[phys_page];
                 if (phys_pe->dev) {
-                    phys_pe->dev->write_uint32(phys_pe->dev_context, phys - phys_pe->base_addr, value);
+                    dev_write32(phys_pe, addr, phys - phys_pe->base_addr, value);
                     return;
                 }
             }
@@ -1079,7 +1123,7 @@ void memory_write_uint32_slow(uint32_t addr, uint32_t value) {
 
     // MMU-off fallback: dispatch device on logical page-table entry.
     if (pe->dev && (addr & PAGE_MASK) <= MEM_PAGE_SIZE - 4) {
-        pe->dev->write_uint32(pe->dev_context, addr - pe->base_addr, value);
+        dev_write32(pe, addr, addr - pe->base_addr, value);
         return;
     }
 

--- a/src/core/scheduler/scheduler.c
+++ b/src/core/scheduler/scheduler.c
@@ -1106,6 +1106,11 @@ bool scheduler_is_running(struct scheduler *restrict s) {
     return s->running;
 }
 
+// Read the scheduler's pacing mode; a machine without a scheduler paces.
+enum schedule_mode scheduler_get_mode(const struct scheduler *s) {
+    return s ? s->mode : schedule_paced;
+}
+
 // Set the scheduler pacing mode (paced, unthrottled or accelerated)
 void scheduler_set_mode(struct scheduler *restrict s, enum schedule_mode mode) {
     if (!s)

--- a/src/core/scheduler/scheduler.h
+++ b/src/core/scheduler/scheduler.h
@@ -136,6 +136,9 @@ bool scheduler_is_running(struct scheduler *restrict s);
 // Set scheduler pacing mode (paced/unthrottled/accelerated)
 void scheduler_set_mode(struct scheduler *restrict s, enum schedule_mode mode);
 
+// Read the current pacing mode (paced when there is no scheduler)
+enum schedule_mode scheduler_get_mode(const struct scheduler *s);
+
 // Set the accelerated-mode CPU speed multiplier: 0 = auto (the adaptive
 // governor picks moment to moment, bounded by max_speed), any other value
 // pins a fixed multiplier (clamped to [1.0, 8.0]; stored as x256 fixed

--- a/src/machines/machine.c
+++ b/src/machines/machine.c
@@ -15,6 +15,7 @@
 #include "object.h"
 #include "prom.h"
 #include "rom.h"
+#include "scheduler.h"
 #include "system.h"
 #include "system_config.h"
 #include "value.h"
@@ -676,6 +677,13 @@ static void stage_pci_options(const char *spec) {
 // a new machine starts with empty drives.
 static bool s_transfer_media = false;
 
+// Is machine_boot_apply rebuilding the same machine (machine.restart) rather
+// than building a new one?  Machine-specific teardown asks this before
+// carrying non-volatile hardware state across the rebuild (machine_config.h).
+bool machine_boot_is_restart(void) {
+    return s_transfer_media;
+}
+
 // Stamp the record's `created` field with the current UTC time (ISO8601).
 static void stamp_created(char *buf, size_t bufsize) {
     time_t now = time(NULL);
@@ -821,6 +829,17 @@ value_t machine_boot_apply(const boot_config_t *doc_in) {
     media_slot_t media[MEDIA_SLOTS_MAX];
     int n_media = 0;
     bool caps_latched = false;
+    // Pacing is a property of the HOST harness, not of the emulated machine,
+    // so it survives the rebuild: without this the daemon's --speed= setting
+    // (and any scheduler.mode a script set) is silently discarded by the
+    // first machine.boot, and scheduler.mode then reads back 'paced' on a
+    // daemon launched --speed=max.
+    enum schedule_mode pacing = schedule_paced;
+    bool pacing_known = false;
+    if (global_emulator && global_emulator->scheduler) {
+        pacing = scheduler_get_mode(global_emulator->scheduler);
+        pacing_known = true;
+    }
     if (global_emulator) {
         if (s_transfer_media && global_emulator->machine->substrate->media_detach)
             n_media = global_emulator->machine->substrate->media_detach(global_emulator, media, MEDIA_SLOTS_MAX);
@@ -876,6 +895,11 @@ value_t machine_boot_apply(const boot_config_t *doc_in) {
             image_close(media[i].img); // half-built machine; drop the transfer
         return val_err("machine.boot: machine created but ROM staging failed for '%s'", doc.rom);
     }
+
+    // The carried pacing (see above): re-assert it on the machine's own
+    // fresh scheduler, which was constructed in the default paced mode.
+    if (pacing_known && cfg->scheduler)
+        scheduler_set_mode(cfg->scheduler, pacing);
 
     // Hand the transferred media handles back through the device attach
     // paths (§3.3).  The rebuilt machine is the same model by construction
@@ -951,9 +975,10 @@ static value_t machine_method_boot(struct object *self, const member_t *m, int a
 // §3.2): rebuild the machine described by the built-from record, taking no
 // configuration arguments, and keep the mounted media attached by
 // transferring the open image handles across the teardown (§3.3).  Errors
-// when no machine is running.  Runtime state that is not construction
-// configuration (scheduler mode, volume, host capture sources) is out of
-// scope — the frontend re-asserts it.
+// when no machine is running.  Host-side runtime state that is not
+// construction configuration (volume, host capture sources) is out of scope
+// — the frontend re-asserts it.  Scheduler pacing is the exception every
+// rebuild keeps: it is the harness's setting, not the machine's.
 static value_t machine_method_restart(struct object *self, const member_t *m, int argc, const value_t *argv) {
     (void)self;
     (void)m;

--- a/src/machines/tnt/tnt.c
+++ b/src/machines/tnt/tnt.c
@@ -38,6 +38,7 @@
 #include "image.h"
 #include "log.h"
 #include "mac_host_io.h"
+#include "machine_config.h" // machine_boot_is_restart (the NVRAM carry rule)
 #include "pci.h"
 #include "ppc.h"
 #include "rtc.h"
@@ -402,6 +403,17 @@ static void tnt_fwscsi_attach(config_t *cfg) {
 // startup volume.  Real hardware behaves the same way; its NVRAM just
 // never starts blank twice.  A checkpoint restore overrides the carry
 // (the gc blob holds the store).
+//
+// The carry follows the power switch, i.e. machine.restart, and stops
+// at machine.boot: that builds a NEW machine, which inherits nothing it
+// was not given (proposal-boot-vs-reset §2).  The distinction is not
+// bookkeeping.  A run stopped part-way through Open Firmware's format of
+// a virgin store — a bounded `scheduler.run`, a client that walked away
+// mid-run — leaves the store torn, and a machine built on a torn store
+// stops in the ROM's serial-console read loop with a black screen and
+// no way back short of restarting the process.  Rows that DO want the
+// same chip across two cold boots (ans-diag-floppy's DIMM table) say so
+// with machine.restart.
 static uint8_t tnt_nvram_carry[TNT_NVRAM_SIZE];
 static bool tnt_nvram_carry_valid;
 
@@ -662,8 +674,15 @@ static void tnt_teardown(config_t *cfg) {
         scheduler_stop(cfg->scheduler);
     tnt_state_t *st = tnt_st(cfg);
     if (st) {
-        memcpy(tnt_nvram_carry, st->gc.nvram, TNT_NVRAM_SIZE);
-        tnt_nvram_carry_valid = true;
+        // Power-cycle (machine.restart): the soldered part comes back with
+        // the machine.  New machine (machine.boot): it gets a virgin store,
+        // and the previous machine's goes with the previous machine.
+        if (machine_boot_is_restart()) {
+            memcpy(tnt_nvram_carry, st->gc.nvram, TNT_NVRAM_SIZE);
+            tnt_nvram_carry_valid = true;
+        } else {
+            tnt_nvram_carry_valid = false;
+        }
     }
     if (st) {
         tnt_awacs_teardown(cfg);

--- a/src/platform/headless/headless_main.c
+++ b/src/platform/headless/headless_main.c
@@ -320,6 +320,56 @@ static int daemon_client_poll(int client_fd) {
     return 0;
 }
 
+// While a run is in flight the daemon is inside one client's dispatch, so a
+// second connection waits in the listen backlog until that dispatch returns.
+// For a bare `scheduler.run` that is a short wait; for a `scheduler.run`
+// inside a shell `while` loop it is forever, and the daemon looks wedged with
+// only kill -9 as a way out.  Answer such a connection out of band instead:
+// the run is stoppable from it, and anything else is refused with a note
+// rather than executed, since the shell is busy with the first client.
+static void daemon_serve_control_connection(void) {
+    struct pollfd pfd = {.fd = g_listen_fd, .events = POLLIN, .revents = 0};
+    if (g_listen_fd < 0 || poll(&pfd, 1, 0) <= 0 || !(pfd.revents & POLLIN))
+        return;
+    int fd = accept(g_listen_fd, NULL, NULL);
+    if (fd < 0)
+        return;
+
+    // One line, and only what is already there: a control client that sends
+    // nothing must not stall the run it came to stop.
+    char line[256];
+    ssize_t n = recv(fd, line, sizeof(line) - 1, MSG_DONTWAIT);
+    if (n < 0)
+        n = 0;
+    line[n] = '\0';
+    for (char *p = line; *p; p++)
+        if (*p == '\n' || *p == '\r')
+            *p = '\0';
+    char *cmd = line;
+    while (*cmd == ' ')
+        cmd++;
+
+    const char *reply;
+    if (strcmp(cmd, "stop") == 0 || strcmp(cmd, "scheduler.stop") == 0 || strcmp(cmd, "shell.interrupt") == 0 ||
+        strcmp(cmd, "shell.interrupt()") == 0) {
+        // The two halves of the terminal's Ctrl-C: end the run in flight, and
+        // cancel the script loop that would otherwise start the next one.
+        scheduler_t *s = system_scheduler();
+        if (s)
+            scheduler_stop(s);
+        script_interrupt();
+        reply = "# run stopped by control connection\n";
+    } else if (strcmp(cmd, "quit") == 0) {
+        quit_requested = 1;
+        reply = "# quit requested\n";
+    } else {
+        reply = "# busy: a run is in flight on another connection; "
+                "this connection accepts only stop / shell.interrupt / quit\n";
+    }
+    (void)!write(fd, reply, strlen(reply));
+    close(fd);
+}
+
 // Pump the scheduler until it stops, emitting periodic heartbeat lines (IMP-105).
 // In daemon mode the heartbeat prevents nc -w timeouts; in script/stdin modes it
 // lets callers follow progress. Emits once per second with instruction count.
@@ -360,9 +410,13 @@ static void pump_scheduler_with_heartbeat(void) {
         if (g_daemon_mode && g_client_fd >= 0) {
             int s = daemon_client_poll(g_client_fd);
             if (s < 0) {
-                // Client gone — cancel the run rather than execute billions more
+                // Client gone — cancel the run rather than execute billions
+                // more.  Cancel the script too: a shell `while` loop would
+                // otherwise start the next `scheduler.run` immediately and
+                // spin on forever with nobody left to read its output.
                 fprintf(stderr, "# client disconnected, stopping run\n");
                 scheduler_stop(sched);
+                script_interrupt();
                 break;
             }
             if (s > 0) {
@@ -371,6 +425,8 @@ static void pump_scheduler_with_heartbeat(void) {
                 scheduler_stop(sched);
                 break;
             }
+            // A second client with something to say about this run.
+            daemon_serve_control_connection();
         }
     }
 }

--- a/tests/integration/ans-diag-floppy/test.script
+++ b/tests/integration/ans-diag-floppy/test.script
@@ -19,7 +19,11 @@ def diag_boot() {
     machine.boot model="ans500" ram=65536 rom="${$ROM}"
     machine.board.keyswitch = "service"
     scheduler.run 2000000000
-    machine.boot model="ans500" ram=65536 rom="${$ROM}"
+    # The SECOND boot is the same machine coming up again, not a new one, so
+    # it is a power-cycle: machine.restart carries the soldered NVRAM part
+    # (and with it POST's DIMM table) across the rebuild, where machine.boot
+    # now hands the new machine a virgin store.
+    machine.restart
 
     # Service: Open Firmware boots `diag-device` (`cd disk6 fd:diags`)
     # instead of `boot-device`, no typed command.

--- a/tests/integration/lib/ans.script
+++ b/tests/integration/lib/ans.script
@@ -84,6 +84,8 @@ def ans_boot_serial(model, ram_kb) {
     # where POST relocates into RAM and starts trusting the cached
     # configuration.  Every row here runs both profiles, so without this the
     # second one wedges.  `try` because the first call has no machine yet.
+    # (machine.boot below now starts from a virgin store on its own; the
+    # explicit battery pull stays as the row's stated precondition.)
     let cleared = try(machine.board.clear_nvram(), none)
     machine.boot model="${$model}" ram=$ram_kb rom="${$ROM}"
 
@@ -122,6 +124,11 @@ def ans_boot_serial(model, ram_kb) {
     machine.adb.keyboard.type("setenv input-device ttya\n")
     scheduler.run 400000000
     let ignored = machine.scc.a.sent()
-    machine.boot model="${$model}" ram=$ram_kb rom="${$ROM}"
+    # Cold-boot the SAME machine so the new console setting takes effect:
+    # machine.restart is the power switch, and the soldered NVRAM part (with
+    # the setenv just written into it) survives it.  A machine.boot would
+    # build a NEW machine, which starts from a virgin store and would come
+    # back on the screen console again.
+    machine.restart
     return ans_wait_prompt()
 }

--- a/tests/integration/lib/mac.script
+++ b/tests/integration/lib/mac.script
@@ -219,9 +219,28 @@ def wait_global(name, want, ceiling) {
 # Run for `n` guest ticks (1/60 s each): interaction delays are guest-
 # time constraints (DoubleTime is in ticks), so choreography built on
 # this ports across CPU speeds unchanged.
+#
+# `Ticks` is maintained by the Mac OS interrupt handler, so it stops
+# advancing the moment the guest stops being Mac OS (the MkLinux Booter's
+# hand-off to the Mach kernel, a system error, a hung interrupt path) --
+# and an unbounded wait for it never ends.  The ceiling below is the same
+# rule wait_stable and wait_match already follow: an instruction budget,
+# and a loud failure when it is spent.  A tick costs ~65 k instructions
+# on an SE/30 and ~550 k on a 601/604 (freq / CPI over 60 Hz), so 4 M per
+# tick leaves the slowest-per-tick machine ~7x of headroom -- enough that
+# only a guest that has genuinely stopped keeping Ticks hits it.  The +30
+# floors short waits, which are the ones a stalled tick would trip first.
+let RUN_TICKS_BUDGET = 4000000
+
 def run_ticks(n) {
     let t0 = debug.mac.globals.read("Ticks")
-    while debug.mac.globals.read("Ticks") < $t0 + $n { scheduler.run 500000 }
+    let spent = 0
+    let ceiling = ($n + 30) * $RUN_TICKS_BUDGET
+    while debug.mac.globals.read("Ticks") < $t0 + $n {
+        assert $spent < $ceiling "run_ticks: Ticks did not advance ${$n} from ${$t0} within ${$ceiling} instructions - has the guest left Mac OS?"
+        scheduler.run 500000
+        $spent = $spent + 500000
+    }
 }
 
 # Move-press-release SINGLE click at screen coordinates. The move is a real


### PR DESCRIPTION
Four of the six open bug tickets, each root-caused and fixed; the other two are
reported on below rather than guessed at.

## Fixed

### #108 — Memory logpoints are silently blind to device pages

A logpoint's RAM/ROM route reads through the page's host pointer, which a device
page does not have, so every I/O-register logpoint fell through to the device
dispatch and never fired. The device dispatch sites in the four slow paths now go
through `dev_read8/16/32` / `dev_write8/16/32`, which notify the hook with the
value the device answered (or was given). Device pages are never in the SoA fast
path, so this costs the nothing-armed load and nothing more.

Verified against the issue's own repro — a `space=physical` `rw` logpoint on
VIA1 port B at `$50F00000` on a pm7100 now reports the traffic `debug.log via 3`
shows — plus the same on a 68k SE/30, with a RAM logpoint in the same run as the
positive control that nothing regressed.

The issue's "possibly related" note about `debug.log adb 3` is not a bug: the
level plumbing sets 3 correctly (`adb level=3` reads back), there simply are no
level-3 lines on the paths that were being watched.

### #112 — A client disconnecting mid-run wedges the machine

Root cause is not the disconnect. It is the TNT's process-lifetime NVRAM carry:
`tnt_teardown` copied the 8 KB Grand Central store into a static holder and
`tnt_init` copied it back, so **any** `machine.boot` after the guest had started
running inherited the previous machine's store. Cutting a run short — a bounded
`scheduler.run`, a client that walked away — leaves that store torn part-way
through Open Firmware's format of a virgin one, and a machine built on a torn
store never boots: it sits in the ROM's serial-console read loop at
`$FFF21350` behind a black screen.

Reduced repro, no disconnect needed:

```
machine.boot model="pm7500" …
scheduler.run 100000          # 1000 is still fine; 100000 is not
machine.boot model="pm7500" …   # this machine can never boot
```

The carry now follows the power switch: `machine.restart` rebuilds *this*
machine and the soldered part comes back with it, while `machine.boot` builds a
*new* machine and hands it a virgin store — which is what
proposal-boot-vs-reset §2 says a machine.boot does with everything else.
`machine_boot_is_restart()` is the query the machine-specific teardown asks.

Two rows genuinely wanted the same chip across two cold boots and said so with
`machine.boot`; both now say `machine.restart`, which is what they meant:

- `ans-diag-floppy` — POST's DIMM table, so the utility's hardware
  configuration means something on the second boot (passes).
- `ans.script`'s `ans_boot_serial` — the `setenv output-device ttya` the row
  types on the machine's own keyboard.

This also removes the class of failure `ans_boot_serial` documents in a comment
("a 700 booting against a table an ans500 wrote … HANGS at `Jumping To RAM
Prog.`"): a `machine.boot` no longer inherits another model's store at all.

### #113 — machine.boot silently resets scheduler.mode

Pacing is the host harness's setting (`--speed=`), not part of the machine's
boot document, so `machine_boot_apply` now carries it across the teardown and
re-asserts it on the new machine's scheduler. A daemon launched `--speed=max`
reads `turbo` after a script's `machine.boot`, and after `machine.restart`.

### #114 — mac.script's tick helpers hang, and the loop cannot be interrupted

Both halves:

- `run_ticks` takes an instruction ceiling and fails loudly when it is spent
  (`run_ticks: Ticks did not advance … has the guest left Mac OS?`), the same
  rule `wait_stable`/`wait_match` already follow. The budget is 4 M
  instructions per tick — ~7x the cost of a tick on the slowest-per-tick
  machine (a 601/604 at ~550 k), ~60x on an SE/30 — so only a guest that has
  genuinely stopped keeping `Ticks` hits it. The loop's execution is otherwise
  unchanged, so click choreography is bit-identical.
- The daemon answers a second connection out of band while a run is in flight:
  `stop` / `scheduler.stop` / `shell.interrupt` / `quit` end the run **and**
  cancel the script loop; anything else is refused with `# busy: …` rather than
  executed behind the first client's back. A client that disconnects mid-run now
  also cancels the script, so a `while` loop stops with it instead of spinning
  forever with nobody to read its output.

Verified live: a `while … { scheduler.run }` loop is stopped from a second
connection (`line 1: interrupted`) with the daemon still serving afterwards, and
the same loop ends when its client drops.

## Not fixed

### #122 — ADB: a no-data Talk R0 completion re-posts a stale mouse-down

Investigated, not fixed — and worth recording what the obvious fix does.

The mechanism in the report is right: for a Talk R0 the device does not answer,
`adb.c` walks the host into the data phase and ends it with a dummy byte
(vADBInt low), which leaves the completion indistinguishable from a data
completion. The model already has the correct shape elsewhere — the idle SRQ
path signals "no data" at the wake-up rather than from a fetch phase.

Making the explicit Talk do the same (assert vADBInt low on the command's own
completion, in `adb_shift_complete_deferred`) does not survive contact:

- applied to every no-reply Talk, including the Talk R3 probes of the ROM's
  address enumeration, ADB dies at boot — a IIcx that reaches the Finder with
  `Ticks=0x167f` gets to `Ticks=0x1` and stops;
- narrowed to "a device that is there but has nothing to report", the machine
  boots identically (same `Ticks` at the same budget) and a click still posts
  exactly one down and one up — but the ROM then re-issues Talk R0 constantly
  (106 polls in the probe window becomes 5954, of which 5884 are timeouts),
  i.e. it reads the low line as SRQ and scans.

I could not reproduce the reported symptom locally to judge either variant
against it: a plain boot-click-release on a IIcx (System 7.1) keeps `MBState` at
`$80` for 120 M instructions after the release, on `main` and on this branch.
The symptom needs the MacTest dialog phases the issue describes. Shipping a
model change of this reach without being able to see the bug it targets is not a
trade I would make, so the branch leaves ADB alone.

### #115 — TNT: 256 colours leaves Control uninitialised

Not attempted: the divergence is inside Open Firmware before its first BAR
write, and reaching the repro at all needs the Monitors control panel driven by
hand on a booted 7.6 desktop. Nothing here is a guess I would want in the tree.

One note for whoever picks it up: the repro's "reboot" must now be
`machine.restart`, not `machine.boot` — after #112 a `machine.boot` hands the
new machine a virgin store, so the depth written into Grand Central's NVRAM is
gone before the boot that was supposed to show the bug.

## Testing

Local (each full output captured to a file):

- core: `debug`, `object-logpoint`, `shell-v2`, `shell-commands`, `boot-config`,
  `machine-restart`, `core-layering`, `machine-lifecycle`
- TNT/ANS (the family whose teardown changed): `tnt-hd-boot`, `tnt-rom-ladder`,
  `tnt-pci-slots`, `tnt-pci-mach64`, `tnt-hd-boot-8500`, `tnt-hd-boot-9500`,
  `ans-rom-ladder`, `ans-pci-slots`, `ans-machine-restart`, `ans-console`,
  `ans-macos-2rom`, `ans-diag-floppy`, `ans-device-tree`, `ans-scsi`
- click/`run_ticks` coverage: `suite-se30`, `suite-iicx`, `suite-iici`,
  `suite-quadra`

`ans-device-tree` and `ans-scsi` failed on the first pass with the old
`ans.script` (the setenv did not survive the final `machine.boot`) and pass with
the library fixed. Both build targets (headless and wasm) compile clean.

One flake, not from this branch: `suite-quadra`'s `q900-75-hd` row missed its
About-box golden once, and passed on a re-run of the same suite and on
`5095bbb` (the base commit) — 12 rows, 0 failed in both. Every row before it
retired an **identical** instruction count in the failing and passing runs
(37099199 / 197984642 / 703470424 / 97143206 / 373119181), so execution was
bit-identical up to the row. Pacing cannot be the cause either: booting that
same q900 and running the row's 600 M budget in `turbo` and in `paced` gives
the same instruction count, screen checksum and `Ticks` (590432442 /
976388698 / 0x1569), which is what scheduler.md already claims for the two
non-accelerated modes and what this branch now leaves in force. The
`run_ticks` change adds host-side statements only — the guest sees the same
`scheduler.run 500000` sequence.

The rest is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
