### PR TITLE
storage: coalesce runs when streaming an image, so "Save image…" is not minutes

### DIFF
--- a/src/core/storage/image.c
+++ b/src/core/storage/image.c
@@ -1130,6 +1130,23 @@ static int file_write_cb(void *ctx, const void *data, size_t size) {
     return (wrote == size) ? 0 : -1;
 }
 
+// storage_save_state emits a block at a time, so the destination stream sees
+// one small fwrite per block.  With stdio's default ~1 KB buffer that is still
+// a filesystem call every two blocks; a large buffer turns the whole export
+// into a handful of big writes.  Returns the buffer, which the caller must
+// keep alive until fclose and then free (NULL is harmless — the stream just
+// keeps its default buffering).
+#define IMAGE_EXPORT_BUFFER_BYTES (4u * 1024 * 1024)
+
+static char *stream_set_large_buffer(FILE *f) {
+    char *buf = malloc(IMAGE_EXPORT_BUFFER_BYTES);
+    if (buf && setvbuf(f, buf, _IOFBF, IMAGE_EXPORT_BUFFER_BYTES) != 0) {
+        free(buf);
+        return NULL;
+    }
+    return buf;
+}
+
 size_t image_save(image_t *image) {
     if (!image || !image->storage || !image->filename)
         return (size_t)-1;
@@ -1140,9 +1157,11 @@ size_t image_save(image_t *image) {
     FILE *f = fopen(image->filename, "wb");
     if (!f)
         return (size_t)-1;
+    char *iobuf = stream_set_large_buffer(f);
     storage_checkpoint(image->storage, NULL);
     int rc = storage_save_state(image->storage, f, file_write_cb);
     fclose(f);
+    free(iobuf);
     return (rc == GS_SUCCESS) ? 0 : (size_t)-1;
 }
 
@@ -1160,8 +1179,10 @@ int image_export_to(image_t *image, const char *dest_path) {
     FILE *f = fopen(dest_path, "wb");
     if (!f)
         return -1;
+    char *iobuf = stream_set_large_buffer(f);
     int rc = storage_save_state(image->storage, f, file_write_cb);
     fclose(f);
+    free(iobuf);
     if (rc != GS_SUCCESS) {
         remove(dest_path);
         return -1;

--- a/src/core/storage/storage.c
+++ b/src/core/storage/storage.c
@@ -47,6 +47,14 @@ LOG_USE_CATEGORY_NAME("storage");
 
 #define STORAGE_SNAPSHOT_VERSION 2
 
+// Staging-buffer size for storage_save_state.  Streaming a disk one block at a
+// time costs a seek plus a read per 512-byte block — over 130 000 filesystem
+// round trips per 64 MB.  Under WASMFS/OPFS each of those is a synchronous
+// access-handle call, which is what made exporting a real hard disk take
+// minutes.  Batching contiguous same-source runs through a buffer this size
+// cuts the round trips by three orders of magnitude.
+#define STORAGE_STREAM_CHUNK_BYTES (4u * 1024 * 1024)
+
 // ============================================================================
 // Internal types
 // ============================================================================
@@ -661,20 +669,93 @@ int storage_restore_from_checkpoint(storage_t *storage, checkpoint_t *checkpoint
 // Public API: Streaming
 // ============================================================================
 
+// Where a block's data comes from.  This is the axis runs are coalesced
+// along: consecutive blocks with the same source sit contiguously in the same
+// file, so they can be read in one call.
+typedef enum {
+    BLOCK_SRC_DELTA, // modified — read from the delta
+    BLOCK_SRC_BASE, // unmodified — read from the base image
+    BLOCK_SRC_ZERO, // unmodified with no base file — reads as zeros
+} block_src_t;
+
+static block_src_t block_source(const storage_t *s, uint64_t block) {
+    if (bitmap_test(s->bitmap, (uint32_t)block))
+        return BLOCK_SRC_DELTA;
+    return s->base_fp ? BLOCK_SRC_BASE : BLOCK_SRC_ZERO;
+}
+
 int storage_save_state(storage_t *storage, void *context, storage_write_callback_t write_cb) {
     if (!storage || !context || !write_cb)
         return GS_ERROR;
 
-    uint8_t buffer[STORAGE_MAX_BLOCK_SIZE];
-    for (uint64_t block = 0; block < storage->block_count; block++) {
-        size_t offset = (size_t)block * storage->block_size;
-        int rc = storage_read_block(storage, offset, buffer);
-        if (rc != GS_SUCCESS)
-            return rc;
-        if (write_cb(context, buffer, storage->block_size) != 0)
+    // Chunk sized in whole blocks.  If the staging allocation fails, fall back
+    // to a single block so a memory-starved host still exports, just slowly.
+    uint64_t chunk_blocks = STORAGE_STREAM_CHUNK_BYTES / storage->block_size;
+    if (chunk_blocks == 0)
+        chunk_blocks = 1;
+    uint8_t *buffer = malloc((size_t)chunk_blocks * storage->block_size);
+    if (!buffer) {
+        chunk_blocks = 1;
+        buffer = malloc(storage->block_size);
+        if (!buffer)
             return GS_ERROR;
     }
-    return GS_SUCCESS;
+
+    int rc = GS_SUCCESS;
+    uint64_t block = 0;
+    while (block < storage->block_count) {
+        // Extend the run while the source stays the same, capped by the chunk.
+        block_src_t src = block_source(storage, block);
+        uint64_t max_run = storage->block_count - block;
+        if (max_run > chunk_blocks)
+            max_run = chunk_blocks;
+        uint64_t run = 1;
+        while (run < max_run && block_source(storage, block + run) == src)
+            run++;
+
+        size_t run_bytes = (size_t)run * storage->block_size;
+
+        if (src == BLOCK_SRC_ZERO) {
+            memset(buffer, 0, run_bytes);
+        } else {
+            FILE *fp = (src == BLOCK_SRC_DELTA) ? storage->delta_fp : storage->base_fp;
+            size_t origin = (src == BLOCK_SRC_DELTA) ? storage->data_offset : storage->base_data_offset;
+            fseek(fp, (long)(origin + (size_t)block * storage->block_size), SEEK_SET);
+            size_t got = fread(buffer, 1, run_bytes, fp);
+            if (got < run_bytes) {
+                // A short read on the base means the base file is shorter than
+                // the declared geometry; storage_read_block zero-fills and
+                // carries on, so match that.  The delta is written a block at a
+                // time and every bit-set block therefore lies within EOF, so a
+                // short read there is real corruption and stays an error.
+                if (src == BLOCK_SRC_DELTA) {
+                    rc = GS_ERROR;
+                    break;
+                }
+                // storage_read_block zeroes a block it could not read *in
+                // full*, so a base whose length is not a whole multiple of
+                // block_size must not leak its trailing partial block.
+                got -= got % storage->block_size;
+                memset(buffer + got, 0, run_bytes - got);
+            }
+        }
+
+        // One callback per block, not per run: the checkpoint stream is a
+        // record format whose reader asserts each record's size, and
+        // storage_load_state pulls it back a block at a time.
+        for (uint64_t i = 0; i < run; i++) {
+            if (write_cb(context, buffer + (size_t)i * storage->block_size, storage->block_size) != 0) {
+                rc = GS_ERROR;
+                break;
+            }
+        }
+        if (rc != GS_SUCCESS)
+            break;
+        block += run;
+    }
+
+    free(buffer);
+    return rc;
 }
 
 static int read_exact(storage_read_callback_t read_cb, void *context, void *buf, size_t size) {

--- a/tests/unit/suites/storage/test.c
+++ b/tests/unit/suites/storage/test.c
@@ -398,6 +398,174 @@ TEST(storage_block_size_validation) {
     teardown_sandbox();
 }
 
+// ============================================================================
+// storage_save_state run coalescing
+// ============================================================================
+//
+// storage_save_state batches contiguous same-source blocks into one read
+// instead of doing a seek+read per block.  storage_read_block still walks a
+// block at a time and is untouched by that change, so it serves as an
+// independent oracle: the streamed bytes must equal the per-block reads
+// concatenated, for every arrangement of base/delta/zero runs.
+
+// Stream `storage` to STATE_FILE, then assert the result is byte-identical to
+// block-by-block storage_read_block output.  Also asserts the stream is
+// emitted as one record per block, which the checkpoint format requires.
+static uint64_t g_stream_records;
+
+static int counting_write_cb(void *ctx, const void *data, size_t size) {
+    g_stream_records++;
+    return file_write_cb(ctx, data, size);
+}
+
+static void assert_stream_matches_per_block(storage_t *storage, uint64_t blocks, uint32_t bsize) {
+    FILE *state = fopen(STATE_FILE, "wb");
+    ASSERT_TRUE(state != NULL);
+    g_stream_records = 0;
+    ASSERT_OK(storage_save_state(storage, state, counting_write_cb));
+    fclose(state);
+
+    // One callback per block: storage_load_state reads the checkpoint stream a
+    // block at a time and its reader asserts each record's exact size.
+    ASSERT_EQ_INT((int)blocks, (int)g_stream_records);
+
+    state = fopen(STATE_FILE, "rb");
+    ASSERT_TRUE(state != NULL);
+    uint8_t *want = malloc(bsize);
+    uint8_t *got = malloc(bsize);
+    ASSERT_TRUE(want != NULL && got != NULL);
+    for (uint64_t lba = 0; lba < blocks; lba++) {
+        ASSERT_OK(storage_read_block(storage, (size_t)lba * bsize, want));
+        ASSERT_TRUE(fread(got, 1, bsize, state) == bsize);
+        ASSERT_TRUE(memcmp(want, got, bsize) == 0);
+    }
+    // Nothing beyond the last block.
+    ASSERT_TRUE(fread(got, 1, 1, state) == 0);
+    free(want);
+    free(got);
+    fclose(state);
+}
+
+// Write a spread of blocks chosen to exercise every run shape: a leading
+// unmodified run, isolated modified blocks, a modified run longer than one
+// staging chunk, an alternating stretch, and a modified final block.
+static void write_run_pattern(storage_t *storage, uint64_t blocks, uint32_t bsize) {
+    uint8_t *buf = malloc(bsize);
+    ASSERT_TRUE(buf != NULL);
+
+    // Isolated singles surrounded by base-sourced blocks.
+    const uint64_t singles[] = {1, 7, 100, 4095, 4096, 8191, 8192, 8193};
+    for (size_t i = 0; i < sizeof(singles) / sizeof(singles[0]); i++) {
+        if (singles[i] >= blocks)
+            continue;
+        fill_block_bs((size_t)singles[i], bsize, 0x30, buf);
+        ASSERT_OK(storage_write_block(storage, (size_t)singles[i] * bsize, buf));
+    }
+
+    // A modified run longer than one staging chunk (4 MB / bsize blocks), so
+    // the run must be split across chunks and rejoined without a gap.
+    uint64_t run_start = 9000;
+    uint64_t run_end = run_start + 10000;
+    if (run_end > blocks)
+        run_end = blocks;
+    for (uint64_t lba = run_start; lba < run_end; lba++) {
+        fill_block_bs((size_t)lba, bsize, 0x40, buf);
+        ASSERT_OK(storage_write_block(storage, (size_t)lba * bsize, buf));
+    }
+
+    // Alternating modified/unmodified — every run is length 1.
+    for (uint64_t lba = 200; lba < 400 && lba < blocks; lba += 2) {
+        fill_block_bs((size_t)lba, bsize, 0x50, buf);
+        ASSERT_OK(storage_write_block(storage, (size_t)lba * bsize, buf));
+    }
+
+    // First and last block modified — the boundaries of the walk.
+    fill_block_bs(0, bsize, 0x60, buf);
+    ASSERT_OK(storage_write_block(storage, 0, buf));
+    fill_block_bs((size_t)(blocks - 1), bsize, 0x60, buf);
+    ASSERT_OK(storage_write_block(storage, (size_t)(blocks - 1) * bsize, buf));
+
+    free(buf);
+}
+
+TEST(storage_save_state_run_patterns) {
+    setup_sandbox();
+    // 20000 blocks x 512 B is ~10 MB, spanning several 4 MB staging chunks.
+    const uint64_t blocks = 20000;
+    create_base_image_bs(BASE_FILE, blocks, STORAGE_BLOCK_SIZE, 0x11);
+
+    storage_config_t config = make_config(BASE_FILE, DELTA_FILE, JOURNAL_FILE, blocks);
+    storage_t *storage = NULL;
+    ASSERT_OK(storage_new(&config, &storage));
+
+    // Fully unmodified: one enormous base-sourced run.
+    assert_stream_matches_per_block(storage, blocks, STORAGE_BLOCK_SIZE);
+
+    write_run_pattern(storage, blocks, STORAGE_BLOCK_SIZE);
+    assert_stream_matches_per_block(storage, blocks, STORAGE_BLOCK_SIZE);
+
+    ASSERT_OK(storage_delete(storage));
+    teardown_sandbox();
+}
+
+TEST(storage_save_state_runs_532) {
+    // 532 does not divide the staging chunk evenly, so the chunk holds a
+    // partial-block remainder that must never be streamed.
+    setup_sandbox();
+    const uint64_t blocks = 20000;
+    create_base_image_bs(BASE_FILE, blocks, 532, 0x22);
+
+    storage_config_t config = make_config(BASE_FILE, DELTA_FILE, JOURNAL_FILE, blocks);
+    config.block_size = 532;
+    storage_t *storage = NULL;
+    ASSERT_OK(storage_new(&config, &storage));
+
+    write_run_pattern(storage, blocks, 532);
+    assert_stream_matches_per_block(storage, blocks, 532);
+
+    ASSERT_OK(storage_delete(storage));
+    teardown_sandbox();
+}
+
+TEST(storage_save_state_no_base) {
+    // No base file: unmodified blocks are the zero source, so runs alternate
+    // between zeros and the delta with no file behind the zeros.
+    setup_sandbox();
+    const uint64_t blocks = 12000;
+    storage_config_t config = make_config(NULL, DELTA_FILE, JOURNAL_FILE, blocks);
+    storage_t *storage = NULL;
+    ASSERT_OK(storage_new(&config, &storage));
+
+    write_run_pattern(storage, blocks, STORAGE_BLOCK_SIZE);
+    assert_stream_matches_per_block(storage, blocks, STORAGE_BLOCK_SIZE);
+
+    ASSERT_OK(storage_delete(storage));
+    teardown_sandbox();
+}
+
+TEST(storage_save_state_short_base) {
+    // A base shorter than the declared geometry, ending mid-block.  Blocks
+    // past EOF read as zeros, and the trailing partial block must read as all
+    // zeros too rather than leaking the bytes that are present.
+    setup_sandbox();
+    const uint64_t blocks = 12000;
+    const uint64_t base_blocks = 5000;
+    create_base_image_bs(BASE_FILE, base_blocks, STORAGE_BLOCK_SIZE, 0x33);
+    // Chop the last block in half so the base ends mid-block.
+    ASSERT_TRUE(truncate(BASE_FILE, (off_t)((base_blocks - 1) * STORAGE_BLOCK_SIZE + 200)) == 0);
+
+    storage_config_t config = make_config(BASE_FILE, DELTA_FILE, JOURNAL_FILE, blocks);
+    storage_t *storage = NULL;
+    ASSERT_OK(storage_new(&config, &storage));
+
+    assert_stream_matches_per_block(storage, blocks, STORAGE_BLOCK_SIZE);
+    write_run_pattern(storage, blocks, STORAGE_BLOCK_SIZE);
+    assert_stream_matches_per_block(storage, blocks, STORAGE_BLOCK_SIZE);
+
+    ASSERT_OK(storage_delete(storage));
+    teardown_sandbox();
+}
+
 int main(void) {
     RUN(storage_invalid_arguments);
     RUN(storage_basic_read_write);
@@ -407,5 +575,9 @@ int main(void) {
     RUN(storage_block_size_532);
     RUN(storage_block_size_other);
     RUN(storage_block_size_validation);
+    RUN(storage_save_state_run_patterns);
+    RUN(storage_save_state_runs_532);
+    RUN(storage_save_state_no_base);
+    RUN(storage_save_state_short_base);
     return 0;
 }


### PR DESCRIPTION
Right-clicking a hard disk in the system browser and choosing **Save image…** took minutes, with no progress indication. This is the first and largest of three fixes for that; it addresses the dominant cost.

## The problem

`storage_save_state` walked the disk one 512-byte block at a time, and `storage_read_block` does an explicit `fseek` + `fread` per block. Exporting the 234 MB Mac OS 8.1 image cost **599,256** filesystem calls.

Native Linux hides that behind the page cache, which is why it never showed up in headless testing. The web build keeps base and delta on OPFS under WASMFS, where every one of those is a synchronous access-handle round trip — hence minutes in the browser.

## The fix

Blocks are laid out linearly in both the base and the delta, so a run of consecutive blocks drawn from the same source (delta / base / zero-fill) is one contiguous read. Walk the bitmap, batch each run through a 4 MB staging buffer.

`image_save` / `image_export_to` also `setvbuf` a 4 MB output buffer, so the per-block `fwrite`s coalesce instead of hitting stdio's ~1 KB default.

## Results

Filesystem syscalls for the export alone:

| image | before | after | |
|---|---|---|---|
| real 234 MB `macos81.img` | 599,256 | **246** | 2,436× |
| synthetic 64 MB, untouched | 163,840 | 48 | 3,413× |
| synthetic 64 MB, clustered writes | 163,990 | 716 | 229× |
| synthetic 64 MB, scattered single blocks | 166,091 | 10,234 | 16× |

## Two constraints the implementation respects

- **`write_cb` still fires once per block.** The checkpoint stream is a length-prefixed record format whose reader asserts each record's exact size (`checkpoint.c:220-225`), and `storage_load_state` reads it a block at a time. Emitting per-run would have made every consolidated checkpoint unloadable — i.e. broken resume. The cost was in the reads, so this is free.
- **A short read on the base is truncated to whole blocks before zero-filling**, because `storage_read_block` zeroes a block it could not read *in full*. Otherwise a base whose length is not a multiple of `block_size` would leak its trailing partial block.

## Verification

- Output is **byte-identical** to the previous implementation, checked on the real 234 MB image and against the old code on synthetic data.
- Four new tests compare the streamed bytes against `storage_read_block` — untouched by this change, so an independent oracle — across chunk-spanning runs, alternating single-block runs, 532-byte ProFile blocks, a no-base zero source, and a base truncated mid-block. They also assert the one-record-per-block invariant.
- Those tests were mutation-checked: dropping the partial-block truncation fails `short_base`; switching to per-run callbacks fails the record-count assert.
- WASM and headless build clean. `image-export-raw`, `checkpoint` (cross-process) and `q900-checkpoint` (boots to desktop, saves, restores, screenshot match) all pass locally.

## Not in this PR

Two follow-ups remain for the same user-visible complaint:

1. The download path materializes the image 3–4× in RAM (export to `/tmp` on the memory backend → `malloc` the whole file → copy out of the shared heap → `Blob`). Streaming it would remove that and the OOM risk on large disks.
2. There is still **no progress indication**, and it is impossible today by construction: `gs_eval` runs synchronously in `em_main_tick` holding the single in-flight bridge slot, so the UI cannot poll while an export is running. That needs a chunked, tick-driven job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)